### PR TITLE
Allow for more negative prefixes

### DIFF
--- a/demo/src/Main.elm
+++ b/demo/src/Main.elm
@@ -171,4 +171,10 @@ buttonCls =
     , TW.tw_mx_auto
     , TW.tw_block
     , TW.tw_w_1over4
+    , TW.tw_transition
+    , TW.tw_duration_500
+    , TW.tw_ease_in_out
+    , TW.tw_transform
+    , TW.hover_tw_neg_translate_y_1
+    , TW.hover_tw_scale_110
     ]

--- a/demo/src/TLWND.elm
+++ b/demo/src/TLWND.elm
@@ -600,6 +600,7 @@ module TLWND exposing
     , tw_rounded_none
     , tw_rounded_sm
     , tw_rounded
+    , tw_rounded_md
     , tw_rounded_lg
     , tw_rounded_full
     , tw_rounded_t_none
@@ -614,6 +615,10 @@ module TLWND exposing
     , tw_rounded_r
     , tw_rounded_b
     , tw_rounded_l
+    , tw_rounded_t_md
+    , tw_rounded_r_md
+    , tw_rounded_b_md
+    , tw_rounded_l_md
     , tw_rounded_t_lg
     , tw_rounded_r_lg
     , tw_rounded_b_lg
@@ -634,6 +639,10 @@ module TLWND exposing
     , tw_rounded_tr
     , tw_rounded_br
     , tw_rounded_bl
+    , tw_rounded_tl_md
+    , tw_rounded_tr_md
+    , tw_rounded_br_md
+    , tw_rounded_bl_md
     , tw_rounded_tl_lg
     , tw_rounded_tr_lg
     , tw_rounded_br_lg
@@ -672,6 +681,8 @@ module TLWND exposing
     , tw_border_r
     , tw_border_b
     , tw_border_l
+    , tw_box_border
+    , tw_box_content
     , tw_cursor_auto
     , tw_cursor_default
     , tw_cursor_pointer
@@ -684,9 +695,16 @@ module TLWND exposing
     , tw_inline
     , tw_flex
     , tw_inline_flex
+    , tw_grid
     , tw_table
-    , tw_table_row
+    , tw_table_caption
     , tw_table_cell
+    , tw_table_column
+    , tw_table_column_group
+    , tw_table_footer_group
+    , tw_table_header_group
+    , tw_table_row_group
+    , tw_table_row
     , tw_hidden
     , tw_flex_row
     , tw_flex_row_reverse
@@ -710,6 +728,7 @@ module TLWND exposing
     , tw_justify_center
     , tw_justify_between
     , tw_justify_around
+    , tw_justify_evenly
     , tw_content_center
     , tw_content_start
     , tw_content_end
@@ -742,6 +761,9 @@ module TLWND exposing
     , tw_float_left
     , tw_float_none
     , tw_clearfix_after
+    , tw_clear_left
+    , tw_clear_right
+    , tw_clear_both
     , tw_font_sans
     , tw_font_serif
     , tw_font_mono
@@ -794,6 +816,14 @@ module TLWND exposing
     , tw_h_px
     , tw_h_full
     , tw_h_screen
+    , tw_leading_3
+    , tw_leading_4
+    , tw_leading_5
+    , tw_leading_6
+    , tw_leading_7
+    , tw_leading_8
+    , tw_leading_9
+    , tw_leading_10
     , tw_leading_none
     , tw_leading_tight
     , tw_leading_snug
@@ -1073,6 +1103,7 @@ module TLWND exposing
     , tw_neg_ml_px
     , tw_max_h_full
     , tw_max_h_screen
+    , tw_max_w_none
     , tw_max_w_xs
     , tw_max_w_sm
     , tw_max_w_md
@@ -1084,6 +1115,10 @@ module TLWND exposing
     , tw_max_w_5xl
     , tw_max_w_6xl
     , tw_max_w_full
+    , tw_max_w_screen_sm
+    , tw_max_w_screen_md
+    , tw_max_w_screen_lg
+    , tw_max_w_screen_xl
     , tw_min_h_0
     , tw_min_h_full
     , tw_min_h_screen
@@ -1478,6 +1513,8 @@ module TLWND exposing
     , tw_resize_y
     , tw_resize_x
     , tw_resize
+    , tw_shadow_xs
+    , tw_shadow_sm
     , tw_shadow
     , tw_shadow_md
     , tw_shadow_lg
@@ -1486,6 +1523,8 @@ module TLWND exposing
     , tw_shadow_inner
     , tw_shadow_outline
     , tw_shadow_none
+    , hover_tw_shadow_xs
+    , hover_tw_shadow_sm
     , hover_tw_shadow
     , hover_tw_shadow_md
     , hover_tw_shadow_lg
@@ -1494,6 +1533,8 @@ module TLWND exposing
     , hover_tw_shadow_inner
     , hover_tw_shadow_outline
     , hover_tw_shadow_none
+    , focus_tw_shadow_xs
+    , focus_tw_shadow_sm
     , focus_tw_shadow
     , focus_tw_shadow_md
     , focus_tw_shadow_lg
@@ -1504,6 +1545,9 @@ module TLWND exposing
     , focus_tw_shadow_none
     , tw_fill_current
     , tw_stroke_current
+    , tw_stroke_0
+    , tw_stroke_1
+    , tw_stroke_2
     , tw_table_auto
     , tw_table_fixed
     , tw_text_left
@@ -1898,6 +1942,580 @@ module TLWND exposing
     , tw_z_40
     , tw_z_50
     , tw_z_auto
+    , tw_gap_0
+    , tw_gap_1
+    , tw_gap_2
+    , tw_gap_3
+    , tw_gap_4
+    , tw_gap_5
+    , tw_gap_6
+    , tw_gap_8
+    , tw_gap_10
+    , tw_gap_12
+    , tw_gap_16
+    , tw_gap_20
+    , tw_gap_24
+    , tw_gap_32
+    , tw_gap_40
+    , tw_gap_48
+    , tw_gap_56
+    , tw_gap_64
+    , tw_gap_px
+    , tw_col_gap_0
+    , tw_col_gap_1
+    , tw_col_gap_2
+    , tw_col_gap_3
+    , tw_col_gap_4
+    , tw_col_gap_5
+    , tw_col_gap_6
+    , tw_col_gap_8
+    , tw_col_gap_10
+    , tw_col_gap_12
+    , tw_col_gap_16
+    , tw_col_gap_20
+    , tw_col_gap_24
+    , tw_col_gap_32
+    , tw_col_gap_40
+    , tw_col_gap_48
+    , tw_col_gap_56
+    , tw_col_gap_64
+    , tw_col_gap_px
+    , tw_row_gap_0
+    , tw_row_gap_1
+    , tw_row_gap_2
+    , tw_row_gap_3
+    , tw_row_gap_4
+    , tw_row_gap_5
+    , tw_row_gap_6
+    , tw_row_gap_8
+    , tw_row_gap_10
+    , tw_row_gap_12
+    , tw_row_gap_16
+    , tw_row_gap_20
+    , tw_row_gap_24
+    , tw_row_gap_32
+    , tw_row_gap_40
+    , tw_row_gap_48
+    , tw_row_gap_56
+    , tw_row_gap_64
+    , tw_row_gap_px
+    , tw_grid_flow_row
+    , tw_grid_flow_col
+    , tw_grid_flow_row_dense
+    , tw_grid_flow_col_dense
+    , tw_grid_cols_1
+    , tw_grid_cols_2
+    , tw_grid_cols_3
+    , tw_grid_cols_4
+    , tw_grid_cols_5
+    , tw_grid_cols_6
+    , tw_grid_cols_7
+    , tw_grid_cols_8
+    , tw_grid_cols_9
+    , tw_grid_cols_10
+    , tw_grid_cols_11
+    , tw_grid_cols_12
+    , tw_grid_cols_none
+    , tw_col_auto
+    , tw_col_span_1
+    , tw_col_span_2
+    , tw_col_span_3
+    , tw_col_span_4
+    , tw_col_span_5
+    , tw_col_span_6
+    , tw_col_span_7
+    , tw_col_span_8
+    , tw_col_span_9
+    , tw_col_span_10
+    , tw_col_span_11
+    , tw_col_span_12
+    , tw_col_start_1
+    , tw_col_start_2
+    , tw_col_start_3
+    , tw_col_start_4
+    , tw_col_start_5
+    , tw_col_start_6
+    , tw_col_start_7
+    , tw_col_start_8
+    , tw_col_start_9
+    , tw_col_start_10
+    , tw_col_start_11
+    , tw_col_start_12
+    , tw_col_start_13
+    , tw_col_start_auto
+    , tw_col_end_1
+    , tw_col_end_2
+    , tw_col_end_3
+    , tw_col_end_4
+    , tw_col_end_5
+    , tw_col_end_6
+    , tw_col_end_7
+    , tw_col_end_8
+    , tw_col_end_9
+    , tw_col_end_10
+    , tw_col_end_11
+    , tw_col_end_12
+    , tw_col_end_13
+    , tw_col_end_auto
+    , tw_grid_rows_1
+    , tw_grid_rows_2
+    , tw_grid_rows_3
+    , tw_grid_rows_4
+    , tw_grid_rows_5
+    , tw_grid_rows_6
+    , tw_grid_rows_none
+    , tw_row_auto
+    , tw_row_span_1
+    , tw_row_span_2
+    , tw_row_span_3
+    , tw_row_span_4
+    , tw_row_span_5
+    , tw_row_span_6
+    , tw_row_start_1
+    , tw_row_start_2
+    , tw_row_start_3
+    , tw_row_start_4
+    , tw_row_start_5
+    , tw_row_start_6
+    , tw_row_start_7
+    , tw_row_start_auto
+    , tw_row_end_1
+    , tw_row_end_2
+    , tw_row_end_3
+    , tw_row_end_4
+    , tw_row_end_5
+    , tw_row_end_6
+    , tw_row_end_7
+    , tw_row_end_auto
+    , tw_transform
+    , tw_transform_none
+    , tw_origin_center
+    , tw_origin_top
+    , tw_origin_top_right
+    , tw_origin_right
+    , tw_origin_bottom_right
+    , tw_origin_bottom
+    , tw_origin_bottom_left
+    , tw_origin_left
+    , tw_origin_top_left
+    , tw_scale_0
+    , tw_scale_50
+    , tw_scale_75
+    , tw_scale_90
+    , tw_scale_95
+    , tw_scale_100
+    , tw_scale_105
+    , tw_scale_110
+    , tw_scale_125
+    , tw_scale_150
+    , tw_scale_x_0
+    , tw_scale_x_50
+    , tw_scale_x_75
+    , tw_scale_x_90
+    , tw_scale_x_95
+    , tw_scale_x_100
+    , tw_scale_x_105
+    , tw_scale_x_110
+    , tw_scale_x_125
+    , tw_scale_x_150
+    , tw_scale_y_0
+    , tw_scale_y_50
+    , tw_scale_y_75
+    , tw_scale_y_90
+    , tw_scale_y_95
+    , tw_scale_y_100
+    , tw_scale_y_105
+    , tw_scale_y_110
+    , tw_scale_y_125
+    , tw_scale_y_150
+    , hover_tw_scale_0
+    , hover_tw_scale_50
+    , hover_tw_scale_75
+    , hover_tw_scale_90
+    , hover_tw_scale_95
+    , hover_tw_scale_100
+    , hover_tw_scale_105
+    , hover_tw_scale_110
+    , hover_tw_scale_125
+    , hover_tw_scale_150
+    , hover_tw_scale_x_0
+    , hover_tw_scale_x_50
+    , hover_tw_scale_x_75
+    , hover_tw_scale_x_90
+    , hover_tw_scale_x_95
+    , hover_tw_scale_x_100
+    , hover_tw_scale_x_105
+    , hover_tw_scale_x_110
+    , hover_tw_scale_x_125
+    , hover_tw_scale_x_150
+    , hover_tw_scale_y_0
+    , hover_tw_scale_y_50
+    , hover_tw_scale_y_75
+    , hover_tw_scale_y_90
+    , hover_tw_scale_y_95
+    , hover_tw_scale_y_100
+    , hover_tw_scale_y_105
+    , hover_tw_scale_y_110
+    , hover_tw_scale_y_125
+    , hover_tw_scale_y_150
+    , focus_tw_scale_0
+    , focus_tw_scale_50
+    , focus_tw_scale_75
+    , focus_tw_scale_90
+    , focus_tw_scale_95
+    , focus_tw_scale_100
+    , focus_tw_scale_105
+    , focus_tw_scale_110
+    , focus_tw_scale_125
+    , focus_tw_scale_150
+    , focus_tw_scale_x_0
+    , focus_tw_scale_x_50
+    , focus_tw_scale_x_75
+    , focus_tw_scale_x_90
+    , focus_tw_scale_x_95
+    , focus_tw_scale_x_100
+    , focus_tw_scale_x_105
+    , focus_tw_scale_x_110
+    , focus_tw_scale_x_125
+    , focus_tw_scale_x_150
+    , focus_tw_scale_y_0
+    , focus_tw_scale_y_50
+    , focus_tw_scale_y_75
+    , focus_tw_scale_y_90
+    , focus_tw_scale_y_95
+    , focus_tw_scale_y_100
+    , focus_tw_scale_y_105
+    , focus_tw_scale_y_110
+    , focus_tw_scale_y_125
+    , focus_tw_scale_y_150
+    , tw_rotate_0
+    , tw_rotate_45
+    , tw_rotate_90
+    , tw_rotate_180
+    , tw_neg_rotate_180
+    , tw_neg_rotate_90
+    , tw_neg_rotate_45
+    , hover_tw_rotate_0
+    , hover_tw_rotate_45
+    , hover_tw_rotate_90
+    , hover_tw_rotate_180
+    , hover_tw_neg_rotate_180
+    , hover_tw_neg_rotate_90
+    , hover_tw_neg_rotate_45
+    , focus_tw_rotate_0
+    , focus_tw_rotate_45
+    , focus_tw_rotate_90
+    , focus_tw_rotate_180
+    , focus_tw_neg_rotate_180
+    , focus_tw_neg_rotate_90
+    , focus_tw_neg_rotate_45
+    , tw_translate_x_0
+    , tw_translate_x_1
+    , tw_translate_x_2
+    , tw_translate_x_3
+    , tw_translate_x_4
+    , tw_translate_x_5
+    , tw_translate_x_6
+    , tw_translate_x_8
+    , tw_translate_x_10
+    , tw_translate_x_12
+    , tw_translate_x_16
+    , tw_translate_x_20
+    , tw_translate_x_24
+    , tw_translate_x_32
+    , tw_translate_x_40
+    , tw_translate_x_48
+    , tw_translate_x_56
+    , tw_translate_x_64
+    , tw_translate_x_px
+    , tw_neg_translate_x_1
+    , tw_neg_translate_x_2
+    , tw_neg_translate_x_3
+    , tw_neg_translate_x_4
+    , tw_neg_translate_x_5
+    , tw_neg_translate_x_6
+    , tw_neg_translate_x_8
+    , tw_neg_translate_x_10
+    , tw_neg_translate_x_12
+    , tw_neg_translate_x_16
+    , tw_neg_translate_x_20
+    , tw_neg_translate_x_24
+    , tw_neg_translate_x_32
+    , tw_neg_translate_x_40
+    , tw_neg_translate_x_48
+    , tw_neg_translate_x_56
+    , tw_neg_translate_x_64
+    , tw_neg_translate_x_px
+    , tw_neg_translate_x_full
+    , tw_neg_translate_x_1over2
+    , tw_translate_x_1over2
+    , tw_translate_x_full
+    , tw_translate_y_0
+    , tw_translate_y_1
+    , tw_translate_y_2
+    , tw_translate_y_3
+    , tw_translate_y_4
+    , tw_translate_y_5
+    , tw_translate_y_6
+    , tw_translate_y_8
+    , tw_translate_y_10
+    , tw_translate_y_12
+    , tw_translate_y_16
+    , tw_translate_y_20
+    , tw_translate_y_24
+    , tw_translate_y_32
+    , tw_translate_y_40
+    , tw_translate_y_48
+    , tw_translate_y_56
+    , tw_translate_y_64
+    , tw_translate_y_px
+    , tw_neg_translate_y_1
+    , tw_neg_translate_y_2
+    , tw_neg_translate_y_3
+    , tw_neg_translate_y_4
+    , tw_neg_translate_y_5
+    , tw_neg_translate_y_6
+    , tw_neg_translate_y_8
+    , tw_neg_translate_y_10
+    , tw_neg_translate_y_12
+    , tw_neg_translate_y_16
+    , tw_neg_translate_y_20
+    , tw_neg_translate_y_24
+    , tw_neg_translate_y_32
+    , tw_neg_translate_y_40
+    , tw_neg_translate_y_48
+    , tw_neg_translate_y_56
+    , tw_neg_translate_y_64
+    , tw_neg_translate_y_px
+    , tw_neg_translate_y_full
+    , tw_neg_translate_y_1over2
+    , tw_translate_y_1over2
+    , tw_translate_y_full
+    , hover_tw_translate_x_0
+    , hover_tw_translate_x_1
+    , hover_tw_translate_x_2
+    , hover_tw_translate_x_3
+    , hover_tw_translate_x_4
+    , hover_tw_translate_x_5
+    , hover_tw_translate_x_6
+    , hover_tw_translate_x_8
+    , hover_tw_translate_x_10
+    , hover_tw_translate_x_12
+    , hover_tw_translate_x_16
+    , hover_tw_translate_x_20
+    , hover_tw_translate_x_24
+    , hover_tw_translate_x_32
+    , hover_tw_translate_x_40
+    , hover_tw_translate_x_48
+    , hover_tw_translate_x_56
+    , hover_tw_translate_x_64
+    , hover_tw_translate_x_px
+    , hover_tw_neg_translate_x_1
+    , hover_tw_neg_translate_x_2
+    , hover_tw_neg_translate_x_3
+    , hover_tw_neg_translate_x_4
+    , hover_tw_neg_translate_x_5
+    , hover_tw_neg_translate_x_6
+    , hover_tw_neg_translate_x_8
+    , hover_tw_neg_translate_x_10
+    , hover_tw_neg_translate_x_12
+    , hover_tw_neg_translate_x_16
+    , hover_tw_neg_translate_x_20
+    , hover_tw_neg_translate_x_24
+    , hover_tw_neg_translate_x_32
+    , hover_tw_neg_translate_x_40
+    , hover_tw_neg_translate_x_48
+    , hover_tw_neg_translate_x_56
+    , hover_tw_neg_translate_x_64
+    , hover_tw_neg_translate_x_px
+    , hover_tw_neg_translate_x_full
+    , hover_tw_neg_translate_x_1over2
+    , hover_tw_translate_x_1over2
+    , hover_tw_translate_x_full
+    , hover_tw_translate_y_0
+    , hover_tw_translate_y_1
+    , hover_tw_translate_y_2
+    , hover_tw_translate_y_3
+    , hover_tw_translate_y_4
+    , hover_tw_translate_y_5
+    , hover_tw_translate_y_6
+    , hover_tw_translate_y_8
+    , hover_tw_translate_y_10
+    , hover_tw_translate_y_12
+    , hover_tw_translate_y_16
+    , hover_tw_translate_y_20
+    , hover_tw_translate_y_24
+    , hover_tw_translate_y_32
+    , hover_tw_translate_y_40
+    , hover_tw_translate_y_48
+    , hover_tw_translate_y_56
+    , hover_tw_translate_y_64
+    , hover_tw_translate_y_px
+    , hover_tw_neg_translate_y_1
+    , hover_tw_neg_translate_y_2
+    , hover_tw_neg_translate_y_3
+    , hover_tw_neg_translate_y_4
+    , hover_tw_neg_translate_y_5
+    , hover_tw_neg_translate_y_6
+    , hover_tw_neg_translate_y_8
+    , hover_tw_neg_translate_y_10
+    , hover_tw_neg_translate_y_12
+    , hover_tw_neg_translate_y_16
+    , hover_tw_neg_translate_y_20
+    , hover_tw_neg_translate_y_24
+    , hover_tw_neg_translate_y_32
+    , hover_tw_neg_translate_y_40
+    , hover_tw_neg_translate_y_48
+    , hover_tw_neg_translate_y_56
+    , hover_tw_neg_translate_y_64
+    , hover_tw_neg_translate_y_px
+    , hover_tw_neg_translate_y_full
+    , hover_tw_neg_translate_y_1over2
+    , hover_tw_translate_y_1over2
+    , hover_tw_translate_y_full
+    , focus_tw_translate_x_0
+    , focus_tw_translate_x_1
+    , focus_tw_translate_x_2
+    , focus_tw_translate_x_3
+    , focus_tw_translate_x_4
+    , focus_tw_translate_x_5
+    , focus_tw_translate_x_6
+    , focus_tw_translate_x_8
+    , focus_tw_translate_x_10
+    , focus_tw_translate_x_12
+    , focus_tw_translate_x_16
+    , focus_tw_translate_x_20
+    , focus_tw_translate_x_24
+    , focus_tw_translate_x_32
+    , focus_tw_translate_x_40
+    , focus_tw_translate_x_48
+    , focus_tw_translate_x_56
+    , focus_tw_translate_x_64
+    , focus_tw_translate_x_px
+    , focus_tw_neg_translate_x_1
+    , focus_tw_neg_translate_x_2
+    , focus_tw_neg_translate_x_3
+    , focus_tw_neg_translate_x_4
+    , focus_tw_neg_translate_x_5
+    , focus_tw_neg_translate_x_6
+    , focus_tw_neg_translate_x_8
+    , focus_tw_neg_translate_x_10
+    , focus_tw_neg_translate_x_12
+    , focus_tw_neg_translate_x_16
+    , focus_tw_neg_translate_x_20
+    , focus_tw_neg_translate_x_24
+    , focus_tw_neg_translate_x_32
+    , focus_tw_neg_translate_x_40
+    , focus_tw_neg_translate_x_48
+    , focus_tw_neg_translate_x_56
+    , focus_tw_neg_translate_x_64
+    , focus_tw_neg_translate_x_px
+    , focus_tw_neg_translate_x_full
+    , focus_tw_neg_translate_x_1over2
+    , focus_tw_translate_x_1over2
+    , focus_tw_translate_x_full
+    , focus_tw_translate_y_0
+    , focus_tw_translate_y_1
+    , focus_tw_translate_y_2
+    , focus_tw_translate_y_3
+    , focus_tw_translate_y_4
+    , focus_tw_translate_y_5
+    , focus_tw_translate_y_6
+    , focus_tw_translate_y_8
+    , focus_tw_translate_y_10
+    , focus_tw_translate_y_12
+    , focus_tw_translate_y_16
+    , focus_tw_translate_y_20
+    , focus_tw_translate_y_24
+    , focus_tw_translate_y_32
+    , focus_tw_translate_y_40
+    , focus_tw_translate_y_48
+    , focus_tw_translate_y_56
+    , focus_tw_translate_y_64
+    , focus_tw_translate_y_px
+    , focus_tw_neg_translate_y_1
+    , focus_tw_neg_translate_y_2
+    , focus_tw_neg_translate_y_3
+    , focus_tw_neg_translate_y_4
+    , focus_tw_neg_translate_y_5
+    , focus_tw_neg_translate_y_6
+    , focus_tw_neg_translate_y_8
+    , focus_tw_neg_translate_y_10
+    , focus_tw_neg_translate_y_12
+    , focus_tw_neg_translate_y_16
+    , focus_tw_neg_translate_y_20
+    , focus_tw_neg_translate_y_24
+    , focus_tw_neg_translate_y_32
+    , focus_tw_neg_translate_y_40
+    , focus_tw_neg_translate_y_48
+    , focus_tw_neg_translate_y_56
+    , focus_tw_neg_translate_y_64
+    , focus_tw_neg_translate_y_px
+    , focus_tw_neg_translate_y_full
+    , focus_tw_neg_translate_y_1over2
+    , focus_tw_translate_y_1over2
+    , focus_tw_translate_y_full
+    , tw_skew_x_0
+    , tw_skew_x_3
+    , tw_skew_x_6
+    , tw_skew_x_12
+    , tw_neg_skew_x_12
+    , tw_neg_skew_x_6
+    , tw_neg_skew_x_3
+    , tw_skew_y_0
+    , tw_skew_y_3
+    , tw_skew_y_6
+    , tw_skew_y_12
+    , tw_neg_skew_y_12
+    , tw_neg_skew_y_6
+    , tw_neg_skew_y_3
+    , hover_tw_skew_x_0
+    , hover_tw_skew_x_3
+    , hover_tw_skew_x_6
+    , hover_tw_skew_x_12
+    , hover_tw_neg_skew_x_12
+    , hover_tw_neg_skew_x_6
+    , hover_tw_neg_skew_x_3
+    , hover_tw_skew_y_0
+    , hover_tw_skew_y_3
+    , hover_tw_skew_y_6
+    , hover_tw_skew_y_12
+    , hover_tw_neg_skew_y_12
+    , hover_tw_neg_skew_y_6
+    , hover_tw_neg_skew_y_3
+    , focus_tw_skew_x_0
+    , focus_tw_skew_x_3
+    , focus_tw_skew_x_6
+    , focus_tw_skew_x_12
+    , focus_tw_neg_skew_x_12
+    , focus_tw_neg_skew_x_6
+    , focus_tw_neg_skew_x_3
+    , focus_tw_skew_y_0
+    , focus_tw_skew_y_3
+    , focus_tw_skew_y_6
+    , focus_tw_skew_y_12
+    , focus_tw_neg_skew_y_12
+    , focus_tw_neg_skew_y_6
+    , focus_tw_neg_skew_y_3
+    , tw_transition_none
+    , tw_transition_all
+    , tw_transition
+    , tw_transition_colors
+    , tw_transition_opacity
+    , tw_transition_shadow
+    , tw_transition_transform
+    , tw_ease_linear
+    , tw_ease_in
+    , tw_ease_out
+    , tw_ease_in_out
+    , tw_duration_75
+    , tw_duration_100
+    , tw_duration_150
+    , tw_duration_200
+    , tw_duration_300
+    , tw_duration_500
+    , tw_duration_700
+    , tw_duration_1000
     , sm_tw_sr_only
     , sm_tw_not_sr_only
     , sm_focus_tw_sr_only
@@ -2487,6 +3105,7 @@ module TLWND exposing
     , sm_tw_rounded_none
     , sm_tw_rounded_sm
     , sm_tw_rounded
+    , sm_tw_rounded_md
     , sm_tw_rounded_lg
     , sm_tw_rounded_full
     , sm_tw_rounded_t_none
@@ -2501,6 +3120,10 @@ module TLWND exposing
     , sm_tw_rounded_r
     , sm_tw_rounded_b
     , sm_tw_rounded_l
+    , sm_tw_rounded_t_md
+    , sm_tw_rounded_r_md
+    , sm_tw_rounded_b_md
+    , sm_tw_rounded_l_md
     , sm_tw_rounded_t_lg
     , sm_tw_rounded_r_lg
     , sm_tw_rounded_b_lg
@@ -2521,6 +3144,10 @@ module TLWND exposing
     , sm_tw_rounded_tr
     , sm_tw_rounded_br
     , sm_tw_rounded_bl
+    , sm_tw_rounded_tl_md
+    , sm_tw_rounded_tr_md
+    , sm_tw_rounded_br_md
+    , sm_tw_rounded_bl_md
     , sm_tw_rounded_tl_lg
     , sm_tw_rounded_tr_lg
     , sm_tw_rounded_br_lg
@@ -2559,6 +3186,8 @@ module TLWND exposing
     , sm_tw_border_r
     , sm_tw_border_b
     , sm_tw_border_l
+    , sm_tw_box_border
+    , sm_tw_box_content
     , sm_tw_cursor_auto
     , sm_tw_cursor_default
     , sm_tw_cursor_pointer
@@ -2571,9 +3200,16 @@ module TLWND exposing
     , sm_tw_inline
     , sm_tw_flex
     , sm_tw_inline_flex
+    , sm_tw_grid
     , sm_tw_table
-    , sm_tw_table_row
+    , sm_tw_table_caption
     , sm_tw_table_cell
+    , sm_tw_table_column
+    , sm_tw_table_column_group
+    , sm_tw_table_footer_group
+    , sm_tw_table_header_group
+    , sm_tw_table_row_group
+    , sm_tw_table_row
     , sm_tw_hidden
     , sm_tw_flex_row
     , sm_tw_flex_row_reverse
@@ -2597,6 +3233,7 @@ module TLWND exposing
     , sm_tw_justify_center
     , sm_tw_justify_between
     , sm_tw_justify_around
+    , sm_tw_justify_evenly
     , sm_tw_content_center
     , sm_tw_content_start
     , sm_tw_content_end
@@ -2629,6 +3266,9 @@ module TLWND exposing
     , sm_tw_float_left
     , sm_tw_float_none
     , sm_tw_clearfix_after
+    , sm_tw_clear_left
+    , sm_tw_clear_right
+    , sm_tw_clear_both
     , sm_tw_font_sans
     , sm_tw_font_serif
     , sm_tw_font_mono
@@ -2681,6 +3321,14 @@ module TLWND exposing
     , sm_tw_h_px
     , sm_tw_h_full
     , sm_tw_h_screen
+    , sm_tw_leading_3
+    , sm_tw_leading_4
+    , sm_tw_leading_5
+    , sm_tw_leading_6
+    , sm_tw_leading_7
+    , sm_tw_leading_8
+    , sm_tw_leading_9
+    , sm_tw_leading_10
     , sm_tw_leading_none
     , sm_tw_leading_tight
     , sm_tw_leading_snug
@@ -2960,6 +3608,7 @@ module TLWND exposing
     , sm_tw_neg_ml_px
     , sm_tw_max_h_full
     , sm_tw_max_h_screen
+    , sm_tw_max_w_none
     , sm_tw_max_w_xs
     , sm_tw_max_w_sm
     , sm_tw_max_w_md
@@ -2971,6 +3620,10 @@ module TLWND exposing
     , sm_tw_max_w_5xl
     , sm_tw_max_w_6xl
     , sm_tw_max_w_full
+    , sm_tw_max_w_screen_sm
+    , sm_tw_max_w_screen_md
+    , sm_tw_max_w_screen_lg
+    , sm_tw_max_w_screen_xl
     , sm_tw_min_h_0
     , sm_tw_min_h_full
     , sm_tw_min_h_screen
@@ -3365,6 +4018,8 @@ module TLWND exposing
     , sm_tw_resize_y
     , sm_tw_resize_x
     , sm_tw_resize
+    , sm_tw_shadow_xs
+    , sm_tw_shadow_sm
     , sm_tw_shadow
     , sm_tw_shadow_md
     , sm_tw_shadow_lg
@@ -3373,6 +4028,8 @@ module TLWND exposing
     , sm_tw_shadow_inner
     , sm_tw_shadow_outline
     , sm_tw_shadow_none
+    , sm_hover_tw_shadow_xs
+    , sm_hover_tw_shadow_sm
     , sm_hover_tw_shadow
     , sm_hover_tw_shadow_md
     , sm_hover_tw_shadow_lg
@@ -3381,6 +4038,8 @@ module TLWND exposing
     , sm_hover_tw_shadow_inner
     , sm_hover_tw_shadow_outline
     , sm_hover_tw_shadow_none
+    , sm_focus_tw_shadow_xs
+    , sm_focus_tw_shadow_sm
     , sm_focus_tw_shadow
     , sm_focus_tw_shadow_md
     , sm_focus_tw_shadow_lg
@@ -3391,6 +4050,9 @@ module TLWND exposing
     , sm_focus_tw_shadow_none
     , sm_tw_fill_current
     , sm_tw_stroke_current
+    , sm_tw_stroke_0
+    , sm_tw_stroke_1
+    , sm_tw_stroke_2
     , sm_tw_table_auto
     , sm_tw_table_fixed
     , sm_tw_text_left
@@ -3785,6 +4447,580 @@ module TLWND exposing
     , sm_tw_z_40
     , sm_tw_z_50
     , sm_tw_z_auto
+    , sm_tw_gap_0
+    , sm_tw_gap_1
+    , sm_tw_gap_2
+    , sm_tw_gap_3
+    , sm_tw_gap_4
+    , sm_tw_gap_5
+    , sm_tw_gap_6
+    , sm_tw_gap_8
+    , sm_tw_gap_10
+    , sm_tw_gap_12
+    , sm_tw_gap_16
+    , sm_tw_gap_20
+    , sm_tw_gap_24
+    , sm_tw_gap_32
+    , sm_tw_gap_40
+    , sm_tw_gap_48
+    , sm_tw_gap_56
+    , sm_tw_gap_64
+    , sm_tw_gap_px
+    , sm_tw_col_gap_0
+    , sm_tw_col_gap_1
+    , sm_tw_col_gap_2
+    , sm_tw_col_gap_3
+    , sm_tw_col_gap_4
+    , sm_tw_col_gap_5
+    , sm_tw_col_gap_6
+    , sm_tw_col_gap_8
+    , sm_tw_col_gap_10
+    , sm_tw_col_gap_12
+    , sm_tw_col_gap_16
+    , sm_tw_col_gap_20
+    , sm_tw_col_gap_24
+    , sm_tw_col_gap_32
+    , sm_tw_col_gap_40
+    , sm_tw_col_gap_48
+    , sm_tw_col_gap_56
+    , sm_tw_col_gap_64
+    , sm_tw_col_gap_px
+    , sm_tw_row_gap_0
+    , sm_tw_row_gap_1
+    , sm_tw_row_gap_2
+    , sm_tw_row_gap_3
+    , sm_tw_row_gap_4
+    , sm_tw_row_gap_5
+    , sm_tw_row_gap_6
+    , sm_tw_row_gap_8
+    , sm_tw_row_gap_10
+    , sm_tw_row_gap_12
+    , sm_tw_row_gap_16
+    , sm_tw_row_gap_20
+    , sm_tw_row_gap_24
+    , sm_tw_row_gap_32
+    , sm_tw_row_gap_40
+    , sm_tw_row_gap_48
+    , sm_tw_row_gap_56
+    , sm_tw_row_gap_64
+    , sm_tw_row_gap_px
+    , sm_tw_grid_flow_row
+    , sm_tw_grid_flow_col
+    , sm_tw_grid_flow_row_dense
+    , sm_tw_grid_flow_col_dense
+    , sm_tw_grid_cols_1
+    , sm_tw_grid_cols_2
+    , sm_tw_grid_cols_3
+    , sm_tw_grid_cols_4
+    , sm_tw_grid_cols_5
+    , sm_tw_grid_cols_6
+    , sm_tw_grid_cols_7
+    , sm_tw_grid_cols_8
+    , sm_tw_grid_cols_9
+    , sm_tw_grid_cols_10
+    , sm_tw_grid_cols_11
+    , sm_tw_grid_cols_12
+    , sm_tw_grid_cols_none
+    , sm_tw_col_auto
+    , sm_tw_col_span_1
+    , sm_tw_col_span_2
+    , sm_tw_col_span_3
+    , sm_tw_col_span_4
+    , sm_tw_col_span_5
+    , sm_tw_col_span_6
+    , sm_tw_col_span_7
+    , sm_tw_col_span_8
+    , sm_tw_col_span_9
+    , sm_tw_col_span_10
+    , sm_tw_col_span_11
+    , sm_tw_col_span_12
+    , sm_tw_col_start_1
+    , sm_tw_col_start_2
+    , sm_tw_col_start_3
+    , sm_tw_col_start_4
+    , sm_tw_col_start_5
+    , sm_tw_col_start_6
+    , sm_tw_col_start_7
+    , sm_tw_col_start_8
+    , sm_tw_col_start_9
+    , sm_tw_col_start_10
+    , sm_tw_col_start_11
+    , sm_tw_col_start_12
+    , sm_tw_col_start_13
+    , sm_tw_col_start_auto
+    , sm_tw_col_end_1
+    , sm_tw_col_end_2
+    , sm_tw_col_end_3
+    , sm_tw_col_end_4
+    , sm_tw_col_end_5
+    , sm_tw_col_end_6
+    , sm_tw_col_end_7
+    , sm_tw_col_end_8
+    , sm_tw_col_end_9
+    , sm_tw_col_end_10
+    , sm_tw_col_end_11
+    , sm_tw_col_end_12
+    , sm_tw_col_end_13
+    , sm_tw_col_end_auto
+    , sm_tw_grid_rows_1
+    , sm_tw_grid_rows_2
+    , sm_tw_grid_rows_3
+    , sm_tw_grid_rows_4
+    , sm_tw_grid_rows_5
+    , sm_tw_grid_rows_6
+    , sm_tw_grid_rows_none
+    , sm_tw_row_auto
+    , sm_tw_row_span_1
+    , sm_tw_row_span_2
+    , sm_tw_row_span_3
+    , sm_tw_row_span_4
+    , sm_tw_row_span_5
+    , sm_tw_row_span_6
+    , sm_tw_row_start_1
+    , sm_tw_row_start_2
+    , sm_tw_row_start_3
+    , sm_tw_row_start_4
+    , sm_tw_row_start_5
+    , sm_tw_row_start_6
+    , sm_tw_row_start_7
+    , sm_tw_row_start_auto
+    , sm_tw_row_end_1
+    , sm_tw_row_end_2
+    , sm_tw_row_end_3
+    , sm_tw_row_end_4
+    , sm_tw_row_end_5
+    , sm_tw_row_end_6
+    , sm_tw_row_end_7
+    , sm_tw_row_end_auto
+    , sm_tw_transform
+    , sm_tw_transform_none
+    , sm_tw_origin_center
+    , sm_tw_origin_top
+    , sm_tw_origin_top_right
+    , sm_tw_origin_right
+    , sm_tw_origin_bottom_right
+    , sm_tw_origin_bottom
+    , sm_tw_origin_bottom_left
+    , sm_tw_origin_left
+    , sm_tw_origin_top_left
+    , sm_tw_scale_0
+    , sm_tw_scale_50
+    , sm_tw_scale_75
+    , sm_tw_scale_90
+    , sm_tw_scale_95
+    , sm_tw_scale_100
+    , sm_tw_scale_105
+    , sm_tw_scale_110
+    , sm_tw_scale_125
+    , sm_tw_scale_150
+    , sm_tw_scale_x_0
+    , sm_tw_scale_x_50
+    , sm_tw_scale_x_75
+    , sm_tw_scale_x_90
+    , sm_tw_scale_x_95
+    , sm_tw_scale_x_100
+    , sm_tw_scale_x_105
+    , sm_tw_scale_x_110
+    , sm_tw_scale_x_125
+    , sm_tw_scale_x_150
+    , sm_tw_scale_y_0
+    , sm_tw_scale_y_50
+    , sm_tw_scale_y_75
+    , sm_tw_scale_y_90
+    , sm_tw_scale_y_95
+    , sm_tw_scale_y_100
+    , sm_tw_scale_y_105
+    , sm_tw_scale_y_110
+    , sm_tw_scale_y_125
+    , sm_tw_scale_y_150
+    , sm_hover_tw_scale_0
+    , sm_hover_tw_scale_50
+    , sm_hover_tw_scale_75
+    , sm_hover_tw_scale_90
+    , sm_hover_tw_scale_95
+    , sm_hover_tw_scale_100
+    , sm_hover_tw_scale_105
+    , sm_hover_tw_scale_110
+    , sm_hover_tw_scale_125
+    , sm_hover_tw_scale_150
+    , sm_hover_tw_scale_x_0
+    , sm_hover_tw_scale_x_50
+    , sm_hover_tw_scale_x_75
+    , sm_hover_tw_scale_x_90
+    , sm_hover_tw_scale_x_95
+    , sm_hover_tw_scale_x_100
+    , sm_hover_tw_scale_x_105
+    , sm_hover_tw_scale_x_110
+    , sm_hover_tw_scale_x_125
+    , sm_hover_tw_scale_x_150
+    , sm_hover_tw_scale_y_0
+    , sm_hover_tw_scale_y_50
+    , sm_hover_tw_scale_y_75
+    , sm_hover_tw_scale_y_90
+    , sm_hover_tw_scale_y_95
+    , sm_hover_tw_scale_y_100
+    , sm_hover_tw_scale_y_105
+    , sm_hover_tw_scale_y_110
+    , sm_hover_tw_scale_y_125
+    , sm_hover_tw_scale_y_150
+    , sm_focus_tw_scale_0
+    , sm_focus_tw_scale_50
+    , sm_focus_tw_scale_75
+    , sm_focus_tw_scale_90
+    , sm_focus_tw_scale_95
+    , sm_focus_tw_scale_100
+    , sm_focus_tw_scale_105
+    , sm_focus_tw_scale_110
+    , sm_focus_tw_scale_125
+    , sm_focus_tw_scale_150
+    , sm_focus_tw_scale_x_0
+    , sm_focus_tw_scale_x_50
+    , sm_focus_tw_scale_x_75
+    , sm_focus_tw_scale_x_90
+    , sm_focus_tw_scale_x_95
+    , sm_focus_tw_scale_x_100
+    , sm_focus_tw_scale_x_105
+    , sm_focus_tw_scale_x_110
+    , sm_focus_tw_scale_x_125
+    , sm_focus_tw_scale_x_150
+    , sm_focus_tw_scale_y_0
+    , sm_focus_tw_scale_y_50
+    , sm_focus_tw_scale_y_75
+    , sm_focus_tw_scale_y_90
+    , sm_focus_tw_scale_y_95
+    , sm_focus_tw_scale_y_100
+    , sm_focus_tw_scale_y_105
+    , sm_focus_tw_scale_y_110
+    , sm_focus_tw_scale_y_125
+    , sm_focus_tw_scale_y_150
+    , sm_tw_rotate_0
+    , sm_tw_rotate_45
+    , sm_tw_rotate_90
+    , sm_tw_rotate_180
+    , sm_tw_neg_rotate_180
+    , sm_tw_neg_rotate_90
+    , sm_tw_neg_rotate_45
+    , sm_hover_tw_rotate_0
+    , sm_hover_tw_rotate_45
+    , sm_hover_tw_rotate_90
+    , sm_hover_tw_rotate_180
+    , sm_hover_tw_neg_rotate_180
+    , sm_hover_tw_neg_rotate_90
+    , sm_hover_tw_neg_rotate_45
+    , sm_focus_tw_rotate_0
+    , sm_focus_tw_rotate_45
+    , sm_focus_tw_rotate_90
+    , sm_focus_tw_rotate_180
+    , sm_focus_tw_neg_rotate_180
+    , sm_focus_tw_neg_rotate_90
+    , sm_focus_tw_neg_rotate_45
+    , sm_tw_translate_x_0
+    , sm_tw_translate_x_1
+    , sm_tw_translate_x_2
+    , sm_tw_translate_x_3
+    , sm_tw_translate_x_4
+    , sm_tw_translate_x_5
+    , sm_tw_translate_x_6
+    , sm_tw_translate_x_8
+    , sm_tw_translate_x_10
+    , sm_tw_translate_x_12
+    , sm_tw_translate_x_16
+    , sm_tw_translate_x_20
+    , sm_tw_translate_x_24
+    , sm_tw_translate_x_32
+    , sm_tw_translate_x_40
+    , sm_tw_translate_x_48
+    , sm_tw_translate_x_56
+    , sm_tw_translate_x_64
+    , sm_tw_translate_x_px
+    , sm_tw_neg_translate_x_1
+    , sm_tw_neg_translate_x_2
+    , sm_tw_neg_translate_x_3
+    , sm_tw_neg_translate_x_4
+    , sm_tw_neg_translate_x_5
+    , sm_tw_neg_translate_x_6
+    , sm_tw_neg_translate_x_8
+    , sm_tw_neg_translate_x_10
+    , sm_tw_neg_translate_x_12
+    , sm_tw_neg_translate_x_16
+    , sm_tw_neg_translate_x_20
+    , sm_tw_neg_translate_x_24
+    , sm_tw_neg_translate_x_32
+    , sm_tw_neg_translate_x_40
+    , sm_tw_neg_translate_x_48
+    , sm_tw_neg_translate_x_56
+    , sm_tw_neg_translate_x_64
+    , sm_tw_neg_translate_x_px
+    , sm_tw_neg_translate_x_full
+    , sm_tw_neg_translate_x_1over2
+    , sm_tw_translate_x_1over2
+    , sm_tw_translate_x_full
+    , sm_tw_translate_y_0
+    , sm_tw_translate_y_1
+    , sm_tw_translate_y_2
+    , sm_tw_translate_y_3
+    , sm_tw_translate_y_4
+    , sm_tw_translate_y_5
+    , sm_tw_translate_y_6
+    , sm_tw_translate_y_8
+    , sm_tw_translate_y_10
+    , sm_tw_translate_y_12
+    , sm_tw_translate_y_16
+    , sm_tw_translate_y_20
+    , sm_tw_translate_y_24
+    , sm_tw_translate_y_32
+    , sm_tw_translate_y_40
+    , sm_tw_translate_y_48
+    , sm_tw_translate_y_56
+    , sm_tw_translate_y_64
+    , sm_tw_translate_y_px
+    , sm_tw_neg_translate_y_1
+    , sm_tw_neg_translate_y_2
+    , sm_tw_neg_translate_y_3
+    , sm_tw_neg_translate_y_4
+    , sm_tw_neg_translate_y_5
+    , sm_tw_neg_translate_y_6
+    , sm_tw_neg_translate_y_8
+    , sm_tw_neg_translate_y_10
+    , sm_tw_neg_translate_y_12
+    , sm_tw_neg_translate_y_16
+    , sm_tw_neg_translate_y_20
+    , sm_tw_neg_translate_y_24
+    , sm_tw_neg_translate_y_32
+    , sm_tw_neg_translate_y_40
+    , sm_tw_neg_translate_y_48
+    , sm_tw_neg_translate_y_56
+    , sm_tw_neg_translate_y_64
+    , sm_tw_neg_translate_y_px
+    , sm_tw_neg_translate_y_full
+    , sm_tw_neg_translate_y_1over2
+    , sm_tw_translate_y_1over2
+    , sm_tw_translate_y_full
+    , sm_hover_tw_translate_x_0
+    , sm_hover_tw_translate_x_1
+    , sm_hover_tw_translate_x_2
+    , sm_hover_tw_translate_x_3
+    , sm_hover_tw_translate_x_4
+    , sm_hover_tw_translate_x_5
+    , sm_hover_tw_translate_x_6
+    , sm_hover_tw_translate_x_8
+    , sm_hover_tw_translate_x_10
+    , sm_hover_tw_translate_x_12
+    , sm_hover_tw_translate_x_16
+    , sm_hover_tw_translate_x_20
+    , sm_hover_tw_translate_x_24
+    , sm_hover_tw_translate_x_32
+    , sm_hover_tw_translate_x_40
+    , sm_hover_tw_translate_x_48
+    , sm_hover_tw_translate_x_56
+    , sm_hover_tw_translate_x_64
+    , sm_hover_tw_translate_x_px
+    , sm_hover_tw_neg_translate_x_1
+    , sm_hover_tw_neg_translate_x_2
+    , sm_hover_tw_neg_translate_x_3
+    , sm_hover_tw_neg_translate_x_4
+    , sm_hover_tw_neg_translate_x_5
+    , sm_hover_tw_neg_translate_x_6
+    , sm_hover_tw_neg_translate_x_8
+    , sm_hover_tw_neg_translate_x_10
+    , sm_hover_tw_neg_translate_x_12
+    , sm_hover_tw_neg_translate_x_16
+    , sm_hover_tw_neg_translate_x_20
+    , sm_hover_tw_neg_translate_x_24
+    , sm_hover_tw_neg_translate_x_32
+    , sm_hover_tw_neg_translate_x_40
+    , sm_hover_tw_neg_translate_x_48
+    , sm_hover_tw_neg_translate_x_56
+    , sm_hover_tw_neg_translate_x_64
+    , sm_hover_tw_neg_translate_x_px
+    , sm_hover_tw_neg_translate_x_full
+    , sm_hover_tw_neg_translate_x_1over2
+    , sm_hover_tw_translate_x_1over2
+    , sm_hover_tw_translate_x_full
+    , sm_hover_tw_translate_y_0
+    , sm_hover_tw_translate_y_1
+    , sm_hover_tw_translate_y_2
+    , sm_hover_tw_translate_y_3
+    , sm_hover_tw_translate_y_4
+    , sm_hover_tw_translate_y_5
+    , sm_hover_tw_translate_y_6
+    , sm_hover_tw_translate_y_8
+    , sm_hover_tw_translate_y_10
+    , sm_hover_tw_translate_y_12
+    , sm_hover_tw_translate_y_16
+    , sm_hover_tw_translate_y_20
+    , sm_hover_tw_translate_y_24
+    , sm_hover_tw_translate_y_32
+    , sm_hover_tw_translate_y_40
+    , sm_hover_tw_translate_y_48
+    , sm_hover_tw_translate_y_56
+    , sm_hover_tw_translate_y_64
+    , sm_hover_tw_translate_y_px
+    , sm_hover_tw_neg_translate_y_1
+    , sm_hover_tw_neg_translate_y_2
+    , sm_hover_tw_neg_translate_y_3
+    , sm_hover_tw_neg_translate_y_4
+    , sm_hover_tw_neg_translate_y_5
+    , sm_hover_tw_neg_translate_y_6
+    , sm_hover_tw_neg_translate_y_8
+    , sm_hover_tw_neg_translate_y_10
+    , sm_hover_tw_neg_translate_y_12
+    , sm_hover_tw_neg_translate_y_16
+    , sm_hover_tw_neg_translate_y_20
+    , sm_hover_tw_neg_translate_y_24
+    , sm_hover_tw_neg_translate_y_32
+    , sm_hover_tw_neg_translate_y_40
+    , sm_hover_tw_neg_translate_y_48
+    , sm_hover_tw_neg_translate_y_56
+    , sm_hover_tw_neg_translate_y_64
+    , sm_hover_tw_neg_translate_y_px
+    , sm_hover_tw_neg_translate_y_full
+    , sm_hover_tw_neg_translate_y_1over2
+    , sm_hover_tw_translate_y_1over2
+    , sm_hover_tw_translate_y_full
+    , sm_focus_tw_translate_x_0
+    , sm_focus_tw_translate_x_1
+    , sm_focus_tw_translate_x_2
+    , sm_focus_tw_translate_x_3
+    , sm_focus_tw_translate_x_4
+    , sm_focus_tw_translate_x_5
+    , sm_focus_tw_translate_x_6
+    , sm_focus_tw_translate_x_8
+    , sm_focus_tw_translate_x_10
+    , sm_focus_tw_translate_x_12
+    , sm_focus_tw_translate_x_16
+    , sm_focus_tw_translate_x_20
+    , sm_focus_tw_translate_x_24
+    , sm_focus_tw_translate_x_32
+    , sm_focus_tw_translate_x_40
+    , sm_focus_tw_translate_x_48
+    , sm_focus_tw_translate_x_56
+    , sm_focus_tw_translate_x_64
+    , sm_focus_tw_translate_x_px
+    , sm_focus_tw_neg_translate_x_1
+    , sm_focus_tw_neg_translate_x_2
+    , sm_focus_tw_neg_translate_x_3
+    , sm_focus_tw_neg_translate_x_4
+    , sm_focus_tw_neg_translate_x_5
+    , sm_focus_tw_neg_translate_x_6
+    , sm_focus_tw_neg_translate_x_8
+    , sm_focus_tw_neg_translate_x_10
+    , sm_focus_tw_neg_translate_x_12
+    , sm_focus_tw_neg_translate_x_16
+    , sm_focus_tw_neg_translate_x_20
+    , sm_focus_tw_neg_translate_x_24
+    , sm_focus_tw_neg_translate_x_32
+    , sm_focus_tw_neg_translate_x_40
+    , sm_focus_tw_neg_translate_x_48
+    , sm_focus_tw_neg_translate_x_56
+    , sm_focus_tw_neg_translate_x_64
+    , sm_focus_tw_neg_translate_x_px
+    , sm_focus_tw_neg_translate_x_full
+    , sm_focus_tw_neg_translate_x_1over2
+    , sm_focus_tw_translate_x_1over2
+    , sm_focus_tw_translate_x_full
+    , sm_focus_tw_translate_y_0
+    , sm_focus_tw_translate_y_1
+    , sm_focus_tw_translate_y_2
+    , sm_focus_tw_translate_y_3
+    , sm_focus_tw_translate_y_4
+    , sm_focus_tw_translate_y_5
+    , sm_focus_tw_translate_y_6
+    , sm_focus_tw_translate_y_8
+    , sm_focus_tw_translate_y_10
+    , sm_focus_tw_translate_y_12
+    , sm_focus_tw_translate_y_16
+    , sm_focus_tw_translate_y_20
+    , sm_focus_tw_translate_y_24
+    , sm_focus_tw_translate_y_32
+    , sm_focus_tw_translate_y_40
+    , sm_focus_tw_translate_y_48
+    , sm_focus_tw_translate_y_56
+    , sm_focus_tw_translate_y_64
+    , sm_focus_tw_translate_y_px
+    , sm_focus_tw_neg_translate_y_1
+    , sm_focus_tw_neg_translate_y_2
+    , sm_focus_tw_neg_translate_y_3
+    , sm_focus_tw_neg_translate_y_4
+    , sm_focus_tw_neg_translate_y_5
+    , sm_focus_tw_neg_translate_y_6
+    , sm_focus_tw_neg_translate_y_8
+    , sm_focus_tw_neg_translate_y_10
+    , sm_focus_tw_neg_translate_y_12
+    , sm_focus_tw_neg_translate_y_16
+    , sm_focus_tw_neg_translate_y_20
+    , sm_focus_tw_neg_translate_y_24
+    , sm_focus_tw_neg_translate_y_32
+    , sm_focus_tw_neg_translate_y_40
+    , sm_focus_tw_neg_translate_y_48
+    , sm_focus_tw_neg_translate_y_56
+    , sm_focus_tw_neg_translate_y_64
+    , sm_focus_tw_neg_translate_y_px
+    , sm_focus_tw_neg_translate_y_full
+    , sm_focus_tw_neg_translate_y_1over2
+    , sm_focus_tw_translate_y_1over2
+    , sm_focus_tw_translate_y_full
+    , sm_tw_skew_x_0
+    , sm_tw_skew_x_3
+    , sm_tw_skew_x_6
+    , sm_tw_skew_x_12
+    , sm_tw_neg_skew_x_12
+    , sm_tw_neg_skew_x_6
+    , sm_tw_neg_skew_x_3
+    , sm_tw_skew_y_0
+    , sm_tw_skew_y_3
+    , sm_tw_skew_y_6
+    , sm_tw_skew_y_12
+    , sm_tw_neg_skew_y_12
+    , sm_tw_neg_skew_y_6
+    , sm_tw_neg_skew_y_3
+    , sm_hover_tw_skew_x_0
+    , sm_hover_tw_skew_x_3
+    , sm_hover_tw_skew_x_6
+    , sm_hover_tw_skew_x_12
+    , sm_hover_tw_neg_skew_x_12
+    , sm_hover_tw_neg_skew_x_6
+    , sm_hover_tw_neg_skew_x_3
+    , sm_hover_tw_skew_y_0
+    , sm_hover_tw_skew_y_3
+    , sm_hover_tw_skew_y_6
+    , sm_hover_tw_skew_y_12
+    , sm_hover_tw_neg_skew_y_12
+    , sm_hover_tw_neg_skew_y_6
+    , sm_hover_tw_neg_skew_y_3
+    , sm_focus_tw_skew_x_0
+    , sm_focus_tw_skew_x_3
+    , sm_focus_tw_skew_x_6
+    , sm_focus_tw_skew_x_12
+    , sm_focus_tw_neg_skew_x_12
+    , sm_focus_tw_neg_skew_x_6
+    , sm_focus_tw_neg_skew_x_3
+    , sm_focus_tw_skew_y_0
+    , sm_focus_tw_skew_y_3
+    , sm_focus_tw_skew_y_6
+    , sm_focus_tw_skew_y_12
+    , sm_focus_tw_neg_skew_y_12
+    , sm_focus_tw_neg_skew_y_6
+    , sm_focus_tw_neg_skew_y_3
+    , sm_tw_transition_none
+    , sm_tw_transition_all
+    , sm_tw_transition
+    , sm_tw_transition_colors
+    , sm_tw_transition_opacity
+    , sm_tw_transition_shadow
+    , sm_tw_transition_transform
+    , sm_tw_ease_linear
+    , sm_tw_ease_in
+    , sm_tw_ease_out
+    , sm_tw_ease_in_out
+    , sm_tw_duration_75
+    , sm_tw_duration_100
+    , sm_tw_duration_150
+    , sm_tw_duration_200
+    , sm_tw_duration_300
+    , sm_tw_duration_500
+    , sm_tw_duration_700
+    , sm_tw_duration_1000
     , md_tw_sr_only
     , md_tw_not_sr_only
     , md_focus_tw_sr_only
@@ -4374,6 +5610,7 @@ module TLWND exposing
     , md_tw_rounded_none
     , md_tw_rounded_sm
     , md_tw_rounded
+    , md_tw_rounded_md
     , md_tw_rounded_lg
     , md_tw_rounded_full
     , md_tw_rounded_t_none
@@ -4388,6 +5625,10 @@ module TLWND exposing
     , md_tw_rounded_r
     , md_tw_rounded_b
     , md_tw_rounded_l
+    , md_tw_rounded_t_md
+    , md_tw_rounded_r_md
+    , md_tw_rounded_b_md
+    , md_tw_rounded_l_md
     , md_tw_rounded_t_lg
     , md_tw_rounded_r_lg
     , md_tw_rounded_b_lg
@@ -4408,6 +5649,10 @@ module TLWND exposing
     , md_tw_rounded_tr
     , md_tw_rounded_br
     , md_tw_rounded_bl
+    , md_tw_rounded_tl_md
+    , md_tw_rounded_tr_md
+    , md_tw_rounded_br_md
+    , md_tw_rounded_bl_md
     , md_tw_rounded_tl_lg
     , md_tw_rounded_tr_lg
     , md_tw_rounded_br_lg
@@ -4446,6 +5691,8 @@ module TLWND exposing
     , md_tw_border_r
     , md_tw_border_b
     , md_tw_border_l
+    , md_tw_box_border
+    , md_tw_box_content
     , md_tw_cursor_auto
     , md_tw_cursor_default
     , md_tw_cursor_pointer
@@ -4458,9 +5705,16 @@ module TLWND exposing
     , md_tw_inline
     , md_tw_flex
     , md_tw_inline_flex
+    , md_tw_grid
     , md_tw_table
-    , md_tw_table_row
+    , md_tw_table_caption
     , md_tw_table_cell
+    , md_tw_table_column
+    , md_tw_table_column_group
+    , md_tw_table_footer_group
+    , md_tw_table_header_group
+    , md_tw_table_row_group
+    , md_tw_table_row
     , md_tw_hidden
     , md_tw_flex_row
     , md_tw_flex_row_reverse
@@ -4484,6 +5738,7 @@ module TLWND exposing
     , md_tw_justify_center
     , md_tw_justify_between
     , md_tw_justify_around
+    , md_tw_justify_evenly
     , md_tw_content_center
     , md_tw_content_start
     , md_tw_content_end
@@ -4516,6 +5771,9 @@ module TLWND exposing
     , md_tw_float_left
     , md_tw_float_none
     , md_tw_clearfix_after
+    , md_tw_clear_left
+    , md_tw_clear_right
+    , md_tw_clear_both
     , md_tw_font_sans
     , md_tw_font_serif
     , md_tw_font_mono
@@ -4568,6 +5826,14 @@ module TLWND exposing
     , md_tw_h_px
     , md_tw_h_full
     , md_tw_h_screen
+    , md_tw_leading_3
+    , md_tw_leading_4
+    , md_tw_leading_5
+    , md_tw_leading_6
+    , md_tw_leading_7
+    , md_tw_leading_8
+    , md_tw_leading_9
+    , md_tw_leading_10
     , md_tw_leading_none
     , md_tw_leading_tight
     , md_tw_leading_snug
@@ -4847,6 +6113,7 @@ module TLWND exposing
     , md_tw_neg_ml_px
     , md_tw_max_h_full
     , md_tw_max_h_screen
+    , md_tw_max_w_none
     , md_tw_max_w_xs
     , md_tw_max_w_sm
     , md_tw_max_w_md
@@ -4858,6 +6125,10 @@ module TLWND exposing
     , md_tw_max_w_5xl
     , md_tw_max_w_6xl
     , md_tw_max_w_full
+    , md_tw_max_w_screen_sm
+    , md_tw_max_w_screen_md
+    , md_tw_max_w_screen_lg
+    , md_tw_max_w_screen_xl
     , md_tw_min_h_0
     , md_tw_min_h_full
     , md_tw_min_h_screen
@@ -5252,6 +6523,8 @@ module TLWND exposing
     , md_tw_resize_y
     , md_tw_resize_x
     , md_tw_resize
+    , md_tw_shadow_xs
+    , md_tw_shadow_sm
     , md_tw_shadow
     , md_tw_shadow_md
     , md_tw_shadow_lg
@@ -5260,6 +6533,8 @@ module TLWND exposing
     , md_tw_shadow_inner
     , md_tw_shadow_outline
     , md_tw_shadow_none
+    , md_hover_tw_shadow_xs
+    , md_hover_tw_shadow_sm
     , md_hover_tw_shadow
     , md_hover_tw_shadow_md
     , md_hover_tw_shadow_lg
@@ -5268,6 +6543,8 @@ module TLWND exposing
     , md_hover_tw_shadow_inner
     , md_hover_tw_shadow_outline
     , md_hover_tw_shadow_none
+    , md_focus_tw_shadow_xs
+    , md_focus_tw_shadow_sm
     , md_focus_tw_shadow
     , md_focus_tw_shadow_md
     , md_focus_tw_shadow_lg
@@ -5278,6 +6555,9 @@ module TLWND exposing
     , md_focus_tw_shadow_none
     , md_tw_fill_current
     , md_tw_stroke_current
+    , md_tw_stroke_0
+    , md_tw_stroke_1
+    , md_tw_stroke_2
     , md_tw_table_auto
     , md_tw_table_fixed
     , md_tw_text_left
@@ -5672,6 +6952,580 @@ module TLWND exposing
     , md_tw_z_40
     , md_tw_z_50
     , md_tw_z_auto
+    , md_tw_gap_0
+    , md_tw_gap_1
+    , md_tw_gap_2
+    , md_tw_gap_3
+    , md_tw_gap_4
+    , md_tw_gap_5
+    , md_tw_gap_6
+    , md_tw_gap_8
+    , md_tw_gap_10
+    , md_tw_gap_12
+    , md_tw_gap_16
+    , md_tw_gap_20
+    , md_tw_gap_24
+    , md_tw_gap_32
+    , md_tw_gap_40
+    , md_tw_gap_48
+    , md_tw_gap_56
+    , md_tw_gap_64
+    , md_tw_gap_px
+    , md_tw_col_gap_0
+    , md_tw_col_gap_1
+    , md_tw_col_gap_2
+    , md_tw_col_gap_3
+    , md_tw_col_gap_4
+    , md_tw_col_gap_5
+    , md_tw_col_gap_6
+    , md_tw_col_gap_8
+    , md_tw_col_gap_10
+    , md_tw_col_gap_12
+    , md_tw_col_gap_16
+    , md_tw_col_gap_20
+    , md_tw_col_gap_24
+    , md_tw_col_gap_32
+    , md_tw_col_gap_40
+    , md_tw_col_gap_48
+    , md_tw_col_gap_56
+    , md_tw_col_gap_64
+    , md_tw_col_gap_px
+    , md_tw_row_gap_0
+    , md_tw_row_gap_1
+    , md_tw_row_gap_2
+    , md_tw_row_gap_3
+    , md_tw_row_gap_4
+    , md_tw_row_gap_5
+    , md_tw_row_gap_6
+    , md_tw_row_gap_8
+    , md_tw_row_gap_10
+    , md_tw_row_gap_12
+    , md_tw_row_gap_16
+    , md_tw_row_gap_20
+    , md_tw_row_gap_24
+    , md_tw_row_gap_32
+    , md_tw_row_gap_40
+    , md_tw_row_gap_48
+    , md_tw_row_gap_56
+    , md_tw_row_gap_64
+    , md_tw_row_gap_px
+    , md_tw_grid_flow_row
+    , md_tw_grid_flow_col
+    , md_tw_grid_flow_row_dense
+    , md_tw_grid_flow_col_dense
+    , md_tw_grid_cols_1
+    , md_tw_grid_cols_2
+    , md_tw_grid_cols_3
+    , md_tw_grid_cols_4
+    , md_tw_grid_cols_5
+    , md_tw_grid_cols_6
+    , md_tw_grid_cols_7
+    , md_tw_grid_cols_8
+    , md_tw_grid_cols_9
+    , md_tw_grid_cols_10
+    , md_tw_grid_cols_11
+    , md_tw_grid_cols_12
+    , md_tw_grid_cols_none
+    , md_tw_col_auto
+    , md_tw_col_span_1
+    , md_tw_col_span_2
+    , md_tw_col_span_3
+    , md_tw_col_span_4
+    , md_tw_col_span_5
+    , md_tw_col_span_6
+    , md_tw_col_span_7
+    , md_tw_col_span_8
+    , md_tw_col_span_9
+    , md_tw_col_span_10
+    , md_tw_col_span_11
+    , md_tw_col_span_12
+    , md_tw_col_start_1
+    , md_tw_col_start_2
+    , md_tw_col_start_3
+    , md_tw_col_start_4
+    , md_tw_col_start_5
+    , md_tw_col_start_6
+    , md_tw_col_start_7
+    , md_tw_col_start_8
+    , md_tw_col_start_9
+    , md_tw_col_start_10
+    , md_tw_col_start_11
+    , md_tw_col_start_12
+    , md_tw_col_start_13
+    , md_tw_col_start_auto
+    , md_tw_col_end_1
+    , md_tw_col_end_2
+    , md_tw_col_end_3
+    , md_tw_col_end_4
+    , md_tw_col_end_5
+    , md_tw_col_end_6
+    , md_tw_col_end_7
+    , md_tw_col_end_8
+    , md_tw_col_end_9
+    , md_tw_col_end_10
+    , md_tw_col_end_11
+    , md_tw_col_end_12
+    , md_tw_col_end_13
+    , md_tw_col_end_auto
+    , md_tw_grid_rows_1
+    , md_tw_grid_rows_2
+    , md_tw_grid_rows_3
+    , md_tw_grid_rows_4
+    , md_tw_grid_rows_5
+    , md_tw_grid_rows_6
+    , md_tw_grid_rows_none
+    , md_tw_row_auto
+    , md_tw_row_span_1
+    , md_tw_row_span_2
+    , md_tw_row_span_3
+    , md_tw_row_span_4
+    , md_tw_row_span_5
+    , md_tw_row_span_6
+    , md_tw_row_start_1
+    , md_tw_row_start_2
+    , md_tw_row_start_3
+    , md_tw_row_start_4
+    , md_tw_row_start_5
+    , md_tw_row_start_6
+    , md_tw_row_start_7
+    , md_tw_row_start_auto
+    , md_tw_row_end_1
+    , md_tw_row_end_2
+    , md_tw_row_end_3
+    , md_tw_row_end_4
+    , md_tw_row_end_5
+    , md_tw_row_end_6
+    , md_tw_row_end_7
+    , md_tw_row_end_auto
+    , md_tw_transform
+    , md_tw_transform_none
+    , md_tw_origin_center
+    , md_tw_origin_top
+    , md_tw_origin_top_right
+    , md_tw_origin_right
+    , md_tw_origin_bottom_right
+    , md_tw_origin_bottom
+    , md_tw_origin_bottom_left
+    , md_tw_origin_left
+    , md_tw_origin_top_left
+    , md_tw_scale_0
+    , md_tw_scale_50
+    , md_tw_scale_75
+    , md_tw_scale_90
+    , md_tw_scale_95
+    , md_tw_scale_100
+    , md_tw_scale_105
+    , md_tw_scale_110
+    , md_tw_scale_125
+    , md_tw_scale_150
+    , md_tw_scale_x_0
+    , md_tw_scale_x_50
+    , md_tw_scale_x_75
+    , md_tw_scale_x_90
+    , md_tw_scale_x_95
+    , md_tw_scale_x_100
+    , md_tw_scale_x_105
+    , md_tw_scale_x_110
+    , md_tw_scale_x_125
+    , md_tw_scale_x_150
+    , md_tw_scale_y_0
+    , md_tw_scale_y_50
+    , md_tw_scale_y_75
+    , md_tw_scale_y_90
+    , md_tw_scale_y_95
+    , md_tw_scale_y_100
+    , md_tw_scale_y_105
+    , md_tw_scale_y_110
+    , md_tw_scale_y_125
+    , md_tw_scale_y_150
+    , md_hover_tw_scale_0
+    , md_hover_tw_scale_50
+    , md_hover_tw_scale_75
+    , md_hover_tw_scale_90
+    , md_hover_tw_scale_95
+    , md_hover_tw_scale_100
+    , md_hover_tw_scale_105
+    , md_hover_tw_scale_110
+    , md_hover_tw_scale_125
+    , md_hover_tw_scale_150
+    , md_hover_tw_scale_x_0
+    , md_hover_tw_scale_x_50
+    , md_hover_tw_scale_x_75
+    , md_hover_tw_scale_x_90
+    , md_hover_tw_scale_x_95
+    , md_hover_tw_scale_x_100
+    , md_hover_tw_scale_x_105
+    , md_hover_tw_scale_x_110
+    , md_hover_tw_scale_x_125
+    , md_hover_tw_scale_x_150
+    , md_hover_tw_scale_y_0
+    , md_hover_tw_scale_y_50
+    , md_hover_tw_scale_y_75
+    , md_hover_tw_scale_y_90
+    , md_hover_tw_scale_y_95
+    , md_hover_tw_scale_y_100
+    , md_hover_tw_scale_y_105
+    , md_hover_tw_scale_y_110
+    , md_hover_tw_scale_y_125
+    , md_hover_tw_scale_y_150
+    , md_focus_tw_scale_0
+    , md_focus_tw_scale_50
+    , md_focus_tw_scale_75
+    , md_focus_tw_scale_90
+    , md_focus_tw_scale_95
+    , md_focus_tw_scale_100
+    , md_focus_tw_scale_105
+    , md_focus_tw_scale_110
+    , md_focus_tw_scale_125
+    , md_focus_tw_scale_150
+    , md_focus_tw_scale_x_0
+    , md_focus_tw_scale_x_50
+    , md_focus_tw_scale_x_75
+    , md_focus_tw_scale_x_90
+    , md_focus_tw_scale_x_95
+    , md_focus_tw_scale_x_100
+    , md_focus_tw_scale_x_105
+    , md_focus_tw_scale_x_110
+    , md_focus_tw_scale_x_125
+    , md_focus_tw_scale_x_150
+    , md_focus_tw_scale_y_0
+    , md_focus_tw_scale_y_50
+    , md_focus_tw_scale_y_75
+    , md_focus_tw_scale_y_90
+    , md_focus_tw_scale_y_95
+    , md_focus_tw_scale_y_100
+    , md_focus_tw_scale_y_105
+    , md_focus_tw_scale_y_110
+    , md_focus_tw_scale_y_125
+    , md_focus_tw_scale_y_150
+    , md_tw_rotate_0
+    , md_tw_rotate_45
+    , md_tw_rotate_90
+    , md_tw_rotate_180
+    , md_tw_neg_rotate_180
+    , md_tw_neg_rotate_90
+    , md_tw_neg_rotate_45
+    , md_hover_tw_rotate_0
+    , md_hover_tw_rotate_45
+    , md_hover_tw_rotate_90
+    , md_hover_tw_rotate_180
+    , md_hover_tw_neg_rotate_180
+    , md_hover_tw_neg_rotate_90
+    , md_hover_tw_neg_rotate_45
+    , md_focus_tw_rotate_0
+    , md_focus_tw_rotate_45
+    , md_focus_tw_rotate_90
+    , md_focus_tw_rotate_180
+    , md_focus_tw_neg_rotate_180
+    , md_focus_tw_neg_rotate_90
+    , md_focus_tw_neg_rotate_45
+    , md_tw_translate_x_0
+    , md_tw_translate_x_1
+    , md_tw_translate_x_2
+    , md_tw_translate_x_3
+    , md_tw_translate_x_4
+    , md_tw_translate_x_5
+    , md_tw_translate_x_6
+    , md_tw_translate_x_8
+    , md_tw_translate_x_10
+    , md_tw_translate_x_12
+    , md_tw_translate_x_16
+    , md_tw_translate_x_20
+    , md_tw_translate_x_24
+    , md_tw_translate_x_32
+    , md_tw_translate_x_40
+    , md_tw_translate_x_48
+    , md_tw_translate_x_56
+    , md_tw_translate_x_64
+    , md_tw_translate_x_px
+    , md_tw_neg_translate_x_1
+    , md_tw_neg_translate_x_2
+    , md_tw_neg_translate_x_3
+    , md_tw_neg_translate_x_4
+    , md_tw_neg_translate_x_5
+    , md_tw_neg_translate_x_6
+    , md_tw_neg_translate_x_8
+    , md_tw_neg_translate_x_10
+    , md_tw_neg_translate_x_12
+    , md_tw_neg_translate_x_16
+    , md_tw_neg_translate_x_20
+    , md_tw_neg_translate_x_24
+    , md_tw_neg_translate_x_32
+    , md_tw_neg_translate_x_40
+    , md_tw_neg_translate_x_48
+    , md_tw_neg_translate_x_56
+    , md_tw_neg_translate_x_64
+    , md_tw_neg_translate_x_px
+    , md_tw_neg_translate_x_full
+    , md_tw_neg_translate_x_1over2
+    , md_tw_translate_x_1over2
+    , md_tw_translate_x_full
+    , md_tw_translate_y_0
+    , md_tw_translate_y_1
+    , md_tw_translate_y_2
+    , md_tw_translate_y_3
+    , md_tw_translate_y_4
+    , md_tw_translate_y_5
+    , md_tw_translate_y_6
+    , md_tw_translate_y_8
+    , md_tw_translate_y_10
+    , md_tw_translate_y_12
+    , md_tw_translate_y_16
+    , md_tw_translate_y_20
+    , md_tw_translate_y_24
+    , md_tw_translate_y_32
+    , md_tw_translate_y_40
+    , md_tw_translate_y_48
+    , md_tw_translate_y_56
+    , md_tw_translate_y_64
+    , md_tw_translate_y_px
+    , md_tw_neg_translate_y_1
+    , md_tw_neg_translate_y_2
+    , md_tw_neg_translate_y_3
+    , md_tw_neg_translate_y_4
+    , md_tw_neg_translate_y_5
+    , md_tw_neg_translate_y_6
+    , md_tw_neg_translate_y_8
+    , md_tw_neg_translate_y_10
+    , md_tw_neg_translate_y_12
+    , md_tw_neg_translate_y_16
+    , md_tw_neg_translate_y_20
+    , md_tw_neg_translate_y_24
+    , md_tw_neg_translate_y_32
+    , md_tw_neg_translate_y_40
+    , md_tw_neg_translate_y_48
+    , md_tw_neg_translate_y_56
+    , md_tw_neg_translate_y_64
+    , md_tw_neg_translate_y_px
+    , md_tw_neg_translate_y_full
+    , md_tw_neg_translate_y_1over2
+    , md_tw_translate_y_1over2
+    , md_tw_translate_y_full
+    , md_hover_tw_translate_x_0
+    , md_hover_tw_translate_x_1
+    , md_hover_tw_translate_x_2
+    , md_hover_tw_translate_x_3
+    , md_hover_tw_translate_x_4
+    , md_hover_tw_translate_x_5
+    , md_hover_tw_translate_x_6
+    , md_hover_tw_translate_x_8
+    , md_hover_tw_translate_x_10
+    , md_hover_tw_translate_x_12
+    , md_hover_tw_translate_x_16
+    , md_hover_tw_translate_x_20
+    , md_hover_tw_translate_x_24
+    , md_hover_tw_translate_x_32
+    , md_hover_tw_translate_x_40
+    , md_hover_tw_translate_x_48
+    , md_hover_tw_translate_x_56
+    , md_hover_tw_translate_x_64
+    , md_hover_tw_translate_x_px
+    , md_hover_tw_neg_translate_x_1
+    , md_hover_tw_neg_translate_x_2
+    , md_hover_tw_neg_translate_x_3
+    , md_hover_tw_neg_translate_x_4
+    , md_hover_tw_neg_translate_x_5
+    , md_hover_tw_neg_translate_x_6
+    , md_hover_tw_neg_translate_x_8
+    , md_hover_tw_neg_translate_x_10
+    , md_hover_tw_neg_translate_x_12
+    , md_hover_tw_neg_translate_x_16
+    , md_hover_tw_neg_translate_x_20
+    , md_hover_tw_neg_translate_x_24
+    , md_hover_tw_neg_translate_x_32
+    , md_hover_tw_neg_translate_x_40
+    , md_hover_tw_neg_translate_x_48
+    , md_hover_tw_neg_translate_x_56
+    , md_hover_tw_neg_translate_x_64
+    , md_hover_tw_neg_translate_x_px
+    , md_hover_tw_neg_translate_x_full
+    , md_hover_tw_neg_translate_x_1over2
+    , md_hover_tw_translate_x_1over2
+    , md_hover_tw_translate_x_full
+    , md_hover_tw_translate_y_0
+    , md_hover_tw_translate_y_1
+    , md_hover_tw_translate_y_2
+    , md_hover_tw_translate_y_3
+    , md_hover_tw_translate_y_4
+    , md_hover_tw_translate_y_5
+    , md_hover_tw_translate_y_6
+    , md_hover_tw_translate_y_8
+    , md_hover_tw_translate_y_10
+    , md_hover_tw_translate_y_12
+    , md_hover_tw_translate_y_16
+    , md_hover_tw_translate_y_20
+    , md_hover_tw_translate_y_24
+    , md_hover_tw_translate_y_32
+    , md_hover_tw_translate_y_40
+    , md_hover_tw_translate_y_48
+    , md_hover_tw_translate_y_56
+    , md_hover_tw_translate_y_64
+    , md_hover_tw_translate_y_px
+    , md_hover_tw_neg_translate_y_1
+    , md_hover_tw_neg_translate_y_2
+    , md_hover_tw_neg_translate_y_3
+    , md_hover_tw_neg_translate_y_4
+    , md_hover_tw_neg_translate_y_5
+    , md_hover_tw_neg_translate_y_6
+    , md_hover_tw_neg_translate_y_8
+    , md_hover_tw_neg_translate_y_10
+    , md_hover_tw_neg_translate_y_12
+    , md_hover_tw_neg_translate_y_16
+    , md_hover_tw_neg_translate_y_20
+    , md_hover_tw_neg_translate_y_24
+    , md_hover_tw_neg_translate_y_32
+    , md_hover_tw_neg_translate_y_40
+    , md_hover_tw_neg_translate_y_48
+    , md_hover_tw_neg_translate_y_56
+    , md_hover_tw_neg_translate_y_64
+    , md_hover_tw_neg_translate_y_px
+    , md_hover_tw_neg_translate_y_full
+    , md_hover_tw_neg_translate_y_1over2
+    , md_hover_tw_translate_y_1over2
+    , md_hover_tw_translate_y_full
+    , md_focus_tw_translate_x_0
+    , md_focus_tw_translate_x_1
+    , md_focus_tw_translate_x_2
+    , md_focus_tw_translate_x_3
+    , md_focus_tw_translate_x_4
+    , md_focus_tw_translate_x_5
+    , md_focus_tw_translate_x_6
+    , md_focus_tw_translate_x_8
+    , md_focus_tw_translate_x_10
+    , md_focus_tw_translate_x_12
+    , md_focus_tw_translate_x_16
+    , md_focus_tw_translate_x_20
+    , md_focus_tw_translate_x_24
+    , md_focus_tw_translate_x_32
+    , md_focus_tw_translate_x_40
+    , md_focus_tw_translate_x_48
+    , md_focus_tw_translate_x_56
+    , md_focus_tw_translate_x_64
+    , md_focus_tw_translate_x_px
+    , md_focus_tw_neg_translate_x_1
+    , md_focus_tw_neg_translate_x_2
+    , md_focus_tw_neg_translate_x_3
+    , md_focus_tw_neg_translate_x_4
+    , md_focus_tw_neg_translate_x_5
+    , md_focus_tw_neg_translate_x_6
+    , md_focus_tw_neg_translate_x_8
+    , md_focus_tw_neg_translate_x_10
+    , md_focus_tw_neg_translate_x_12
+    , md_focus_tw_neg_translate_x_16
+    , md_focus_tw_neg_translate_x_20
+    , md_focus_tw_neg_translate_x_24
+    , md_focus_tw_neg_translate_x_32
+    , md_focus_tw_neg_translate_x_40
+    , md_focus_tw_neg_translate_x_48
+    , md_focus_tw_neg_translate_x_56
+    , md_focus_tw_neg_translate_x_64
+    , md_focus_tw_neg_translate_x_px
+    , md_focus_tw_neg_translate_x_full
+    , md_focus_tw_neg_translate_x_1over2
+    , md_focus_tw_translate_x_1over2
+    , md_focus_tw_translate_x_full
+    , md_focus_tw_translate_y_0
+    , md_focus_tw_translate_y_1
+    , md_focus_tw_translate_y_2
+    , md_focus_tw_translate_y_3
+    , md_focus_tw_translate_y_4
+    , md_focus_tw_translate_y_5
+    , md_focus_tw_translate_y_6
+    , md_focus_tw_translate_y_8
+    , md_focus_tw_translate_y_10
+    , md_focus_tw_translate_y_12
+    , md_focus_tw_translate_y_16
+    , md_focus_tw_translate_y_20
+    , md_focus_tw_translate_y_24
+    , md_focus_tw_translate_y_32
+    , md_focus_tw_translate_y_40
+    , md_focus_tw_translate_y_48
+    , md_focus_tw_translate_y_56
+    , md_focus_tw_translate_y_64
+    , md_focus_tw_translate_y_px
+    , md_focus_tw_neg_translate_y_1
+    , md_focus_tw_neg_translate_y_2
+    , md_focus_tw_neg_translate_y_3
+    , md_focus_tw_neg_translate_y_4
+    , md_focus_tw_neg_translate_y_5
+    , md_focus_tw_neg_translate_y_6
+    , md_focus_tw_neg_translate_y_8
+    , md_focus_tw_neg_translate_y_10
+    , md_focus_tw_neg_translate_y_12
+    , md_focus_tw_neg_translate_y_16
+    , md_focus_tw_neg_translate_y_20
+    , md_focus_tw_neg_translate_y_24
+    , md_focus_tw_neg_translate_y_32
+    , md_focus_tw_neg_translate_y_40
+    , md_focus_tw_neg_translate_y_48
+    , md_focus_tw_neg_translate_y_56
+    , md_focus_tw_neg_translate_y_64
+    , md_focus_tw_neg_translate_y_px
+    , md_focus_tw_neg_translate_y_full
+    , md_focus_tw_neg_translate_y_1over2
+    , md_focus_tw_translate_y_1over2
+    , md_focus_tw_translate_y_full
+    , md_tw_skew_x_0
+    , md_tw_skew_x_3
+    , md_tw_skew_x_6
+    , md_tw_skew_x_12
+    , md_tw_neg_skew_x_12
+    , md_tw_neg_skew_x_6
+    , md_tw_neg_skew_x_3
+    , md_tw_skew_y_0
+    , md_tw_skew_y_3
+    , md_tw_skew_y_6
+    , md_tw_skew_y_12
+    , md_tw_neg_skew_y_12
+    , md_tw_neg_skew_y_6
+    , md_tw_neg_skew_y_3
+    , md_hover_tw_skew_x_0
+    , md_hover_tw_skew_x_3
+    , md_hover_tw_skew_x_6
+    , md_hover_tw_skew_x_12
+    , md_hover_tw_neg_skew_x_12
+    , md_hover_tw_neg_skew_x_6
+    , md_hover_tw_neg_skew_x_3
+    , md_hover_tw_skew_y_0
+    , md_hover_tw_skew_y_3
+    , md_hover_tw_skew_y_6
+    , md_hover_tw_skew_y_12
+    , md_hover_tw_neg_skew_y_12
+    , md_hover_tw_neg_skew_y_6
+    , md_hover_tw_neg_skew_y_3
+    , md_focus_tw_skew_x_0
+    , md_focus_tw_skew_x_3
+    , md_focus_tw_skew_x_6
+    , md_focus_tw_skew_x_12
+    , md_focus_tw_neg_skew_x_12
+    , md_focus_tw_neg_skew_x_6
+    , md_focus_tw_neg_skew_x_3
+    , md_focus_tw_skew_y_0
+    , md_focus_tw_skew_y_3
+    , md_focus_tw_skew_y_6
+    , md_focus_tw_skew_y_12
+    , md_focus_tw_neg_skew_y_12
+    , md_focus_tw_neg_skew_y_6
+    , md_focus_tw_neg_skew_y_3
+    , md_tw_transition_none
+    , md_tw_transition_all
+    , md_tw_transition
+    , md_tw_transition_colors
+    , md_tw_transition_opacity
+    , md_tw_transition_shadow
+    , md_tw_transition_transform
+    , md_tw_ease_linear
+    , md_tw_ease_in
+    , md_tw_ease_out
+    , md_tw_ease_in_out
+    , md_tw_duration_75
+    , md_tw_duration_100
+    , md_tw_duration_150
+    , md_tw_duration_200
+    , md_tw_duration_300
+    , md_tw_duration_500
+    , md_tw_duration_700
+    , md_tw_duration_1000
     , lg_tw_sr_only
     , lg_tw_not_sr_only
     , lg_focus_tw_sr_only
@@ -6261,6 +8115,7 @@ module TLWND exposing
     , lg_tw_rounded_none
     , lg_tw_rounded_sm
     , lg_tw_rounded
+    , lg_tw_rounded_md
     , lg_tw_rounded_lg
     , lg_tw_rounded_full
     , lg_tw_rounded_t_none
@@ -6275,6 +8130,10 @@ module TLWND exposing
     , lg_tw_rounded_r
     , lg_tw_rounded_b
     , lg_tw_rounded_l
+    , lg_tw_rounded_t_md
+    , lg_tw_rounded_r_md
+    , lg_tw_rounded_b_md
+    , lg_tw_rounded_l_md
     , lg_tw_rounded_t_lg
     , lg_tw_rounded_r_lg
     , lg_tw_rounded_b_lg
@@ -6295,6 +8154,10 @@ module TLWND exposing
     , lg_tw_rounded_tr
     , lg_tw_rounded_br
     , lg_tw_rounded_bl
+    , lg_tw_rounded_tl_md
+    , lg_tw_rounded_tr_md
+    , lg_tw_rounded_br_md
+    , lg_tw_rounded_bl_md
     , lg_tw_rounded_tl_lg
     , lg_tw_rounded_tr_lg
     , lg_tw_rounded_br_lg
@@ -6333,6 +8196,8 @@ module TLWND exposing
     , lg_tw_border_r
     , lg_tw_border_b
     , lg_tw_border_l
+    , lg_tw_box_border
+    , lg_tw_box_content
     , lg_tw_cursor_auto
     , lg_tw_cursor_default
     , lg_tw_cursor_pointer
@@ -6345,9 +8210,16 @@ module TLWND exposing
     , lg_tw_inline
     , lg_tw_flex
     , lg_tw_inline_flex
+    , lg_tw_grid
     , lg_tw_table
-    , lg_tw_table_row
+    , lg_tw_table_caption
     , lg_tw_table_cell
+    , lg_tw_table_column
+    , lg_tw_table_column_group
+    , lg_tw_table_footer_group
+    , lg_tw_table_header_group
+    , lg_tw_table_row_group
+    , lg_tw_table_row
     , lg_tw_hidden
     , lg_tw_flex_row
     , lg_tw_flex_row_reverse
@@ -6371,6 +8243,7 @@ module TLWND exposing
     , lg_tw_justify_center
     , lg_tw_justify_between
     , lg_tw_justify_around
+    , lg_tw_justify_evenly
     , lg_tw_content_center
     , lg_tw_content_start
     , lg_tw_content_end
@@ -6403,6 +8276,9 @@ module TLWND exposing
     , lg_tw_float_left
     , lg_tw_float_none
     , lg_tw_clearfix_after
+    , lg_tw_clear_left
+    , lg_tw_clear_right
+    , lg_tw_clear_both
     , lg_tw_font_sans
     , lg_tw_font_serif
     , lg_tw_font_mono
@@ -6455,6 +8331,14 @@ module TLWND exposing
     , lg_tw_h_px
     , lg_tw_h_full
     , lg_tw_h_screen
+    , lg_tw_leading_3
+    , lg_tw_leading_4
+    , lg_tw_leading_5
+    , lg_tw_leading_6
+    , lg_tw_leading_7
+    , lg_tw_leading_8
+    , lg_tw_leading_9
+    , lg_tw_leading_10
     , lg_tw_leading_none
     , lg_tw_leading_tight
     , lg_tw_leading_snug
@@ -6734,6 +8618,7 @@ module TLWND exposing
     , lg_tw_neg_ml_px
     , lg_tw_max_h_full
     , lg_tw_max_h_screen
+    , lg_tw_max_w_none
     , lg_tw_max_w_xs
     , lg_tw_max_w_sm
     , lg_tw_max_w_md
@@ -6745,6 +8630,10 @@ module TLWND exposing
     , lg_tw_max_w_5xl
     , lg_tw_max_w_6xl
     , lg_tw_max_w_full
+    , lg_tw_max_w_screen_sm
+    , lg_tw_max_w_screen_md
+    , lg_tw_max_w_screen_lg
+    , lg_tw_max_w_screen_xl
     , lg_tw_min_h_0
     , lg_tw_min_h_full
     , lg_tw_min_h_screen
@@ -7139,6 +9028,8 @@ module TLWND exposing
     , lg_tw_resize_y
     , lg_tw_resize_x
     , lg_tw_resize
+    , lg_tw_shadow_xs
+    , lg_tw_shadow_sm
     , lg_tw_shadow
     , lg_tw_shadow_md
     , lg_tw_shadow_lg
@@ -7147,6 +9038,8 @@ module TLWND exposing
     , lg_tw_shadow_inner
     , lg_tw_shadow_outline
     , lg_tw_shadow_none
+    , lg_hover_tw_shadow_xs
+    , lg_hover_tw_shadow_sm
     , lg_hover_tw_shadow
     , lg_hover_tw_shadow_md
     , lg_hover_tw_shadow_lg
@@ -7155,6 +9048,8 @@ module TLWND exposing
     , lg_hover_tw_shadow_inner
     , lg_hover_tw_shadow_outline
     , lg_hover_tw_shadow_none
+    , lg_focus_tw_shadow_xs
+    , lg_focus_tw_shadow_sm
     , lg_focus_tw_shadow
     , lg_focus_tw_shadow_md
     , lg_focus_tw_shadow_lg
@@ -7165,6 +9060,9 @@ module TLWND exposing
     , lg_focus_tw_shadow_none
     , lg_tw_fill_current
     , lg_tw_stroke_current
+    , lg_tw_stroke_0
+    , lg_tw_stroke_1
+    , lg_tw_stroke_2
     , lg_tw_table_auto
     , lg_tw_table_fixed
     , lg_tw_text_left
@@ -7559,6 +9457,580 @@ module TLWND exposing
     , lg_tw_z_40
     , lg_tw_z_50
     , lg_tw_z_auto
+    , lg_tw_gap_0
+    , lg_tw_gap_1
+    , lg_tw_gap_2
+    , lg_tw_gap_3
+    , lg_tw_gap_4
+    , lg_tw_gap_5
+    , lg_tw_gap_6
+    , lg_tw_gap_8
+    , lg_tw_gap_10
+    , lg_tw_gap_12
+    , lg_tw_gap_16
+    , lg_tw_gap_20
+    , lg_tw_gap_24
+    , lg_tw_gap_32
+    , lg_tw_gap_40
+    , lg_tw_gap_48
+    , lg_tw_gap_56
+    , lg_tw_gap_64
+    , lg_tw_gap_px
+    , lg_tw_col_gap_0
+    , lg_tw_col_gap_1
+    , lg_tw_col_gap_2
+    , lg_tw_col_gap_3
+    , lg_tw_col_gap_4
+    , lg_tw_col_gap_5
+    , lg_tw_col_gap_6
+    , lg_tw_col_gap_8
+    , lg_tw_col_gap_10
+    , lg_tw_col_gap_12
+    , lg_tw_col_gap_16
+    , lg_tw_col_gap_20
+    , lg_tw_col_gap_24
+    , lg_tw_col_gap_32
+    , lg_tw_col_gap_40
+    , lg_tw_col_gap_48
+    , lg_tw_col_gap_56
+    , lg_tw_col_gap_64
+    , lg_tw_col_gap_px
+    , lg_tw_row_gap_0
+    , lg_tw_row_gap_1
+    , lg_tw_row_gap_2
+    , lg_tw_row_gap_3
+    , lg_tw_row_gap_4
+    , lg_tw_row_gap_5
+    , lg_tw_row_gap_6
+    , lg_tw_row_gap_8
+    , lg_tw_row_gap_10
+    , lg_tw_row_gap_12
+    , lg_tw_row_gap_16
+    , lg_tw_row_gap_20
+    , lg_tw_row_gap_24
+    , lg_tw_row_gap_32
+    , lg_tw_row_gap_40
+    , lg_tw_row_gap_48
+    , lg_tw_row_gap_56
+    , lg_tw_row_gap_64
+    , lg_tw_row_gap_px
+    , lg_tw_grid_flow_row
+    , lg_tw_grid_flow_col
+    , lg_tw_grid_flow_row_dense
+    , lg_tw_grid_flow_col_dense
+    , lg_tw_grid_cols_1
+    , lg_tw_grid_cols_2
+    , lg_tw_grid_cols_3
+    , lg_tw_grid_cols_4
+    , lg_tw_grid_cols_5
+    , lg_tw_grid_cols_6
+    , lg_tw_grid_cols_7
+    , lg_tw_grid_cols_8
+    , lg_tw_grid_cols_9
+    , lg_tw_grid_cols_10
+    , lg_tw_grid_cols_11
+    , lg_tw_grid_cols_12
+    , lg_tw_grid_cols_none
+    , lg_tw_col_auto
+    , lg_tw_col_span_1
+    , lg_tw_col_span_2
+    , lg_tw_col_span_3
+    , lg_tw_col_span_4
+    , lg_tw_col_span_5
+    , lg_tw_col_span_6
+    , lg_tw_col_span_7
+    , lg_tw_col_span_8
+    , lg_tw_col_span_9
+    , lg_tw_col_span_10
+    , lg_tw_col_span_11
+    , lg_tw_col_span_12
+    , lg_tw_col_start_1
+    , lg_tw_col_start_2
+    , lg_tw_col_start_3
+    , lg_tw_col_start_4
+    , lg_tw_col_start_5
+    , lg_tw_col_start_6
+    , lg_tw_col_start_7
+    , lg_tw_col_start_8
+    , lg_tw_col_start_9
+    , lg_tw_col_start_10
+    , lg_tw_col_start_11
+    , lg_tw_col_start_12
+    , lg_tw_col_start_13
+    , lg_tw_col_start_auto
+    , lg_tw_col_end_1
+    , lg_tw_col_end_2
+    , lg_tw_col_end_3
+    , lg_tw_col_end_4
+    , lg_tw_col_end_5
+    , lg_tw_col_end_6
+    , lg_tw_col_end_7
+    , lg_tw_col_end_8
+    , lg_tw_col_end_9
+    , lg_tw_col_end_10
+    , lg_tw_col_end_11
+    , lg_tw_col_end_12
+    , lg_tw_col_end_13
+    , lg_tw_col_end_auto
+    , lg_tw_grid_rows_1
+    , lg_tw_grid_rows_2
+    , lg_tw_grid_rows_3
+    , lg_tw_grid_rows_4
+    , lg_tw_grid_rows_5
+    , lg_tw_grid_rows_6
+    , lg_tw_grid_rows_none
+    , lg_tw_row_auto
+    , lg_tw_row_span_1
+    , lg_tw_row_span_2
+    , lg_tw_row_span_3
+    , lg_tw_row_span_4
+    , lg_tw_row_span_5
+    , lg_tw_row_span_6
+    , lg_tw_row_start_1
+    , lg_tw_row_start_2
+    , lg_tw_row_start_3
+    , lg_tw_row_start_4
+    , lg_tw_row_start_5
+    , lg_tw_row_start_6
+    , lg_tw_row_start_7
+    , lg_tw_row_start_auto
+    , lg_tw_row_end_1
+    , lg_tw_row_end_2
+    , lg_tw_row_end_3
+    , lg_tw_row_end_4
+    , lg_tw_row_end_5
+    , lg_tw_row_end_6
+    , lg_tw_row_end_7
+    , lg_tw_row_end_auto
+    , lg_tw_transform
+    , lg_tw_transform_none
+    , lg_tw_origin_center
+    , lg_tw_origin_top
+    , lg_tw_origin_top_right
+    , lg_tw_origin_right
+    , lg_tw_origin_bottom_right
+    , lg_tw_origin_bottom
+    , lg_tw_origin_bottom_left
+    , lg_tw_origin_left
+    , lg_tw_origin_top_left
+    , lg_tw_scale_0
+    , lg_tw_scale_50
+    , lg_tw_scale_75
+    , lg_tw_scale_90
+    , lg_tw_scale_95
+    , lg_tw_scale_100
+    , lg_tw_scale_105
+    , lg_tw_scale_110
+    , lg_tw_scale_125
+    , lg_tw_scale_150
+    , lg_tw_scale_x_0
+    , lg_tw_scale_x_50
+    , lg_tw_scale_x_75
+    , lg_tw_scale_x_90
+    , lg_tw_scale_x_95
+    , lg_tw_scale_x_100
+    , lg_tw_scale_x_105
+    , lg_tw_scale_x_110
+    , lg_tw_scale_x_125
+    , lg_tw_scale_x_150
+    , lg_tw_scale_y_0
+    , lg_tw_scale_y_50
+    , lg_tw_scale_y_75
+    , lg_tw_scale_y_90
+    , lg_tw_scale_y_95
+    , lg_tw_scale_y_100
+    , lg_tw_scale_y_105
+    , lg_tw_scale_y_110
+    , lg_tw_scale_y_125
+    , lg_tw_scale_y_150
+    , lg_hover_tw_scale_0
+    , lg_hover_tw_scale_50
+    , lg_hover_tw_scale_75
+    , lg_hover_tw_scale_90
+    , lg_hover_tw_scale_95
+    , lg_hover_tw_scale_100
+    , lg_hover_tw_scale_105
+    , lg_hover_tw_scale_110
+    , lg_hover_tw_scale_125
+    , lg_hover_tw_scale_150
+    , lg_hover_tw_scale_x_0
+    , lg_hover_tw_scale_x_50
+    , lg_hover_tw_scale_x_75
+    , lg_hover_tw_scale_x_90
+    , lg_hover_tw_scale_x_95
+    , lg_hover_tw_scale_x_100
+    , lg_hover_tw_scale_x_105
+    , lg_hover_tw_scale_x_110
+    , lg_hover_tw_scale_x_125
+    , lg_hover_tw_scale_x_150
+    , lg_hover_tw_scale_y_0
+    , lg_hover_tw_scale_y_50
+    , lg_hover_tw_scale_y_75
+    , lg_hover_tw_scale_y_90
+    , lg_hover_tw_scale_y_95
+    , lg_hover_tw_scale_y_100
+    , lg_hover_tw_scale_y_105
+    , lg_hover_tw_scale_y_110
+    , lg_hover_tw_scale_y_125
+    , lg_hover_tw_scale_y_150
+    , lg_focus_tw_scale_0
+    , lg_focus_tw_scale_50
+    , lg_focus_tw_scale_75
+    , lg_focus_tw_scale_90
+    , lg_focus_tw_scale_95
+    , lg_focus_tw_scale_100
+    , lg_focus_tw_scale_105
+    , lg_focus_tw_scale_110
+    , lg_focus_tw_scale_125
+    , lg_focus_tw_scale_150
+    , lg_focus_tw_scale_x_0
+    , lg_focus_tw_scale_x_50
+    , lg_focus_tw_scale_x_75
+    , lg_focus_tw_scale_x_90
+    , lg_focus_tw_scale_x_95
+    , lg_focus_tw_scale_x_100
+    , lg_focus_tw_scale_x_105
+    , lg_focus_tw_scale_x_110
+    , lg_focus_tw_scale_x_125
+    , lg_focus_tw_scale_x_150
+    , lg_focus_tw_scale_y_0
+    , lg_focus_tw_scale_y_50
+    , lg_focus_tw_scale_y_75
+    , lg_focus_tw_scale_y_90
+    , lg_focus_tw_scale_y_95
+    , lg_focus_tw_scale_y_100
+    , lg_focus_tw_scale_y_105
+    , lg_focus_tw_scale_y_110
+    , lg_focus_tw_scale_y_125
+    , lg_focus_tw_scale_y_150
+    , lg_tw_rotate_0
+    , lg_tw_rotate_45
+    , lg_tw_rotate_90
+    , lg_tw_rotate_180
+    , lg_tw_neg_rotate_180
+    , lg_tw_neg_rotate_90
+    , lg_tw_neg_rotate_45
+    , lg_hover_tw_rotate_0
+    , lg_hover_tw_rotate_45
+    , lg_hover_tw_rotate_90
+    , lg_hover_tw_rotate_180
+    , lg_hover_tw_neg_rotate_180
+    , lg_hover_tw_neg_rotate_90
+    , lg_hover_tw_neg_rotate_45
+    , lg_focus_tw_rotate_0
+    , lg_focus_tw_rotate_45
+    , lg_focus_tw_rotate_90
+    , lg_focus_tw_rotate_180
+    , lg_focus_tw_neg_rotate_180
+    , lg_focus_tw_neg_rotate_90
+    , lg_focus_tw_neg_rotate_45
+    , lg_tw_translate_x_0
+    , lg_tw_translate_x_1
+    , lg_tw_translate_x_2
+    , lg_tw_translate_x_3
+    , lg_tw_translate_x_4
+    , lg_tw_translate_x_5
+    , lg_tw_translate_x_6
+    , lg_tw_translate_x_8
+    , lg_tw_translate_x_10
+    , lg_tw_translate_x_12
+    , lg_tw_translate_x_16
+    , lg_tw_translate_x_20
+    , lg_tw_translate_x_24
+    , lg_tw_translate_x_32
+    , lg_tw_translate_x_40
+    , lg_tw_translate_x_48
+    , lg_tw_translate_x_56
+    , lg_tw_translate_x_64
+    , lg_tw_translate_x_px
+    , lg_tw_neg_translate_x_1
+    , lg_tw_neg_translate_x_2
+    , lg_tw_neg_translate_x_3
+    , lg_tw_neg_translate_x_4
+    , lg_tw_neg_translate_x_5
+    , lg_tw_neg_translate_x_6
+    , lg_tw_neg_translate_x_8
+    , lg_tw_neg_translate_x_10
+    , lg_tw_neg_translate_x_12
+    , lg_tw_neg_translate_x_16
+    , lg_tw_neg_translate_x_20
+    , lg_tw_neg_translate_x_24
+    , lg_tw_neg_translate_x_32
+    , lg_tw_neg_translate_x_40
+    , lg_tw_neg_translate_x_48
+    , lg_tw_neg_translate_x_56
+    , lg_tw_neg_translate_x_64
+    , lg_tw_neg_translate_x_px
+    , lg_tw_neg_translate_x_full
+    , lg_tw_neg_translate_x_1over2
+    , lg_tw_translate_x_1over2
+    , lg_tw_translate_x_full
+    , lg_tw_translate_y_0
+    , lg_tw_translate_y_1
+    , lg_tw_translate_y_2
+    , lg_tw_translate_y_3
+    , lg_tw_translate_y_4
+    , lg_tw_translate_y_5
+    , lg_tw_translate_y_6
+    , lg_tw_translate_y_8
+    , lg_tw_translate_y_10
+    , lg_tw_translate_y_12
+    , lg_tw_translate_y_16
+    , lg_tw_translate_y_20
+    , lg_tw_translate_y_24
+    , lg_tw_translate_y_32
+    , lg_tw_translate_y_40
+    , lg_tw_translate_y_48
+    , lg_tw_translate_y_56
+    , lg_tw_translate_y_64
+    , lg_tw_translate_y_px
+    , lg_tw_neg_translate_y_1
+    , lg_tw_neg_translate_y_2
+    , lg_tw_neg_translate_y_3
+    , lg_tw_neg_translate_y_4
+    , lg_tw_neg_translate_y_5
+    , lg_tw_neg_translate_y_6
+    , lg_tw_neg_translate_y_8
+    , lg_tw_neg_translate_y_10
+    , lg_tw_neg_translate_y_12
+    , lg_tw_neg_translate_y_16
+    , lg_tw_neg_translate_y_20
+    , lg_tw_neg_translate_y_24
+    , lg_tw_neg_translate_y_32
+    , lg_tw_neg_translate_y_40
+    , lg_tw_neg_translate_y_48
+    , lg_tw_neg_translate_y_56
+    , lg_tw_neg_translate_y_64
+    , lg_tw_neg_translate_y_px
+    , lg_tw_neg_translate_y_full
+    , lg_tw_neg_translate_y_1over2
+    , lg_tw_translate_y_1over2
+    , lg_tw_translate_y_full
+    , lg_hover_tw_translate_x_0
+    , lg_hover_tw_translate_x_1
+    , lg_hover_tw_translate_x_2
+    , lg_hover_tw_translate_x_3
+    , lg_hover_tw_translate_x_4
+    , lg_hover_tw_translate_x_5
+    , lg_hover_tw_translate_x_6
+    , lg_hover_tw_translate_x_8
+    , lg_hover_tw_translate_x_10
+    , lg_hover_tw_translate_x_12
+    , lg_hover_tw_translate_x_16
+    , lg_hover_tw_translate_x_20
+    , lg_hover_tw_translate_x_24
+    , lg_hover_tw_translate_x_32
+    , lg_hover_tw_translate_x_40
+    , lg_hover_tw_translate_x_48
+    , lg_hover_tw_translate_x_56
+    , lg_hover_tw_translate_x_64
+    , lg_hover_tw_translate_x_px
+    , lg_hover_tw_neg_translate_x_1
+    , lg_hover_tw_neg_translate_x_2
+    , lg_hover_tw_neg_translate_x_3
+    , lg_hover_tw_neg_translate_x_4
+    , lg_hover_tw_neg_translate_x_5
+    , lg_hover_tw_neg_translate_x_6
+    , lg_hover_tw_neg_translate_x_8
+    , lg_hover_tw_neg_translate_x_10
+    , lg_hover_tw_neg_translate_x_12
+    , lg_hover_tw_neg_translate_x_16
+    , lg_hover_tw_neg_translate_x_20
+    , lg_hover_tw_neg_translate_x_24
+    , lg_hover_tw_neg_translate_x_32
+    , lg_hover_tw_neg_translate_x_40
+    , lg_hover_tw_neg_translate_x_48
+    , lg_hover_tw_neg_translate_x_56
+    , lg_hover_tw_neg_translate_x_64
+    , lg_hover_tw_neg_translate_x_px
+    , lg_hover_tw_neg_translate_x_full
+    , lg_hover_tw_neg_translate_x_1over2
+    , lg_hover_tw_translate_x_1over2
+    , lg_hover_tw_translate_x_full
+    , lg_hover_tw_translate_y_0
+    , lg_hover_tw_translate_y_1
+    , lg_hover_tw_translate_y_2
+    , lg_hover_tw_translate_y_3
+    , lg_hover_tw_translate_y_4
+    , lg_hover_tw_translate_y_5
+    , lg_hover_tw_translate_y_6
+    , lg_hover_tw_translate_y_8
+    , lg_hover_tw_translate_y_10
+    , lg_hover_tw_translate_y_12
+    , lg_hover_tw_translate_y_16
+    , lg_hover_tw_translate_y_20
+    , lg_hover_tw_translate_y_24
+    , lg_hover_tw_translate_y_32
+    , lg_hover_tw_translate_y_40
+    , lg_hover_tw_translate_y_48
+    , lg_hover_tw_translate_y_56
+    , lg_hover_tw_translate_y_64
+    , lg_hover_tw_translate_y_px
+    , lg_hover_tw_neg_translate_y_1
+    , lg_hover_tw_neg_translate_y_2
+    , lg_hover_tw_neg_translate_y_3
+    , lg_hover_tw_neg_translate_y_4
+    , lg_hover_tw_neg_translate_y_5
+    , lg_hover_tw_neg_translate_y_6
+    , lg_hover_tw_neg_translate_y_8
+    , lg_hover_tw_neg_translate_y_10
+    , lg_hover_tw_neg_translate_y_12
+    , lg_hover_tw_neg_translate_y_16
+    , lg_hover_tw_neg_translate_y_20
+    , lg_hover_tw_neg_translate_y_24
+    , lg_hover_tw_neg_translate_y_32
+    , lg_hover_tw_neg_translate_y_40
+    , lg_hover_tw_neg_translate_y_48
+    , lg_hover_tw_neg_translate_y_56
+    , lg_hover_tw_neg_translate_y_64
+    , lg_hover_tw_neg_translate_y_px
+    , lg_hover_tw_neg_translate_y_full
+    , lg_hover_tw_neg_translate_y_1over2
+    , lg_hover_tw_translate_y_1over2
+    , lg_hover_tw_translate_y_full
+    , lg_focus_tw_translate_x_0
+    , lg_focus_tw_translate_x_1
+    , lg_focus_tw_translate_x_2
+    , lg_focus_tw_translate_x_3
+    , lg_focus_tw_translate_x_4
+    , lg_focus_tw_translate_x_5
+    , lg_focus_tw_translate_x_6
+    , lg_focus_tw_translate_x_8
+    , lg_focus_tw_translate_x_10
+    , lg_focus_tw_translate_x_12
+    , lg_focus_tw_translate_x_16
+    , lg_focus_tw_translate_x_20
+    , lg_focus_tw_translate_x_24
+    , lg_focus_tw_translate_x_32
+    , lg_focus_tw_translate_x_40
+    , lg_focus_tw_translate_x_48
+    , lg_focus_tw_translate_x_56
+    , lg_focus_tw_translate_x_64
+    , lg_focus_tw_translate_x_px
+    , lg_focus_tw_neg_translate_x_1
+    , lg_focus_tw_neg_translate_x_2
+    , lg_focus_tw_neg_translate_x_3
+    , lg_focus_tw_neg_translate_x_4
+    , lg_focus_tw_neg_translate_x_5
+    , lg_focus_tw_neg_translate_x_6
+    , lg_focus_tw_neg_translate_x_8
+    , lg_focus_tw_neg_translate_x_10
+    , lg_focus_tw_neg_translate_x_12
+    , lg_focus_tw_neg_translate_x_16
+    , lg_focus_tw_neg_translate_x_20
+    , lg_focus_tw_neg_translate_x_24
+    , lg_focus_tw_neg_translate_x_32
+    , lg_focus_tw_neg_translate_x_40
+    , lg_focus_tw_neg_translate_x_48
+    , lg_focus_tw_neg_translate_x_56
+    , lg_focus_tw_neg_translate_x_64
+    , lg_focus_tw_neg_translate_x_px
+    , lg_focus_tw_neg_translate_x_full
+    , lg_focus_tw_neg_translate_x_1over2
+    , lg_focus_tw_translate_x_1over2
+    , lg_focus_tw_translate_x_full
+    , lg_focus_tw_translate_y_0
+    , lg_focus_tw_translate_y_1
+    , lg_focus_tw_translate_y_2
+    , lg_focus_tw_translate_y_3
+    , lg_focus_tw_translate_y_4
+    , lg_focus_tw_translate_y_5
+    , lg_focus_tw_translate_y_6
+    , lg_focus_tw_translate_y_8
+    , lg_focus_tw_translate_y_10
+    , lg_focus_tw_translate_y_12
+    , lg_focus_tw_translate_y_16
+    , lg_focus_tw_translate_y_20
+    , lg_focus_tw_translate_y_24
+    , lg_focus_tw_translate_y_32
+    , lg_focus_tw_translate_y_40
+    , lg_focus_tw_translate_y_48
+    , lg_focus_tw_translate_y_56
+    , lg_focus_tw_translate_y_64
+    , lg_focus_tw_translate_y_px
+    , lg_focus_tw_neg_translate_y_1
+    , lg_focus_tw_neg_translate_y_2
+    , lg_focus_tw_neg_translate_y_3
+    , lg_focus_tw_neg_translate_y_4
+    , lg_focus_tw_neg_translate_y_5
+    , lg_focus_tw_neg_translate_y_6
+    , lg_focus_tw_neg_translate_y_8
+    , lg_focus_tw_neg_translate_y_10
+    , lg_focus_tw_neg_translate_y_12
+    , lg_focus_tw_neg_translate_y_16
+    , lg_focus_tw_neg_translate_y_20
+    , lg_focus_tw_neg_translate_y_24
+    , lg_focus_tw_neg_translate_y_32
+    , lg_focus_tw_neg_translate_y_40
+    , lg_focus_tw_neg_translate_y_48
+    , lg_focus_tw_neg_translate_y_56
+    , lg_focus_tw_neg_translate_y_64
+    , lg_focus_tw_neg_translate_y_px
+    , lg_focus_tw_neg_translate_y_full
+    , lg_focus_tw_neg_translate_y_1over2
+    , lg_focus_tw_translate_y_1over2
+    , lg_focus_tw_translate_y_full
+    , lg_tw_skew_x_0
+    , lg_tw_skew_x_3
+    , lg_tw_skew_x_6
+    , lg_tw_skew_x_12
+    , lg_tw_neg_skew_x_12
+    , lg_tw_neg_skew_x_6
+    , lg_tw_neg_skew_x_3
+    , lg_tw_skew_y_0
+    , lg_tw_skew_y_3
+    , lg_tw_skew_y_6
+    , lg_tw_skew_y_12
+    , lg_tw_neg_skew_y_12
+    , lg_tw_neg_skew_y_6
+    , lg_tw_neg_skew_y_3
+    , lg_hover_tw_skew_x_0
+    , lg_hover_tw_skew_x_3
+    , lg_hover_tw_skew_x_6
+    , lg_hover_tw_skew_x_12
+    , lg_hover_tw_neg_skew_x_12
+    , lg_hover_tw_neg_skew_x_6
+    , lg_hover_tw_neg_skew_x_3
+    , lg_hover_tw_skew_y_0
+    , lg_hover_tw_skew_y_3
+    , lg_hover_tw_skew_y_6
+    , lg_hover_tw_skew_y_12
+    , lg_hover_tw_neg_skew_y_12
+    , lg_hover_tw_neg_skew_y_6
+    , lg_hover_tw_neg_skew_y_3
+    , lg_focus_tw_skew_x_0
+    , lg_focus_tw_skew_x_3
+    , lg_focus_tw_skew_x_6
+    , lg_focus_tw_skew_x_12
+    , lg_focus_tw_neg_skew_x_12
+    , lg_focus_tw_neg_skew_x_6
+    , lg_focus_tw_neg_skew_x_3
+    , lg_focus_tw_skew_y_0
+    , lg_focus_tw_skew_y_3
+    , lg_focus_tw_skew_y_6
+    , lg_focus_tw_skew_y_12
+    , lg_focus_tw_neg_skew_y_12
+    , lg_focus_tw_neg_skew_y_6
+    , lg_focus_tw_neg_skew_y_3
+    , lg_tw_transition_none
+    , lg_tw_transition_all
+    , lg_tw_transition
+    , lg_tw_transition_colors
+    , lg_tw_transition_opacity
+    , lg_tw_transition_shadow
+    , lg_tw_transition_transform
+    , lg_tw_ease_linear
+    , lg_tw_ease_in
+    , lg_tw_ease_out
+    , lg_tw_ease_in_out
+    , lg_tw_duration_75
+    , lg_tw_duration_100
+    , lg_tw_duration_150
+    , lg_tw_duration_200
+    , lg_tw_duration_300
+    , lg_tw_duration_500
+    , lg_tw_duration_700
+    , lg_tw_duration_1000
     , xl_tw_sr_only
     , xl_tw_not_sr_only
     , xl_focus_tw_sr_only
@@ -8148,6 +10620,7 @@ module TLWND exposing
     , xl_tw_rounded_none
     , xl_tw_rounded_sm
     , xl_tw_rounded
+    , xl_tw_rounded_md
     , xl_tw_rounded_lg
     , xl_tw_rounded_full
     , xl_tw_rounded_t_none
@@ -8162,6 +10635,10 @@ module TLWND exposing
     , xl_tw_rounded_r
     , xl_tw_rounded_b
     , xl_tw_rounded_l
+    , xl_tw_rounded_t_md
+    , xl_tw_rounded_r_md
+    , xl_tw_rounded_b_md
+    , xl_tw_rounded_l_md
     , xl_tw_rounded_t_lg
     , xl_tw_rounded_r_lg
     , xl_tw_rounded_b_lg
@@ -8182,6 +10659,10 @@ module TLWND exposing
     , xl_tw_rounded_tr
     , xl_tw_rounded_br
     , xl_tw_rounded_bl
+    , xl_tw_rounded_tl_md
+    , xl_tw_rounded_tr_md
+    , xl_tw_rounded_br_md
+    , xl_tw_rounded_bl_md
     , xl_tw_rounded_tl_lg
     , xl_tw_rounded_tr_lg
     , xl_tw_rounded_br_lg
@@ -8220,6 +10701,8 @@ module TLWND exposing
     , xl_tw_border_r
     , xl_tw_border_b
     , xl_tw_border_l
+    , xl_tw_box_border
+    , xl_tw_box_content
     , xl_tw_cursor_auto
     , xl_tw_cursor_default
     , xl_tw_cursor_pointer
@@ -8232,9 +10715,16 @@ module TLWND exposing
     , xl_tw_inline
     , xl_tw_flex
     , xl_tw_inline_flex
+    , xl_tw_grid
     , xl_tw_table
-    , xl_tw_table_row
+    , xl_tw_table_caption
     , xl_tw_table_cell
+    , xl_tw_table_column
+    , xl_tw_table_column_group
+    , xl_tw_table_footer_group
+    , xl_tw_table_header_group
+    , xl_tw_table_row_group
+    , xl_tw_table_row
     , xl_tw_hidden
     , xl_tw_flex_row
     , xl_tw_flex_row_reverse
@@ -8258,6 +10748,7 @@ module TLWND exposing
     , xl_tw_justify_center
     , xl_tw_justify_between
     , xl_tw_justify_around
+    , xl_tw_justify_evenly
     , xl_tw_content_center
     , xl_tw_content_start
     , xl_tw_content_end
@@ -8290,6 +10781,9 @@ module TLWND exposing
     , xl_tw_float_left
     , xl_tw_float_none
     , xl_tw_clearfix_after
+    , xl_tw_clear_left
+    , xl_tw_clear_right
+    , xl_tw_clear_both
     , xl_tw_font_sans
     , xl_tw_font_serif
     , xl_tw_font_mono
@@ -8342,6 +10836,14 @@ module TLWND exposing
     , xl_tw_h_px
     , xl_tw_h_full
     , xl_tw_h_screen
+    , xl_tw_leading_3
+    , xl_tw_leading_4
+    , xl_tw_leading_5
+    , xl_tw_leading_6
+    , xl_tw_leading_7
+    , xl_tw_leading_8
+    , xl_tw_leading_9
+    , xl_tw_leading_10
     , xl_tw_leading_none
     , xl_tw_leading_tight
     , xl_tw_leading_snug
@@ -8621,6 +11123,7 @@ module TLWND exposing
     , xl_tw_neg_ml_px
     , xl_tw_max_h_full
     , xl_tw_max_h_screen
+    , xl_tw_max_w_none
     , xl_tw_max_w_xs
     , xl_tw_max_w_sm
     , xl_tw_max_w_md
@@ -8632,6 +11135,10 @@ module TLWND exposing
     , xl_tw_max_w_5xl
     , xl_tw_max_w_6xl
     , xl_tw_max_w_full
+    , xl_tw_max_w_screen_sm
+    , xl_tw_max_w_screen_md
+    , xl_tw_max_w_screen_lg
+    , xl_tw_max_w_screen_xl
     , xl_tw_min_h_0
     , xl_tw_min_h_full
     , xl_tw_min_h_screen
@@ -9026,6 +11533,8 @@ module TLWND exposing
     , xl_tw_resize_y
     , xl_tw_resize_x
     , xl_tw_resize
+    , xl_tw_shadow_xs
+    , xl_tw_shadow_sm
     , xl_tw_shadow
     , xl_tw_shadow_md
     , xl_tw_shadow_lg
@@ -9034,6 +11543,8 @@ module TLWND exposing
     , xl_tw_shadow_inner
     , xl_tw_shadow_outline
     , xl_tw_shadow_none
+    , xl_hover_tw_shadow_xs
+    , xl_hover_tw_shadow_sm
     , xl_hover_tw_shadow
     , xl_hover_tw_shadow_md
     , xl_hover_tw_shadow_lg
@@ -9042,6 +11553,8 @@ module TLWND exposing
     , xl_hover_tw_shadow_inner
     , xl_hover_tw_shadow_outline
     , xl_hover_tw_shadow_none
+    , xl_focus_tw_shadow_xs
+    , xl_focus_tw_shadow_sm
     , xl_focus_tw_shadow
     , xl_focus_tw_shadow_md
     , xl_focus_tw_shadow_lg
@@ -9052,6 +11565,9 @@ module TLWND exposing
     , xl_focus_tw_shadow_none
     , xl_tw_fill_current
     , xl_tw_stroke_current
+    , xl_tw_stroke_0
+    , xl_tw_stroke_1
+    , xl_tw_stroke_2
     , xl_tw_table_auto
     , xl_tw_table_fixed
     , xl_tw_text_left
@@ -9446,6 +11962,580 @@ module TLWND exposing
     , xl_tw_z_40
     , xl_tw_z_50
     , xl_tw_z_auto
+    , xl_tw_gap_0
+    , xl_tw_gap_1
+    , xl_tw_gap_2
+    , xl_tw_gap_3
+    , xl_tw_gap_4
+    , xl_tw_gap_5
+    , xl_tw_gap_6
+    , xl_tw_gap_8
+    , xl_tw_gap_10
+    , xl_tw_gap_12
+    , xl_tw_gap_16
+    , xl_tw_gap_20
+    , xl_tw_gap_24
+    , xl_tw_gap_32
+    , xl_tw_gap_40
+    , xl_tw_gap_48
+    , xl_tw_gap_56
+    , xl_tw_gap_64
+    , xl_tw_gap_px
+    , xl_tw_col_gap_0
+    , xl_tw_col_gap_1
+    , xl_tw_col_gap_2
+    , xl_tw_col_gap_3
+    , xl_tw_col_gap_4
+    , xl_tw_col_gap_5
+    , xl_tw_col_gap_6
+    , xl_tw_col_gap_8
+    , xl_tw_col_gap_10
+    , xl_tw_col_gap_12
+    , xl_tw_col_gap_16
+    , xl_tw_col_gap_20
+    , xl_tw_col_gap_24
+    , xl_tw_col_gap_32
+    , xl_tw_col_gap_40
+    , xl_tw_col_gap_48
+    , xl_tw_col_gap_56
+    , xl_tw_col_gap_64
+    , xl_tw_col_gap_px
+    , xl_tw_row_gap_0
+    , xl_tw_row_gap_1
+    , xl_tw_row_gap_2
+    , xl_tw_row_gap_3
+    , xl_tw_row_gap_4
+    , xl_tw_row_gap_5
+    , xl_tw_row_gap_6
+    , xl_tw_row_gap_8
+    , xl_tw_row_gap_10
+    , xl_tw_row_gap_12
+    , xl_tw_row_gap_16
+    , xl_tw_row_gap_20
+    , xl_tw_row_gap_24
+    , xl_tw_row_gap_32
+    , xl_tw_row_gap_40
+    , xl_tw_row_gap_48
+    , xl_tw_row_gap_56
+    , xl_tw_row_gap_64
+    , xl_tw_row_gap_px
+    , xl_tw_grid_flow_row
+    , xl_tw_grid_flow_col
+    , xl_tw_grid_flow_row_dense
+    , xl_tw_grid_flow_col_dense
+    , xl_tw_grid_cols_1
+    , xl_tw_grid_cols_2
+    , xl_tw_grid_cols_3
+    , xl_tw_grid_cols_4
+    , xl_tw_grid_cols_5
+    , xl_tw_grid_cols_6
+    , xl_tw_grid_cols_7
+    , xl_tw_grid_cols_8
+    , xl_tw_grid_cols_9
+    , xl_tw_grid_cols_10
+    , xl_tw_grid_cols_11
+    , xl_tw_grid_cols_12
+    , xl_tw_grid_cols_none
+    , xl_tw_col_auto
+    , xl_tw_col_span_1
+    , xl_tw_col_span_2
+    , xl_tw_col_span_3
+    , xl_tw_col_span_4
+    , xl_tw_col_span_5
+    , xl_tw_col_span_6
+    , xl_tw_col_span_7
+    , xl_tw_col_span_8
+    , xl_tw_col_span_9
+    , xl_tw_col_span_10
+    , xl_tw_col_span_11
+    , xl_tw_col_span_12
+    , xl_tw_col_start_1
+    , xl_tw_col_start_2
+    , xl_tw_col_start_3
+    , xl_tw_col_start_4
+    , xl_tw_col_start_5
+    , xl_tw_col_start_6
+    , xl_tw_col_start_7
+    , xl_tw_col_start_8
+    , xl_tw_col_start_9
+    , xl_tw_col_start_10
+    , xl_tw_col_start_11
+    , xl_tw_col_start_12
+    , xl_tw_col_start_13
+    , xl_tw_col_start_auto
+    , xl_tw_col_end_1
+    , xl_tw_col_end_2
+    , xl_tw_col_end_3
+    , xl_tw_col_end_4
+    , xl_tw_col_end_5
+    , xl_tw_col_end_6
+    , xl_tw_col_end_7
+    , xl_tw_col_end_8
+    , xl_tw_col_end_9
+    , xl_tw_col_end_10
+    , xl_tw_col_end_11
+    , xl_tw_col_end_12
+    , xl_tw_col_end_13
+    , xl_tw_col_end_auto
+    , xl_tw_grid_rows_1
+    , xl_tw_grid_rows_2
+    , xl_tw_grid_rows_3
+    , xl_tw_grid_rows_4
+    , xl_tw_grid_rows_5
+    , xl_tw_grid_rows_6
+    , xl_tw_grid_rows_none
+    , xl_tw_row_auto
+    , xl_tw_row_span_1
+    , xl_tw_row_span_2
+    , xl_tw_row_span_3
+    , xl_tw_row_span_4
+    , xl_tw_row_span_5
+    , xl_tw_row_span_6
+    , xl_tw_row_start_1
+    , xl_tw_row_start_2
+    , xl_tw_row_start_3
+    , xl_tw_row_start_4
+    , xl_tw_row_start_5
+    , xl_tw_row_start_6
+    , xl_tw_row_start_7
+    , xl_tw_row_start_auto
+    , xl_tw_row_end_1
+    , xl_tw_row_end_2
+    , xl_tw_row_end_3
+    , xl_tw_row_end_4
+    , xl_tw_row_end_5
+    , xl_tw_row_end_6
+    , xl_tw_row_end_7
+    , xl_tw_row_end_auto
+    , xl_tw_transform
+    , xl_tw_transform_none
+    , xl_tw_origin_center
+    , xl_tw_origin_top
+    , xl_tw_origin_top_right
+    , xl_tw_origin_right
+    , xl_tw_origin_bottom_right
+    , xl_tw_origin_bottom
+    , xl_tw_origin_bottom_left
+    , xl_tw_origin_left
+    , xl_tw_origin_top_left
+    , xl_tw_scale_0
+    , xl_tw_scale_50
+    , xl_tw_scale_75
+    , xl_tw_scale_90
+    , xl_tw_scale_95
+    , xl_tw_scale_100
+    , xl_tw_scale_105
+    , xl_tw_scale_110
+    , xl_tw_scale_125
+    , xl_tw_scale_150
+    , xl_tw_scale_x_0
+    , xl_tw_scale_x_50
+    , xl_tw_scale_x_75
+    , xl_tw_scale_x_90
+    , xl_tw_scale_x_95
+    , xl_tw_scale_x_100
+    , xl_tw_scale_x_105
+    , xl_tw_scale_x_110
+    , xl_tw_scale_x_125
+    , xl_tw_scale_x_150
+    , xl_tw_scale_y_0
+    , xl_tw_scale_y_50
+    , xl_tw_scale_y_75
+    , xl_tw_scale_y_90
+    , xl_tw_scale_y_95
+    , xl_tw_scale_y_100
+    , xl_tw_scale_y_105
+    , xl_tw_scale_y_110
+    , xl_tw_scale_y_125
+    , xl_tw_scale_y_150
+    , xl_hover_tw_scale_0
+    , xl_hover_tw_scale_50
+    , xl_hover_tw_scale_75
+    , xl_hover_tw_scale_90
+    , xl_hover_tw_scale_95
+    , xl_hover_tw_scale_100
+    , xl_hover_tw_scale_105
+    , xl_hover_tw_scale_110
+    , xl_hover_tw_scale_125
+    , xl_hover_tw_scale_150
+    , xl_hover_tw_scale_x_0
+    , xl_hover_tw_scale_x_50
+    , xl_hover_tw_scale_x_75
+    , xl_hover_tw_scale_x_90
+    , xl_hover_tw_scale_x_95
+    , xl_hover_tw_scale_x_100
+    , xl_hover_tw_scale_x_105
+    , xl_hover_tw_scale_x_110
+    , xl_hover_tw_scale_x_125
+    , xl_hover_tw_scale_x_150
+    , xl_hover_tw_scale_y_0
+    , xl_hover_tw_scale_y_50
+    , xl_hover_tw_scale_y_75
+    , xl_hover_tw_scale_y_90
+    , xl_hover_tw_scale_y_95
+    , xl_hover_tw_scale_y_100
+    , xl_hover_tw_scale_y_105
+    , xl_hover_tw_scale_y_110
+    , xl_hover_tw_scale_y_125
+    , xl_hover_tw_scale_y_150
+    , xl_focus_tw_scale_0
+    , xl_focus_tw_scale_50
+    , xl_focus_tw_scale_75
+    , xl_focus_tw_scale_90
+    , xl_focus_tw_scale_95
+    , xl_focus_tw_scale_100
+    , xl_focus_tw_scale_105
+    , xl_focus_tw_scale_110
+    , xl_focus_tw_scale_125
+    , xl_focus_tw_scale_150
+    , xl_focus_tw_scale_x_0
+    , xl_focus_tw_scale_x_50
+    , xl_focus_tw_scale_x_75
+    , xl_focus_tw_scale_x_90
+    , xl_focus_tw_scale_x_95
+    , xl_focus_tw_scale_x_100
+    , xl_focus_tw_scale_x_105
+    , xl_focus_tw_scale_x_110
+    , xl_focus_tw_scale_x_125
+    , xl_focus_tw_scale_x_150
+    , xl_focus_tw_scale_y_0
+    , xl_focus_tw_scale_y_50
+    , xl_focus_tw_scale_y_75
+    , xl_focus_tw_scale_y_90
+    , xl_focus_tw_scale_y_95
+    , xl_focus_tw_scale_y_100
+    , xl_focus_tw_scale_y_105
+    , xl_focus_tw_scale_y_110
+    , xl_focus_tw_scale_y_125
+    , xl_focus_tw_scale_y_150
+    , xl_tw_rotate_0
+    , xl_tw_rotate_45
+    , xl_tw_rotate_90
+    , xl_tw_rotate_180
+    , xl_tw_neg_rotate_180
+    , xl_tw_neg_rotate_90
+    , xl_tw_neg_rotate_45
+    , xl_hover_tw_rotate_0
+    , xl_hover_tw_rotate_45
+    , xl_hover_tw_rotate_90
+    , xl_hover_tw_rotate_180
+    , xl_hover_tw_neg_rotate_180
+    , xl_hover_tw_neg_rotate_90
+    , xl_hover_tw_neg_rotate_45
+    , xl_focus_tw_rotate_0
+    , xl_focus_tw_rotate_45
+    , xl_focus_tw_rotate_90
+    , xl_focus_tw_rotate_180
+    , xl_focus_tw_neg_rotate_180
+    , xl_focus_tw_neg_rotate_90
+    , xl_focus_tw_neg_rotate_45
+    , xl_tw_translate_x_0
+    , xl_tw_translate_x_1
+    , xl_tw_translate_x_2
+    , xl_tw_translate_x_3
+    , xl_tw_translate_x_4
+    , xl_tw_translate_x_5
+    , xl_tw_translate_x_6
+    , xl_tw_translate_x_8
+    , xl_tw_translate_x_10
+    , xl_tw_translate_x_12
+    , xl_tw_translate_x_16
+    , xl_tw_translate_x_20
+    , xl_tw_translate_x_24
+    , xl_tw_translate_x_32
+    , xl_tw_translate_x_40
+    , xl_tw_translate_x_48
+    , xl_tw_translate_x_56
+    , xl_tw_translate_x_64
+    , xl_tw_translate_x_px
+    , xl_tw_neg_translate_x_1
+    , xl_tw_neg_translate_x_2
+    , xl_tw_neg_translate_x_3
+    , xl_tw_neg_translate_x_4
+    , xl_tw_neg_translate_x_5
+    , xl_tw_neg_translate_x_6
+    , xl_tw_neg_translate_x_8
+    , xl_tw_neg_translate_x_10
+    , xl_tw_neg_translate_x_12
+    , xl_tw_neg_translate_x_16
+    , xl_tw_neg_translate_x_20
+    , xl_tw_neg_translate_x_24
+    , xl_tw_neg_translate_x_32
+    , xl_tw_neg_translate_x_40
+    , xl_tw_neg_translate_x_48
+    , xl_tw_neg_translate_x_56
+    , xl_tw_neg_translate_x_64
+    , xl_tw_neg_translate_x_px
+    , xl_tw_neg_translate_x_full
+    , xl_tw_neg_translate_x_1over2
+    , xl_tw_translate_x_1over2
+    , xl_tw_translate_x_full
+    , xl_tw_translate_y_0
+    , xl_tw_translate_y_1
+    , xl_tw_translate_y_2
+    , xl_tw_translate_y_3
+    , xl_tw_translate_y_4
+    , xl_tw_translate_y_5
+    , xl_tw_translate_y_6
+    , xl_tw_translate_y_8
+    , xl_tw_translate_y_10
+    , xl_tw_translate_y_12
+    , xl_tw_translate_y_16
+    , xl_tw_translate_y_20
+    , xl_tw_translate_y_24
+    , xl_tw_translate_y_32
+    , xl_tw_translate_y_40
+    , xl_tw_translate_y_48
+    , xl_tw_translate_y_56
+    , xl_tw_translate_y_64
+    , xl_tw_translate_y_px
+    , xl_tw_neg_translate_y_1
+    , xl_tw_neg_translate_y_2
+    , xl_tw_neg_translate_y_3
+    , xl_tw_neg_translate_y_4
+    , xl_tw_neg_translate_y_5
+    , xl_tw_neg_translate_y_6
+    , xl_tw_neg_translate_y_8
+    , xl_tw_neg_translate_y_10
+    , xl_tw_neg_translate_y_12
+    , xl_tw_neg_translate_y_16
+    , xl_tw_neg_translate_y_20
+    , xl_tw_neg_translate_y_24
+    , xl_tw_neg_translate_y_32
+    , xl_tw_neg_translate_y_40
+    , xl_tw_neg_translate_y_48
+    , xl_tw_neg_translate_y_56
+    , xl_tw_neg_translate_y_64
+    , xl_tw_neg_translate_y_px
+    , xl_tw_neg_translate_y_full
+    , xl_tw_neg_translate_y_1over2
+    , xl_tw_translate_y_1over2
+    , xl_tw_translate_y_full
+    , xl_hover_tw_translate_x_0
+    , xl_hover_tw_translate_x_1
+    , xl_hover_tw_translate_x_2
+    , xl_hover_tw_translate_x_3
+    , xl_hover_tw_translate_x_4
+    , xl_hover_tw_translate_x_5
+    , xl_hover_tw_translate_x_6
+    , xl_hover_tw_translate_x_8
+    , xl_hover_tw_translate_x_10
+    , xl_hover_tw_translate_x_12
+    , xl_hover_tw_translate_x_16
+    , xl_hover_tw_translate_x_20
+    , xl_hover_tw_translate_x_24
+    , xl_hover_tw_translate_x_32
+    , xl_hover_tw_translate_x_40
+    , xl_hover_tw_translate_x_48
+    , xl_hover_tw_translate_x_56
+    , xl_hover_tw_translate_x_64
+    , xl_hover_tw_translate_x_px
+    , xl_hover_tw_neg_translate_x_1
+    , xl_hover_tw_neg_translate_x_2
+    , xl_hover_tw_neg_translate_x_3
+    , xl_hover_tw_neg_translate_x_4
+    , xl_hover_tw_neg_translate_x_5
+    , xl_hover_tw_neg_translate_x_6
+    , xl_hover_tw_neg_translate_x_8
+    , xl_hover_tw_neg_translate_x_10
+    , xl_hover_tw_neg_translate_x_12
+    , xl_hover_tw_neg_translate_x_16
+    , xl_hover_tw_neg_translate_x_20
+    , xl_hover_tw_neg_translate_x_24
+    , xl_hover_tw_neg_translate_x_32
+    , xl_hover_tw_neg_translate_x_40
+    , xl_hover_tw_neg_translate_x_48
+    , xl_hover_tw_neg_translate_x_56
+    , xl_hover_tw_neg_translate_x_64
+    , xl_hover_tw_neg_translate_x_px
+    , xl_hover_tw_neg_translate_x_full
+    , xl_hover_tw_neg_translate_x_1over2
+    , xl_hover_tw_translate_x_1over2
+    , xl_hover_tw_translate_x_full
+    , xl_hover_tw_translate_y_0
+    , xl_hover_tw_translate_y_1
+    , xl_hover_tw_translate_y_2
+    , xl_hover_tw_translate_y_3
+    , xl_hover_tw_translate_y_4
+    , xl_hover_tw_translate_y_5
+    , xl_hover_tw_translate_y_6
+    , xl_hover_tw_translate_y_8
+    , xl_hover_tw_translate_y_10
+    , xl_hover_tw_translate_y_12
+    , xl_hover_tw_translate_y_16
+    , xl_hover_tw_translate_y_20
+    , xl_hover_tw_translate_y_24
+    , xl_hover_tw_translate_y_32
+    , xl_hover_tw_translate_y_40
+    , xl_hover_tw_translate_y_48
+    , xl_hover_tw_translate_y_56
+    , xl_hover_tw_translate_y_64
+    , xl_hover_tw_translate_y_px
+    , xl_hover_tw_neg_translate_y_1
+    , xl_hover_tw_neg_translate_y_2
+    , xl_hover_tw_neg_translate_y_3
+    , xl_hover_tw_neg_translate_y_4
+    , xl_hover_tw_neg_translate_y_5
+    , xl_hover_tw_neg_translate_y_6
+    , xl_hover_tw_neg_translate_y_8
+    , xl_hover_tw_neg_translate_y_10
+    , xl_hover_tw_neg_translate_y_12
+    , xl_hover_tw_neg_translate_y_16
+    , xl_hover_tw_neg_translate_y_20
+    , xl_hover_tw_neg_translate_y_24
+    , xl_hover_tw_neg_translate_y_32
+    , xl_hover_tw_neg_translate_y_40
+    , xl_hover_tw_neg_translate_y_48
+    , xl_hover_tw_neg_translate_y_56
+    , xl_hover_tw_neg_translate_y_64
+    , xl_hover_tw_neg_translate_y_px
+    , xl_hover_tw_neg_translate_y_full
+    , xl_hover_tw_neg_translate_y_1over2
+    , xl_hover_tw_translate_y_1over2
+    , xl_hover_tw_translate_y_full
+    , xl_focus_tw_translate_x_0
+    , xl_focus_tw_translate_x_1
+    , xl_focus_tw_translate_x_2
+    , xl_focus_tw_translate_x_3
+    , xl_focus_tw_translate_x_4
+    , xl_focus_tw_translate_x_5
+    , xl_focus_tw_translate_x_6
+    , xl_focus_tw_translate_x_8
+    , xl_focus_tw_translate_x_10
+    , xl_focus_tw_translate_x_12
+    , xl_focus_tw_translate_x_16
+    , xl_focus_tw_translate_x_20
+    , xl_focus_tw_translate_x_24
+    , xl_focus_tw_translate_x_32
+    , xl_focus_tw_translate_x_40
+    , xl_focus_tw_translate_x_48
+    , xl_focus_tw_translate_x_56
+    , xl_focus_tw_translate_x_64
+    , xl_focus_tw_translate_x_px
+    , xl_focus_tw_neg_translate_x_1
+    , xl_focus_tw_neg_translate_x_2
+    , xl_focus_tw_neg_translate_x_3
+    , xl_focus_tw_neg_translate_x_4
+    , xl_focus_tw_neg_translate_x_5
+    , xl_focus_tw_neg_translate_x_6
+    , xl_focus_tw_neg_translate_x_8
+    , xl_focus_tw_neg_translate_x_10
+    , xl_focus_tw_neg_translate_x_12
+    , xl_focus_tw_neg_translate_x_16
+    , xl_focus_tw_neg_translate_x_20
+    , xl_focus_tw_neg_translate_x_24
+    , xl_focus_tw_neg_translate_x_32
+    , xl_focus_tw_neg_translate_x_40
+    , xl_focus_tw_neg_translate_x_48
+    , xl_focus_tw_neg_translate_x_56
+    , xl_focus_tw_neg_translate_x_64
+    , xl_focus_tw_neg_translate_x_px
+    , xl_focus_tw_neg_translate_x_full
+    , xl_focus_tw_neg_translate_x_1over2
+    , xl_focus_tw_translate_x_1over2
+    , xl_focus_tw_translate_x_full
+    , xl_focus_tw_translate_y_0
+    , xl_focus_tw_translate_y_1
+    , xl_focus_tw_translate_y_2
+    , xl_focus_tw_translate_y_3
+    , xl_focus_tw_translate_y_4
+    , xl_focus_tw_translate_y_5
+    , xl_focus_tw_translate_y_6
+    , xl_focus_tw_translate_y_8
+    , xl_focus_tw_translate_y_10
+    , xl_focus_tw_translate_y_12
+    , xl_focus_tw_translate_y_16
+    , xl_focus_tw_translate_y_20
+    , xl_focus_tw_translate_y_24
+    , xl_focus_tw_translate_y_32
+    , xl_focus_tw_translate_y_40
+    , xl_focus_tw_translate_y_48
+    , xl_focus_tw_translate_y_56
+    , xl_focus_tw_translate_y_64
+    , xl_focus_tw_translate_y_px
+    , xl_focus_tw_neg_translate_y_1
+    , xl_focus_tw_neg_translate_y_2
+    , xl_focus_tw_neg_translate_y_3
+    , xl_focus_tw_neg_translate_y_4
+    , xl_focus_tw_neg_translate_y_5
+    , xl_focus_tw_neg_translate_y_6
+    , xl_focus_tw_neg_translate_y_8
+    , xl_focus_tw_neg_translate_y_10
+    , xl_focus_tw_neg_translate_y_12
+    , xl_focus_tw_neg_translate_y_16
+    , xl_focus_tw_neg_translate_y_20
+    , xl_focus_tw_neg_translate_y_24
+    , xl_focus_tw_neg_translate_y_32
+    , xl_focus_tw_neg_translate_y_40
+    , xl_focus_tw_neg_translate_y_48
+    , xl_focus_tw_neg_translate_y_56
+    , xl_focus_tw_neg_translate_y_64
+    , xl_focus_tw_neg_translate_y_px
+    , xl_focus_tw_neg_translate_y_full
+    , xl_focus_tw_neg_translate_y_1over2
+    , xl_focus_tw_translate_y_1over2
+    , xl_focus_tw_translate_y_full
+    , xl_tw_skew_x_0
+    , xl_tw_skew_x_3
+    , xl_tw_skew_x_6
+    , xl_tw_skew_x_12
+    , xl_tw_neg_skew_x_12
+    , xl_tw_neg_skew_x_6
+    , xl_tw_neg_skew_x_3
+    , xl_tw_skew_y_0
+    , xl_tw_skew_y_3
+    , xl_tw_skew_y_6
+    , xl_tw_skew_y_12
+    , xl_tw_neg_skew_y_12
+    , xl_tw_neg_skew_y_6
+    , xl_tw_neg_skew_y_3
+    , xl_hover_tw_skew_x_0
+    , xl_hover_tw_skew_x_3
+    , xl_hover_tw_skew_x_6
+    , xl_hover_tw_skew_x_12
+    , xl_hover_tw_neg_skew_x_12
+    , xl_hover_tw_neg_skew_x_6
+    , xl_hover_tw_neg_skew_x_3
+    , xl_hover_tw_skew_y_0
+    , xl_hover_tw_skew_y_3
+    , xl_hover_tw_skew_y_6
+    , xl_hover_tw_skew_y_12
+    , xl_hover_tw_neg_skew_y_12
+    , xl_hover_tw_neg_skew_y_6
+    , xl_hover_tw_neg_skew_y_3
+    , xl_focus_tw_skew_x_0
+    , xl_focus_tw_skew_x_3
+    , xl_focus_tw_skew_x_6
+    , xl_focus_tw_skew_x_12
+    , xl_focus_tw_neg_skew_x_12
+    , xl_focus_tw_neg_skew_x_6
+    , xl_focus_tw_neg_skew_x_3
+    , xl_focus_tw_skew_y_0
+    , xl_focus_tw_skew_y_3
+    , xl_focus_tw_skew_y_6
+    , xl_focus_tw_skew_y_12
+    , xl_focus_tw_neg_skew_y_12
+    , xl_focus_tw_neg_skew_y_6
+    , xl_focus_tw_neg_skew_y_3
+    , xl_tw_transition_none
+    , xl_tw_transition_all
+    , xl_tw_transition
+    , xl_tw_transition_colors
+    , xl_tw_transition_opacity
+    , xl_tw_transition_shadow
+    , xl_tw_transition_transform
+    , xl_tw_ease_linear
+    , xl_tw_ease_in
+    , xl_tw_ease_out
+    , xl_tw_ease_in_out
+    , xl_tw_duration_75
+    , xl_tw_duration_100
+    , xl_tw_duration_150
+    , xl_tw_duration_200
+    , xl_tw_duration_300
+    , xl_tw_duration_500
+    , xl_tw_duration_700
+    , xl_tw_duration_1000
     , classList
     )
 
@@ -12463,6 +15553,11 @@ tw_rounded =
     A.class "tw-rounded"
 
 
+tw_rounded_md : Html.Attribute msg
+tw_rounded_md =
+    A.class "tw-rounded-md"
+
+
 tw_rounded_lg : Html.Attribute msg
 tw_rounded_lg =
     A.class "tw-rounded-lg"
@@ -12531,6 +15626,26 @@ tw_rounded_b =
 tw_rounded_l : Html.Attribute msg
 tw_rounded_l =
     A.class "tw-rounded-l"
+
+
+tw_rounded_t_md : Html.Attribute msg
+tw_rounded_t_md =
+    A.class "tw-rounded-t-md"
+
+
+tw_rounded_r_md : Html.Attribute msg
+tw_rounded_r_md =
+    A.class "tw-rounded-r-md"
+
+
+tw_rounded_b_md : Html.Attribute msg
+tw_rounded_b_md =
+    A.class "tw-rounded-b-md"
+
+
+tw_rounded_l_md : Html.Attribute msg
+tw_rounded_l_md =
+    A.class "tw-rounded-l-md"
 
 
 tw_rounded_t_lg : Html.Attribute msg
@@ -12631,6 +15746,26 @@ tw_rounded_br =
 tw_rounded_bl : Html.Attribute msg
 tw_rounded_bl =
     A.class "tw-rounded-bl"
+
+
+tw_rounded_tl_md : Html.Attribute msg
+tw_rounded_tl_md =
+    A.class "tw-rounded-tl-md"
+
+
+tw_rounded_tr_md : Html.Attribute msg
+tw_rounded_tr_md =
+    A.class "tw-rounded-tr-md"
+
+
+tw_rounded_br_md : Html.Attribute msg
+tw_rounded_br_md =
+    A.class "tw-rounded-br-md"
+
+
+tw_rounded_bl_md : Html.Attribute msg
+tw_rounded_bl_md =
+    A.class "tw-rounded-bl-md"
 
 
 tw_rounded_tl_lg : Html.Attribute msg
@@ -12823,6 +15958,16 @@ tw_border_l =
     A.class "tw-border-l"
 
 
+tw_box_border : Html.Attribute msg
+tw_box_border =
+    A.class "tw-box-border"
+
+
+tw_box_content : Html.Attribute msg
+tw_box_content =
+    A.class "tw-box-content"
+
+
 tw_cursor_auto : Html.Attribute msg
 tw_cursor_auto =
     A.class "tw-cursor-auto"
@@ -12883,19 +16028,54 @@ tw_inline_flex =
     A.class "tw-inline-flex"
 
 
+tw_grid : Html.Attribute msg
+tw_grid =
+    A.class "tw-grid"
+
+
 tw_table : Html.Attribute msg
 tw_table =
     A.class "tw-table"
 
 
-tw_table_row : Html.Attribute msg
-tw_table_row =
-    A.class "tw-table-row"
+tw_table_caption : Html.Attribute msg
+tw_table_caption =
+    A.class "tw-table-caption"
 
 
 tw_table_cell : Html.Attribute msg
 tw_table_cell =
     A.class "tw-table-cell"
+
+
+tw_table_column : Html.Attribute msg
+tw_table_column =
+    A.class "tw-table-column"
+
+
+tw_table_column_group : Html.Attribute msg
+tw_table_column_group =
+    A.class "tw-table-column-group"
+
+
+tw_table_footer_group : Html.Attribute msg
+tw_table_footer_group =
+    A.class "tw-table-footer-group"
+
+
+tw_table_header_group : Html.Attribute msg
+tw_table_header_group =
+    A.class "tw-table-header-group"
+
+
+tw_table_row_group : Html.Attribute msg
+tw_table_row_group =
+    A.class "tw-table-row-group"
+
+
+tw_table_row : Html.Attribute msg
+tw_table_row =
+    A.class "tw-table-row"
 
 
 tw_hidden : Html.Attribute msg
@@ -13011,6 +16191,11 @@ tw_justify_between =
 tw_justify_around : Html.Attribute msg
 tw_justify_around =
     A.class "tw-justify-around"
+
+
+tw_justify_evenly : Html.Attribute msg
+tw_justify_evenly =
+    A.class "tw-justify-evenly"
 
 
 tw_content_center : Html.Attribute msg
@@ -13171,6 +16356,21 @@ tw_float_none =
 tw_clearfix_after : Html.Attribute msg
 tw_clearfix_after =
     A.class "tw-clearfix:after"
+
+
+tw_clear_left : Html.Attribute msg
+tw_clear_left =
+    A.class "tw-clear-left"
+
+
+tw_clear_right : Html.Attribute msg
+tw_clear_right =
+    A.class "tw-clear-right"
+
+
+tw_clear_both : Html.Attribute msg
+tw_clear_both =
+    A.class "tw-clear-both"
 
 
 tw_font_sans : Html.Attribute msg
@@ -13431,6 +16631,46 @@ tw_h_full =
 tw_h_screen : Html.Attribute msg
 tw_h_screen =
     A.class "tw-h-screen"
+
+
+tw_leading_3 : Html.Attribute msg
+tw_leading_3 =
+    A.class "tw-leading-3"
+
+
+tw_leading_4 : Html.Attribute msg
+tw_leading_4 =
+    A.class "tw-leading-4"
+
+
+tw_leading_5 : Html.Attribute msg
+tw_leading_5 =
+    A.class "tw-leading-5"
+
+
+tw_leading_6 : Html.Attribute msg
+tw_leading_6 =
+    A.class "tw-leading-6"
+
+
+tw_leading_7 : Html.Attribute msg
+tw_leading_7 =
+    A.class "tw-leading-7"
+
+
+tw_leading_8 : Html.Attribute msg
+tw_leading_8 =
+    A.class "tw-leading-8"
+
+
+tw_leading_9 : Html.Attribute msg
+tw_leading_9 =
+    A.class "tw-leading-9"
+
+
+tw_leading_10 : Html.Attribute msg
+tw_leading_10 =
+    A.class "tw-leading-10"
 
 
 tw_leading_none : Html.Attribute msg
@@ -14828,6 +18068,11 @@ tw_max_h_screen =
     A.class "tw-max-h-screen"
 
 
+tw_max_w_none : Html.Attribute msg
+tw_max_w_none =
+    A.class "tw-max-w-none"
+
+
 tw_max_w_xs : Html.Attribute msg
 tw_max_w_xs =
     A.class "tw-max-w-xs"
@@ -14881,6 +18126,26 @@ tw_max_w_6xl =
 tw_max_w_full : Html.Attribute msg
 tw_max_w_full =
     A.class "tw-max-w-full"
+
+
+tw_max_w_screen_sm : Html.Attribute msg
+tw_max_w_screen_sm =
+    A.class "tw-max-w-screen-sm"
+
+
+tw_max_w_screen_md : Html.Attribute msg
+tw_max_w_screen_md =
+    A.class "tw-max-w-screen-md"
+
+
+tw_max_w_screen_lg : Html.Attribute msg
+tw_max_w_screen_lg =
+    A.class "tw-max-w-screen-lg"
+
+
+tw_max_w_screen_xl : Html.Attribute msg
+tw_max_w_screen_xl =
+    A.class "tw-max-w-screen-xl"
 
 
 tw_min_h_0 : Html.Attribute msg
@@ -16853,6 +20118,16 @@ tw_resize =
     A.class "tw-resize"
 
 
+tw_shadow_xs : Html.Attribute msg
+tw_shadow_xs =
+    A.class "tw-shadow-xs"
+
+
+tw_shadow_sm : Html.Attribute msg
+tw_shadow_sm =
+    A.class "tw-shadow-sm"
+
+
 tw_shadow : Html.Attribute msg
 tw_shadow =
     A.class "tw-shadow"
@@ -16893,6 +20168,16 @@ tw_shadow_none =
     A.class "tw-shadow-none"
 
 
+hover_tw_shadow_xs : Html.Attribute msg
+hover_tw_shadow_xs =
+    A.class "hover:tw-shadow-xs"
+
+
+hover_tw_shadow_sm : Html.Attribute msg
+hover_tw_shadow_sm =
+    A.class "hover:tw-shadow-sm"
+
+
 hover_tw_shadow : Html.Attribute msg
 hover_tw_shadow =
     A.class "hover:tw-shadow"
@@ -16931,6 +20216,16 @@ hover_tw_shadow_outline =
 hover_tw_shadow_none : Html.Attribute msg
 hover_tw_shadow_none =
     A.class "hover:tw-shadow-none"
+
+
+focus_tw_shadow_xs : Html.Attribute msg
+focus_tw_shadow_xs =
+    A.class "focus:tw-shadow-xs"
+
+
+focus_tw_shadow_sm : Html.Attribute msg
+focus_tw_shadow_sm =
+    A.class "focus:tw-shadow-sm"
 
 
 focus_tw_shadow : Html.Attribute msg
@@ -16981,6 +20276,21 @@ tw_fill_current =
 tw_stroke_current : Html.Attribute msg
 tw_stroke_current =
     A.class "tw-stroke-current"
+
+
+tw_stroke_0 : Html.Attribute msg
+tw_stroke_0 =
+    A.class "tw-stroke-0"
+
+
+tw_stroke_1 : Html.Attribute msg
+tw_stroke_1 =
+    A.class "tw-stroke-1"
+
+
+tw_stroke_2 : Html.Attribute msg
+tw_stroke_2 =
+    A.class "tw-stroke-2"
 
 
 tw_table_auto : Html.Attribute msg
@@ -18951,6 +22261,2876 @@ tw_z_50 =
 tw_z_auto : Html.Attribute msg
 tw_z_auto =
     A.class "tw-z-auto"
+
+
+tw_gap_0 : Html.Attribute msg
+tw_gap_0 =
+    A.class "tw-gap-0"
+
+
+tw_gap_1 : Html.Attribute msg
+tw_gap_1 =
+    A.class "tw-gap-1"
+
+
+tw_gap_2 : Html.Attribute msg
+tw_gap_2 =
+    A.class "tw-gap-2"
+
+
+tw_gap_3 : Html.Attribute msg
+tw_gap_3 =
+    A.class "tw-gap-3"
+
+
+tw_gap_4 : Html.Attribute msg
+tw_gap_4 =
+    A.class "tw-gap-4"
+
+
+tw_gap_5 : Html.Attribute msg
+tw_gap_5 =
+    A.class "tw-gap-5"
+
+
+tw_gap_6 : Html.Attribute msg
+tw_gap_6 =
+    A.class "tw-gap-6"
+
+
+tw_gap_8 : Html.Attribute msg
+tw_gap_8 =
+    A.class "tw-gap-8"
+
+
+tw_gap_10 : Html.Attribute msg
+tw_gap_10 =
+    A.class "tw-gap-10"
+
+
+tw_gap_12 : Html.Attribute msg
+tw_gap_12 =
+    A.class "tw-gap-12"
+
+
+tw_gap_16 : Html.Attribute msg
+tw_gap_16 =
+    A.class "tw-gap-16"
+
+
+tw_gap_20 : Html.Attribute msg
+tw_gap_20 =
+    A.class "tw-gap-20"
+
+
+tw_gap_24 : Html.Attribute msg
+tw_gap_24 =
+    A.class "tw-gap-24"
+
+
+tw_gap_32 : Html.Attribute msg
+tw_gap_32 =
+    A.class "tw-gap-32"
+
+
+tw_gap_40 : Html.Attribute msg
+tw_gap_40 =
+    A.class "tw-gap-40"
+
+
+tw_gap_48 : Html.Attribute msg
+tw_gap_48 =
+    A.class "tw-gap-48"
+
+
+tw_gap_56 : Html.Attribute msg
+tw_gap_56 =
+    A.class "tw-gap-56"
+
+
+tw_gap_64 : Html.Attribute msg
+tw_gap_64 =
+    A.class "tw-gap-64"
+
+
+tw_gap_px : Html.Attribute msg
+tw_gap_px =
+    A.class "tw-gap-px"
+
+
+tw_col_gap_0 : Html.Attribute msg
+tw_col_gap_0 =
+    A.class "tw-col-gap-0"
+
+
+tw_col_gap_1 : Html.Attribute msg
+tw_col_gap_1 =
+    A.class "tw-col-gap-1"
+
+
+tw_col_gap_2 : Html.Attribute msg
+tw_col_gap_2 =
+    A.class "tw-col-gap-2"
+
+
+tw_col_gap_3 : Html.Attribute msg
+tw_col_gap_3 =
+    A.class "tw-col-gap-3"
+
+
+tw_col_gap_4 : Html.Attribute msg
+tw_col_gap_4 =
+    A.class "tw-col-gap-4"
+
+
+tw_col_gap_5 : Html.Attribute msg
+tw_col_gap_5 =
+    A.class "tw-col-gap-5"
+
+
+tw_col_gap_6 : Html.Attribute msg
+tw_col_gap_6 =
+    A.class "tw-col-gap-6"
+
+
+tw_col_gap_8 : Html.Attribute msg
+tw_col_gap_8 =
+    A.class "tw-col-gap-8"
+
+
+tw_col_gap_10 : Html.Attribute msg
+tw_col_gap_10 =
+    A.class "tw-col-gap-10"
+
+
+tw_col_gap_12 : Html.Attribute msg
+tw_col_gap_12 =
+    A.class "tw-col-gap-12"
+
+
+tw_col_gap_16 : Html.Attribute msg
+tw_col_gap_16 =
+    A.class "tw-col-gap-16"
+
+
+tw_col_gap_20 : Html.Attribute msg
+tw_col_gap_20 =
+    A.class "tw-col-gap-20"
+
+
+tw_col_gap_24 : Html.Attribute msg
+tw_col_gap_24 =
+    A.class "tw-col-gap-24"
+
+
+tw_col_gap_32 : Html.Attribute msg
+tw_col_gap_32 =
+    A.class "tw-col-gap-32"
+
+
+tw_col_gap_40 : Html.Attribute msg
+tw_col_gap_40 =
+    A.class "tw-col-gap-40"
+
+
+tw_col_gap_48 : Html.Attribute msg
+tw_col_gap_48 =
+    A.class "tw-col-gap-48"
+
+
+tw_col_gap_56 : Html.Attribute msg
+tw_col_gap_56 =
+    A.class "tw-col-gap-56"
+
+
+tw_col_gap_64 : Html.Attribute msg
+tw_col_gap_64 =
+    A.class "tw-col-gap-64"
+
+
+tw_col_gap_px : Html.Attribute msg
+tw_col_gap_px =
+    A.class "tw-col-gap-px"
+
+
+tw_row_gap_0 : Html.Attribute msg
+tw_row_gap_0 =
+    A.class "tw-row-gap-0"
+
+
+tw_row_gap_1 : Html.Attribute msg
+tw_row_gap_1 =
+    A.class "tw-row-gap-1"
+
+
+tw_row_gap_2 : Html.Attribute msg
+tw_row_gap_2 =
+    A.class "tw-row-gap-2"
+
+
+tw_row_gap_3 : Html.Attribute msg
+tw_row_gap_3 =
+    A.class "tw-row-gap-3"
+
+
+tw_row_gap_4 : Html.Attribute msg
+tw_row_gap_4 =
+    A.class "tw-row-gap-4"
+
+
+tw_row_gap_5 : Html.Attribute msg
+tw_row_gap_5 =
+    A.class "tw-row-gap-5"
+
+
+tw_row_gap_6 : Html.Attribute msg
+tw_row_gap_6 =
+    A.class "tw-row-gap-6"
+
+
+tw_row_gap_8 : Html.Attribute msg
+tw_row_gap_8 =
+    A.class "tw-row-gap-8"
+
+
+tw_row_gap_10 : Html.Attribute msg
+tw_row_gap_10 =
+    A.class "tw-row-gap-10"
+
+
+tw_row_gap_12 : Html.Attribute msg
+tw_row_gap_12 =
+    A.class "tw-row-gap-12"
+
+
+tw_row_gap_16 : Html.Attribute msg
+tw_row_gap_16 =
+    A.class "tw-row-gap-16"
+
+
+tw_row_gap_20 : Html.Attribute msg
+tw_row_gap_20 =
+    A.class "tw-row-gap-20"
+
+
+tw_row_gap_24 : Html.Attribute msg
+tw_row_gap_24 =
+    A.class "tw-row-gap-24"
+
+
+tw_row_gap_32 : Html.Attribute msg
+tw_row_gap_32 =
+    A.class "tw-row-gap-32"
+
+
+tw_row_gap_40 : Html.Attribute msg
+tw_row_gap_40 =
+    A.class "tw-row-gap-40"
+
+
+tw_row_gap_48 : Html.Attribute msg
+tw_row_gap_48 =
+    A.class "tw-row-gap-48"
+
+
+tw_row_gap_56 : Html.Attribute msg
+tw_row_gap_56 =
+    A.class "tw-row-gap-56"
+
+
+tw_row_gap_64 : Html.Attribute msg
+tw_row_gap_64 =
+    A.class "tw-row-gap-64"
+
+
+tw_row_gap_px : Html.Attribute msg
+tw_row_gap_px =
+    A.class "tw-row-gap-px"
+
+
+tw_grid_flow_row : Html.Attribute msg
+tw_grid_flow_row =
+    A.class "tw-grid-flow-row"
+
+
+tw_grid_flow_col : Html.Attribute msg
+tw_grid_flow_col =
+    A.class "tw-grid-flow-col"
+
+
+tw_grid_flow_row_dense : Html.Attribute msg
+tw_grid_flow_row_dense =
+    A.class "tw-grid-flow-row-dense"
+
+
+tw_grid_flow_col_dense : Html.Attribute msg
+tw_grid_flow_col_dense =
+    A.class "tw-grid-flow-col-dense"
+
+
+tw_grid_cols_1 : Html.Attribute msg
+tw_grid_cols_1 =
+    A.class "tw-grid-cols-1"
+
+
+tw_grid_cols_2 : Html.Attribute msg
+tw_grid_cols_2 =
+    A.class "tw-grid-cols-2"
+
+
+tw_grid_cols_3 : Html.Attribute msg
+tw_grid_cols_3 =
+    A.class "tw-grid-cols-3"
+
+
+tw_grid_cols_4 : Html.Attribute msg
+tw_grid_cols_4 =
+    A.class "tw-grid-cols-4"
+
+
+tw_grid_cols_5 : Html.Attribute msg
+tw_grid_cols_5 =
+    A.class "tw-grid-cols-5"
+
+
+tw_grid_cols_6 : Html.Attribute msg
+tw_grid_cols_6 =
+    A.class "tw-grid-cols-6"
+
+
+tw_grid_cols_7 : Html.Attribute msg
+tw_grid_cols_7 =
+    A.class "tw-grid-cols-7"
+
+
+tw_grid_cols_8 : Html.Attribute msg
+tw_grid_cols_8 =
+    A.class "tw-grid-cols-8"
+
+
+tw_grid_cols_9 : Html.Attribute msg
+tw_grid_cols_9 =
+    A.class "tw-grid-cols-9"
+
+
+tw_grid_cols_10 : Html.Attribute msg
+tw_grid_cols_10 =
+    A.class "tw-grid-cols-10"
+
+
+tw_grid_cols_11 : Html.Attribute msg
+tw_grid_cols_11 =
+    A.class "tw-grid-cols-11"
+
+
+tw_grid_cols_12 : Html.Attribute msg
+tw_grid_cols_12 =
+    A.class "tw-grid-cols-12"
+
+
+tw_grid_cols_none : Html.Attribute msg
+tw_grid_cols_none =
+    A.class "tw-grid-cols-none"
+
+
+tw_col_auto : Html.Attribute msg
+tw_col_auto =
+    A.class "tw-col-auto"
+
+
+tw_col_span_1 : Html.Attribute msg
+tw_col_span_1 =
+    A.class "tw-col-span-1"
+
+
+tw_col_span_2 : Html.Attribute msg
+tw_col_span_2 =
+    A.class "tw-col-span-2"
+
+
+tw_col_span_3 : Html.Attribute msg
+tw_col_span_3 =
+    A.class "tw-col-span-3"
+
+
+tw_col_span_4 : Html.Attribute msg
+tw_col_span_4 =
+    A.class "tw-col-span-4"
+
+
+tw_col_span_5 : Html.Attribute msg
+tw_col_span_5 =
+    A.class "tw-col-span-5"
+
+
+tw_col_span_6 : Html.Attribute msg
+tw_col_span_6 =
+    A.class "tw-col-span-6"
+
+
+tw_col_span_7 : Html.Attribute msg
+tw_col_span_7 =
+    A.class "tw-col-span-7"
+
+
+tw_col_span_8 : Html.Attribute msg
+tw_col_span_8 =
+    A.class "tw-col-span-8"
+
+
+tw_col_span_9 : Html.Attribute msg
+tw_col_span_9 =
+    A.class "tw-col-span-9"
+
+
+tw_col_span_10 : Html.Attribute msg
+tw_col_span_10 =
+    A.class "tw-col-span-10"
+
+
+tw_col_span_11 : Html.Attribute msg
+tw_col_span_11 =
+    A.class "tw-col-span-11"
+
+
+tw_col_span_12 : Html.Attribute msg
+tw_col_span_12 =
+    A.class "tw-col-span-12"
+
+
+tw_col_start_1 : Html.Attribute msg
+tw_col_start_1 =
+    A.class "tw-col-start-1"
+
+
+tw_col_start_2 : Html.Attribute msg
+tw_col_start_2 =
+    A.class "tw-col-start-2"
+
+
+tw_col_start_3 : Html.Attribute msg
+tw_col_start_3 =
+    A.class "tw-col-start-3"
+
+
+tw_col_start_4 : Html.Attribute msg
+tw_col_start_4 =
+    A.class "tw-col-start-4"
+
+
+tw_col_start_5 : Html.Attribute msg
+tw_col_start_5 =
+    A.class "tw-col-start-5"
+
+
+tw_col_start_6 : Html.Attribute msg
+tw_col_start_6 =
+    A.class "tw-col-start-6"
+
+
+tw_col_start_7 : Html.Attribute msg
+tw_col_start_7 =
+    A.class "tw-col-start-7"
+
+
+tw_col_start_8 : Html.Attribute msg
+tw_col_start_8 =
+    A.class "tw-col-start-8"
+
+
+tw_col_start_9 : Html.Attribute msg
+tw_col_start_9 =
+    A.class "tw-col-start-9"
+
+
+tw_col_start_10 : Html.Attribute msg
+tw_col_start_10 =
+    A.class "tw-col-start-10"
+
+
+tw_col_start_11 : Html.Attribute msg
+tw_col_start_11 =
+    A.class "tw-col-start-11"
+
+
+tw_col_start_12 : Html.Attribute msg
+tw_col_start_12 =
+    A.class "tw-col-start-12"
+
+
+tw_col_start_13 : Html.Attribute msg
+tw_col_start_13 =
+    A.class "tw-col-start-13"
+
+
+tw_col_start_auto : Html.Attribute msg
+tw_col_start_auto =
+    A.class "tw-col-start-auto"
+
+
+tw_col_end_1 : Html.Attribute msg
+tw_col_end_1 =
+    A.class "tw-col-end-1"
+
+
+tw_col_end_2 : Html.Attribute msg
+tw_col_end_2 =
+    A.class "tw-col-end-2"
+
+
+tw_col_end_3 : Html.Attribute msg
+tw_col_end_3 =
+    A.class "tw-col-end-3"
+
+
+tw_col_end_4 : Html.Attribute msg
+tw_col_end_4 =
+    A.class "tw-col-end-4"
+
+
+tw_col_end_5 : Html.Attribute msg
+tw_col_end_5 =
+    A.class "tw-col-end-5"
+
+
+tw_col_end_6 : Html.Attribute msg
+tw_col_end_6 =
+    A.class "tw-col-end-6"
+
+
+tw_col_end_7 : Html.Attribute msg
+tw_col_end_7 =
+    A.class "tw-col-end-7"
+
+
+tw_col_end_8 : Html.Attribute msg
+tw_col_end_8 =
+    A.class "tw-col-end-8"
+
+
+tw_col_end_9 : Html.Attribute msg
+tw_col_end_9 =
+    A.class "tw-col-end-9"
+
+
+tw_col_end_10 : Html.Attribute msg
+tw_col_end_10 =
+    A.class "tw-col-end-10"
+
+
+tw_col_end_11 : Html.Attribute msg
+tw_col_end_11 =
+    A.class "tw-col-end-11"
+
+
+tw_col_end_12 : Html.Attribute msg
+tw_col_end_12 =
+    A.class "tw-col-end-12"
+
+
+tw_col_end_13 : Html.Attribute msg
+tw_col_end_13 =
+    A.class "tw-col-end-13"
+
+
+tw_col_end_auto : Html.Attribute msg
+tw_col_end_auto =
+    A.class "tw-col-end-auto"
+
+
+tw_grid_rows_1 : Html.Attribute msg
+tw_grid_rows_1 =
+    A.class "tw-grid-rows-1"
+
+
+tw_grid_rows_2 : Html.Attribute msg
+tw_grid_rows_2 =
+    A.class "tw-grid-rows-2"
+
+
+tw_grid_rows_3 : Html.Attribute msg
+tw_grid_rows_3 =
+    A.class "tw-grid-rows-3"
+
+
+tw_grid_rows_4 : Html.Attribute msg
+tw_grid_rows_4 =
+    A.class "tw-grid-rows-4"
+
+
+tw_grid_rows_5 : Html.Attribute msg
+tw_grid_rows_5 =
+    A.class "tw-grid-rows-5"
+
+
+tw_grid_rows_6 : Html.Attribute msg
+tw_grid_rows_6 =
+    A.class "tw-grid-rows-6"
+
+
+tw_grid_rows_none : Html.Attribute msg
+tw_grid_rows_none =
+    A.class "tw-grid-rows-none"
+
+
+tw_row_auto : Html.Attribute msg
+tw_row_auto =
+    A.class "tw-row-auto"
+
+
+tw_row_span_1 : Html.Attribute msg
+tw_row_span_1 =
+    A.class "tw-row-span-1"
+
+
+tw_row_span_2 : Html.Attribute msg
+tw_row_span_2 =
+    A.class "tw-row-span-2"
+
+
+tw_row_span_3 : Html.Attribute msg
+tw_row_span_3 =
+    A.class "tw-row-span-3"
+
+
+tw_row_span_4 : Html.Attribute msg
+tw_row_span_4 =
+    A.class "tw-row-span-4"
+
+
+tw_row_span_5 : Html.Attribute msg
+tw_row_span_5 =
+    A.class "tw-row-span-5"
+
+
+tw_row_span_6 : Html.Attribute msg
+tw_row_span_6 =
+    A.class "tw-row-span-6"
+
+
+tw_row_start_1 : Html.Attribute msg
+tw_row_start_1 =
+    A.class "tw-row-start-1"
+
+
+tw_row_start_2 : Html.Attribute msg
+tw_row_start_2 =
+    A.class "tw-row-start-2"
+
+
+tw_row_start_3 : Html.Attribute msg
+tw_row_start_3 =
+    A.class "tw-row-start-3"
+
+
+tw_row_start_4 : Html.Attribute msg
+tw_row_start_4 =
+    A.class "tw-row-start-4"
+
+
+tw_row_start_5 : Html.Attribute msg
+tw_row_start_5 =
+    A.class "tw-row-start-5"
+
+
+tw_row_start_6 : Html.Attribute msg
+tw_row_start_6 =
+    A.class "tw-row-start-6"
+
+
+tw_row_start_7 : Html.Attribute msg
+tw_row_start_7 =
+    A.class "tw-row-start-7"
+
+
+tw_row_start_auto : Html.Attribute msg
+tw_row_start_auto =
+    A.class "tw-row-start-auto"
+
+
+tw_row_end_1 : Html.Attribute msg
+tw_row_end_1 =
+    A.class "tw-row-end-1"
+
+
+tw_row_end_2 : Html.Attribute msg
+tw_row_end_2 =
+    A.class "tw-row-end-2"
+
+
+tw_row_end_3 : Html.Attribute msg
+tw_row_end_3 =
+    A.class "tw-row-end-3"
+
+
+tw_row_end_4 : Html.Attribute msg
+tw_row_end_4 =
+    A.class "tw-row-end-4"
+
+
+tw_row_end_5 : Html.Attribute msg
+tw_row_end_5 =
+    A.class "tw-row-end-5"
+
+
+tw_row_end_6 : Html.Attribute msg
+tw_row_end_6 =
+    A.class "tw-row-end-6"
+
+
+tw_row_end_7 : Html.Attribute msg
+tw_row_end_7 =
+    A.class "tw-row-end-7"
+
+
+tw_row_end_auto : Html.Attribute msg
+tw_row_end_auto =
+    A.class "tw-row-end-auto"
+
+
+tw_transform : Html.Attribute msg
+tw_transform =
+    A.class "tw-transform"
+
+
+tw_transform_none : Html.Attribute msg
+tw_transform_none =
+    A.class "tw-transform-none"
+
+
+tw_origin_center : Html.Attribute msg
+tw_origin_center =
+    A.class "tw-origin-center"
+
+
+tw_origin_top : Html.Attribute msg
+tw_origin_top =
+    A.class "tw-origin-top"
+
+
+tw_origin_top_right : Html.Attribute msg
+tw_origin_top_right =
+    A.class "tw-origin-top-right"
+
+
+tw_origin_right : Html.Attribute msg
+tw_origin_right =
+    A.class "tw-origin-right"
+
+
+tw_origin_bottom_right : Html.Attribute msg
+tw_origin_bottom_right =
+    A.class "tw-origin-bottom-right"
+
+
+tw_origin_bottom : Html.Attribute msg
+tw_origin_bottom =
+    A.class "tw-origin-bottom"
+
+
+tw_origin_bottom_left : Html.Attribute msg
+tw_origin_bottom_left =
+    A.class "tw-origin-bottom-left"
+
+
+tw_origin_left : Html.Attribute msg
+tw_origin_left =
+    A.class "tw-origin-left"
+
+
+tw_origin_top_left : Html.Attribute msg
+tw_origin_top_left =
+    A.class "tw-origin-top-left"
+
+
+tw_scale_0 : Html.Attribute msg
+tw_scale_0 =
+    A.class "tw-scale-0"
+
+
+tw_scale_50 : Html.Attribute msg
+tw_scale_50 =
+    A.class "tw-scale-50"
+
+
+tw_scale_75 : Html.Attribute msg
+tw_scale_75 =
+    A.class "tw-scale-75"
+
+
+tw_scale_90 : Html.Attribute msg
+tw_scale_90 =
+    A.class "tw-scale-90"
+
+
+tw_scale_95 : Html.Attribute msg
+tw_scale_95 =
+    A.class "tw-scale-95"
+
+
+tw_scale_100 : Html.Attribute msg
+tw_scale_100 =
+    A.class "tw-scale-100"
+
+
+tw_scale_105 : Html.Attribute msg
+tw_scale_105 =
+    A.class "tw-scale-105"
+
+
+tw_scale_110 : Html.Attribute msg
+tw_scale_110 =
+    A.class "tw-scale-110"
+
+
+tw_scale_125 : Html.Attribute msg
+tw_scale_125 =
+    A.class "tw-scale-125"
+
+
+tw_scale_150 : Html.Attribute msg
+tw_scale_150 =
+    A.class "tw-scale-150"
+
+
+tw_scale_x_0 : Html.Attribute msg
+tw_scale_x_0 =
+    A.class "tw-scale-x-0"
+
+
+tw_scale_x_50 : Html.Attribute msg
+tw_scale_x_50 =
+    A.class "tw-scale-x-50"
+
+
+tw_scale_x_75 : Html.Attribute msg
+tw_scale_x_75 =
+    A.class "tw-scale-x-75"
+
+
+tw_scale_x_90 : Html.Attribute msg
+tw_scale_x_90 =
+    A.class "tw-scale-x-90"
+
+
+tw_scale_x_95 : Html.Attribute msg
+tw_scale_x_95 =
+    A.class "tw-scale-x-95"
+
+
+tw_scale_x_100 : Html.Attribute msg
+tw_scale_x_100 =
+    A.class "tw-scale-x-100"
+
+
+tw_scale_x_105 : Html.Attribute msg
+tw_scale_x_105 =
+    A.class "tw-scale-x-105"
+
+
+tw_scale_x_110 : Html.Attribute msg
+tw_scale_x_110 =
+    A.class "tw-scale-x-110"
+
+
+tw_scale_x_125 : Html.Attribute msg
+tw_scale_x_125 =
+    A.class "tw-scale-x-125"
+
+
+tw_scale_x_150 : Html.Attribute msg
+tw_scale_x_150 =
+    A.class "tw-scale-x-150"
+
+
+tw_scale_y_0 : Html.Attribute msg
+tw_scale_y_0 =
+    A.class "tw-scale-y-0"
+
+
+tw_scale_y_50 : Html.Attribute msg
+tw_scale_y_50 =
+    A.class "tw-scale-y-50"
+
+
+tw_scale_y_75 : Html.Attribute msg
+tw_scale_y_75 =
+    A.class "tw-scale-y-75"
+
+
+tw_scale_y_90 : Html.Attribute msg
+tw_scale_y_90 =
+    A.class "tw-scale-y-90"
+
+
+tw_scale_y_95 : Html.Attribute msg
+tw_scale_y_95 =
+    A.class "tw-scale-y-95"
+
+
+tw_scale_y_100 : Html.Attribute msg
+tw_scale_y_100 =
+    A.class "tw-scale-y-100"
+
+
+tw_scale_y_105 : Html.Attribute msg
+tw_scale_y_105 =
+    A.class "tw-scale-y-105"
+
+
+tw_scale_y_110 : Html.Attribute msg
+tw_scale_y_110 =
+    A.class "tw-scale-y-110"
+
+
+tw_scale_y_125 : Html.Attribute msg
+tw_scale_y_125 =
+    A.class "tw-scale-y-125"
+
+
+tw_scale_y_150 : Html.Attribute msg
+tw_scale_y_150 =
+    A.class "tw-scale-y-150"
+
+
+hover_tw_scale_0 : Html.Attribute msg
+hover_tw_scale_0 =
+    A.class "hover:tw-scale-0"
+
+
+hover_tw_scale_50 : Html.Attribute msg
+hover_tw_scale_50 =
+    A.class "hover:tw-scale-50"
+
+
+hover_tw_scale_75 : Html.Attribute msg
+hover_tw_scale_75 =
+    A.class "hover:tw-scale-75"
+
+
+hover_tw_scale_90 : Html.Attribute msg
+hover_tw_scale_90 =
+    A.class "hover:tw-scale-90"
+
+
+hover_tw_scale_95 : Html.Attribute msg
+hover_tw_scale_95 =
+    A.class "hover:tw-scale-95"
+
+
+hover_tw_scale_100 : Html.Attribute msg
+hover_tw_scale_100 =
+    A.class "hover:tw-scale-100"
+
+
+hover_tw_scale_105 : Html.Attribute msg
+hover_tw_scale_105 =
+    A.class "hover:tw-scale-105"
+
+
+hover_tw_scale_110 : Html.Attribute msg
+hover_tw_scale_110 =
+    A.class "hover:tw-scale-110"
+
+
+hover_tw_scale_125 : Html.Attribute msg
+hover_tw_scale_125 =
+    A.class "hover:tw-scale-125"
+
+
+hover_tw_scale_150 : Html.Attribute msg
+hover_tw_scale_150 =
+    A.class "hover:tw-scale-150"
+
+
+hover_tw_scale_x_0 : Html.Attribute msg
+hover_tw_scale_x_0 =
+    A.class "hover:tw-scale-x-0"
+
+
+hover_tw_scale_x_50 : Html.Attribute msg
+hover_tw_scale_x_50 =
+    A.class "hover:tw-scale-x-50"
+
+
+hover_tw_scale_x_75 : Html.Attribute msg
+hover_tw_scale_x_75 =
+    A.class "hover:tw-scale-x-75"
+
+
+hover_tw_scale_x_90 : Html.Attribute msg
+hover_tw_scale_x_90 =
+    A.class "hover:tw-scale-x-90"
+
+
+hover_tw_scale_x_95 : Html.Attribute msg
+hover_tw_scale_x_95 =
+    A.class "hover:tw-scale-x-95"
+
+
+hover_tw_scale_x_100 : Html.Attribute msg
+hover_tw_scale_x_100 =
+    A.class "hover:tw-scale-x-100"
+
+
+hover_tw_scale_x_105 : Html.Attribute msg
+hover_tw_scale_x_105 =
+    A.class "hover:tw-scale-x-105"
+
+
+hover_tw_scale_x_110 : Html.Attribute msg
+hover_tw_scale_x_110 =
+    A.class "hover:tw-scale-x-110"
+
+
+hover_tw_scale_x_125 : Html.Attribute msg
+hover_tw_scale_x_125 =
+    A.class "hover:tw-scale-x-125"
+
+
+hover_tw_scale_x_150 : Html.Attribute msg
+hover_tw_scale_x_150 =
+    A.class "hover:tw-scale-x-150"
+
+
+hover_tw_scale_y_0 : Html.Attribute msg
+hover_tw_scale_y_0 =
+    A.class "hover:tw-scale-y-0"
+
+
+hover_tw_scale_y_50 : Html.Attribute msg
+hover_tw_scale_y_50 =
+    A.class "hover:tw-scale-y-50"
+
+
+hover_tw_scale_y_75 : Html.Attribute msg
+hover_tw_scale_y_75 =
+    A.class "hover:tw-scale-y-75"
+
+
+hover_tw_scale_y_90 : Html.Attribute msg
+hover_tw_scale_y_90 =
+    A.class "hover:tw-scale-y-90"
+
+
+hover_tw_scale_y_95 : Html.Attribute msg
+hover_tw_scale_y_95 =
+    A.class "hover:tw-scale-y-95"
+
+
+hover_tw_scale_y_100 : Html.Attribute msg
+hover_tw_scale_y_100 =
+    A.class "hover:tw-scale-y-100"
+
+
+hover_tw_scale_y_105 : Html.Attribute msg
+hover_tw_scale_y_105 =
+    A.class "hover:tw-scale-y-105"
+
+
+hover_tw_scale_y_110 : Html.Attribute msg
+hover_tw_scale_y_110 =
+    A.class "hover:tw-scale-y-110"
+
+
+hover_tw_scale_y_125 : Html.Attribute msg
+hover_tw_scale_y_125 =
+    A.class "hover:tw-scale-y-125"
+
+
+hover_tw_scale_y_150 : Html.Attribute msg
+hover_tw_scale_y_150 =
+    A.class "hover:tw-scale-y-150"
+
+
+focus_tw_scale_0 : Html.Attribute msg
+focus_tw_scale_0 =
+    A.class "focus:tw-scale-0"
+
+
+focus_tw_scale_50 : Html.Attribute msg
+focus_tw_scale_50 =
+    A.class "focus:tw-scale-50"
+
+
+focus_tw_scale_75 : Html.Attribute msg
+focus_tw_scale_75 =
+    A.class "focus:tw-scale-75"
+
+
+focus_tw_scale_90 : Html.Attribute msg
+focus_tw_scale_90 =
+    A.class "focus:tw-scale-90"
+
+
+focus_tw_scale_95 : Html.Attribute msg
+focus_tw_scale_95 =
+    A.class "focus:tw-scale-95"
+
+
+focus_tw_scale_100 : Html.Attribute msg
+focus_tw_scale_100 =
+    A.class "focus:tw-scale-100"
+
+
+focus_tw_scale_105 : Html.Attribute msg
+focus_tw_scale_105 =
+    A.class "focus:tw-scale-105"
+
+
+focus_tw_scale_110 : Html.Attribute msg
+focus_tw_scale_110 =
+    A.class "focus:tw-scale-110"
+
+
+focus_tw_scale_125 : Html.Attribute msg
+focus_tw_scale_125 =
+    A.class "focus:tw-scale-125"
+
+
+focus_tw_scale_150 : Html.Attribute msg
+focus_tw_scale_150 =
+    A.class "focus:tw-scale-150"
+
+
+focus_tw_scale_x_0 : Html.Attribute msg
+focus_tw_scale_x_0 =
+    A.class "focus:tw-scale-x-0"
+
+
+focus_tw_scale_x_50 : Html.Attribute msg
+focus_tw_scale_x_50 =
+    A.class "focus:tw-scale-x-50"
+
+
+focus_tw_scale_x_75 : Html.Attribute msg
+focus_tw_scale_x_75 =
+    A.class "focus:tw-scale-x-75"
+
+
+focus_tw_scale_x_90 : Html.Attribute msg
+focus_tw_scale_x_90 =
+    A.class "focus:tw-scale-x-90"
+
+
+focus_tw_scale_x_95 : Html.Attribute msg
+focus_tw_scale_x_95 =
+    A.class "focus:tw-scale-x-95"
+
+
+focus_tw_scale_x_100 : Html.Attribute msg
+focus_tw_scale_x_100 =
+    A.class "focus:tw-scale-x-100"
+
+
+focus_tw_scale_x_105 : Html.Attribute msg
+focus_tw_scale_x_105 =
+    A.class "focus:tw-scale-x-105"
+
+
+focus_tw_scale_x_110 : Html.Attribute msg
+focus_tw_scale_x_110 =
+    A.class "focus:tw-scale-x-110"
+
+
+focus_tw_scale_x_125 : Html.Attribute msg
+focus_tw_scale_x_125 =
+    A.class "focus:tw-scale-x-125"
+
+
+focus_tw_scale_x_150 : Html.Attribute msg
+focus_tw_scale_x_150 =
+    A.class "focus:tw-scale-x-150"
+
+
+focus_tw_scale_y_0 : Html.Attribute msg
+focus_tw_scale_y_0 =
+    A.class "focus:tw-scale-y-0"
+
+
+focus_tw_scale_y_50 : Html.Attribute msg
+focus_tw_scale_y_50 =
+    A.class "focus:tw-scale-y-50"
+
+
+focus_tw_scale_y_75 : Html.Attribute msg
+focus_tw_scale_y_75 =
+    A.class "focus:tw-scale-y-75"
+
+
+focus_tw_scale_y_90 : Html.Attribute msg
+focus_tw_scale_y_90 =
+    A.class "focus:tw-scale-y-90"
+
+
+focus_tw_scale_y_95 : Html.Attribute msg
+focus_tw_scale_y_95 =
+    A.class "focus:tw-scale-y-95"
+
+
+focus_tw_scale_y_100 : Html.Attribute msg
+focus_tw_scale_y_100 =
+    A.class "focus:tw-scale-y-100"
+
+
+focus_tw_scale_y_105 : Html.Attribute msg
+focus_tw_scale_y_105 =
+    A.class "focus:tw-scale-y-105"
+
+
+focus_tw_scale_y_110 : Html.Attribute msg
+focus_tw_scale_y_110 =
+    A.class "focus:tw-scale-y-110"
+
+
+focus_tw_scale_y_125 : Html.Attribute msg
+focus_tw_scale_y_125 =
+    A.class "focus:tw-scale-y-125"
+
+
+focus_tw_scale_y_150 : Html.Attribute msg
+focus_tw_scale_y_150 =
+    A.class "focus:tw-scale-y-150"
+
+
+tw_rotate_0 : Html.Attribute msg
+tw_rotate_0 =
+    A.class "tw-rotate-0"
+
+
+tw_rotate_45 : Html.Attribute msg
+tw_rotate_45 =
+    A.class "tw-rotate-45"
+
+
+tw_rotate_90 : Html.Attribute msg
+tw_rotate_90 =
+    A.class "tw-rotate-90"
+
+
+tw_rotate_180 : Html.Attribute msg
+tw_rotate_180 =
+    A.class "tw-rotate-180"
+
+
+tw_neg_rotate_180 : Html.Attribute msg
+tw_neg_rotate_180 =
+    A.class "tw--rotate-180"
+
+
+tw_neg_rotate_90 : Html.Attribute msg
+tw_neg_rotate_90 =
+    A.class "tw--rotate-90"
+
+
+tw_neg_rotate_45 : Html.Attribute msg
+tw_neg_rotate_45 =
+    A.class "tw--rotate-45"
+
+
+hover_tw_rotate_0 : Html.Attribute msg
+hover_tw_rotate_0 =
+    A.class "hover:tw-rotate-0"
+
+
+hover_tw_rotate_45 : Html.Attribute msg
+hover_tw_rotate_45 =
+    A.class "hover:tw-rotate-45"
+
+
+hover_tw_rotate_90 : Html.Attribute msg
+hover_tw_rotate_90 =
+    A.class "hover:tw-rotate-90"
+
+
+hover_tw_rotate_180 : Html.Attribute msg
+hover_tw_rotate_180 =
+    A.class "hover:tw-rotate-180"
+
+
+hover_tw_neg_rotate_180 : Html.Attribute msg
+hover_tw_neg_rotate_180 =
+    A.class "hover:tw--rotate-180"
+
+
+hover_tw_neg_rotate_90 : Html.Attribute msg
+hover_tw_neg_rotate_90 =
+    A.class "hover:tw--rotate-90"
+
+
+hover_tw_neg_rotate_45 : Html.Attribute msg
+hover_tw_neg_rotate_45 =
+    A.class "hover:tw--rotate-45"
+
+
+focus_tw_rotate_0 : Html.Attribute msg
+focus_tw_rotate_0 =
+    A.class "focus:tw-rotate-0"
+
+
+focus_tw_rotate_45 : Html.Attribute msg
+focus_tw_rotate_45 =
+    A.class "focus:tw-rotate-45"
+
+
+focus_tw_rotate_90 : Html.Attribute msg
+focus_tw_rotate_90 =
+    A.class "focus:tw-rotate-90"
+
+
+focus_tw_rotate_180 : Html.Attribute msg
+focus_tw_rotate_180 =
+    A.class "focus:tw-rotate-180"
+
+
+focus_tw_neg_rotate_180 : Html.Attribute msg
+focus_tw_neg_rotate_180 =
+    A.class "focus:tw--rotate-180"
+
+
+focus_tw_neg_rotate_90 : Html.Attribute msg
+focus_tw_neg_rotate_90 =
+    A.class "focus:tw--rotate-90"
+
+
+focus_tw_neg_rotate_45 : Html.Attribute msg
+focus_tw_neg_rotate_45 =
+    A.class "focus:tw--rotate-45"
+
+
+tw_translate_x_0 : Html.Attribute msg
+tw_translate_x_0 =
+    A.class "tw-translate-x-0"
+
+
+tw_translate_x_1 : Html.Attribute msg
+tw_translate_x_1 =
+    A.class "tw-translate-x-1"
+
+
+tw_translate_x_2 : Html.Attribute msg
+tw_translate_x_2 =
+    A.class "tw-translate-x-2"
+
+
+tw_translate_x_3 : Html.Attribute msg
+tw_translate_x_3 =
+    A.class "tw-translate-x-3"
+
+
+tw_translate_x_4 : Html.Attribute msg
+tw_translate_x_4 =
+    A.class "tw-translate-x-4"
+
+
+tw_translate_x_5 : Html.Attribute msg
+tw_translate_x_5 =
+    A.class "tw-translate-x-5"
+
+
+tw_translate_x_6 : Html.Attribute msg
+tw_translate_x_6 =
+    A.class "tw-translate-x-6"
+
+
+tw_translate_x_8 : Html.Attribute msg
+tw_translate_x_8 =
+    A.class "tw-translate-x-8"
+
+
+tw_translate_x_10 : Html.Attribute msg
+tw_translate_x_10 =
+    A.class "tw-translate-x-10"
+
+
+tw_translate_x_12 : Html.Attribute msg
+tw_translate_x_12 =
+    A.class "tw-translate-x-12"
+
+
+tw_translate_x_16 : Html.Attribute msg
+tw_translate_x_16 =
+    A.class "tw-translate-x-16"
+
+
+tw_translate_x_20 : Html.Attribute msg
+tw_translate_x_20 =
+    A.class "tw-translate-x-20"
+
+
+tw_translate_x_24 : Html.Attribute msg
+tw_translate_x_24 =
+    A.class "tw-translate-x-24"
+
+
+tw_translate_x_32 : Html.Attribute msg
+tw_translate_x_32 =
+    A.class "tw-translate-x-32"
+
+
+tw_translate_x_40 : Html.Attribute msg
+tw_translate_x_40 =
+    A.class "tw-translate-x-40"
+
+
+tw_translate_x_48 : Html.Attribute msg
+tw_translate_x_48 =
+    A.class "tw-translate-x-48"
+
+
+tw_translate_x_56 : Html.Attribute msg
+tw_translate_x_56 =
+    A.class "tw-translate-x-56"
+
+
+tw_translate_x_64 : Html.Attribute msg
+tw_translate_x_64 =
+    A.class "tw-translate-x-64"
+
+
+tw_translate_x_px : Html.Attribute msg
+tw_translate_x_px =
+    A.class "tw-translate-x-px"
+
+
+tw_neg_translate_x_1 : Html.Attribute msg
+tw_neg_translate_x_1 =
+    A.class "tw--translate-x-1"
+
+
+tw_neg_translate_x_2 : Html.Attribute msg
+tw_neg_translate_x_2 =
+    A.class "tw--translate-x-2"
+
+
+tw_neg_translate_x_3 : Html.Attribute msg
+tw_neg_translate_x_3 =
+    A.class "tw--translate-x-3"
+
+
+tw_neg_translate_x_4 : Html.Attribute msg
+tw_neg_translate_x_4 =
+    A.class "tw--translate-x-4"
+
+
+tw_neg_translate_x_5 : Html.Attribute msg
+tw_neg_translate_x_5 =
+    A.class "tw--translate-x-5"
+
+
+tw_neg_translate_x_6 : Html.Attribute msg
+tw_neg_translate_x_6 =
+    A.class "tw--translate-x-6"
+
+
+tw_neg_translate_x_8 : Html.Attribute msg
+tw_neg_translate_x_8 =
+    A.class "tw--translate-x-8"
+
+
+tw_neg_translate_x_10 : Html.Attribute msg
+tw_neg_translate_x_10 =
+    A.class "tw--translate-x-10"
+
+
+tw_neg_translate_x_12 : Html.Attribute msg
+tw_neg_translate_x_12 =
+    A.class "tw--translate-x-12"
+
+
+tw_neg_translate_x_16 : Html.Attribute msg
+tw_neg_translate_x_16 =
+    A.class "tw--translate-x-16"
+
+
+tw_neg_translate_x_20 : Html.Attribute msg
+tw_neg_translate_x_20 =
+    A.class "tw--translate-x-20"
+
+
+tw_neg_translate_x_24 : Html.Attribute msg
+tw_neg_translate_x_24 =
+    A.class "tw--translate-x-24"
+
+
+tw_neg_translate_x_32 : Html.Attribute msg
+tw_neg_translate_x_32 =
+    A.class "tw--translate-x-32"
+
+
+tw_neg_translate_x_40 : Html.Attribute msg
+tw_neg_translate_x_40 =
+    A.class "tw--translate-x-40"
+
+
+tw_neg_translate_x_48 : Html.Attribute msg
+tw_neg_translate_x_48 =
+    A.class "tw--translate-x-48"
+
+
+tw_neg_translate_x_56 : Html.Attribute msg
+tw_neg_translate_x_56 =
+    A.class "tw--translate-x-56"
+
+
+tw_neg_translate_x_64 : Html.Attribute msg
+tw_neg_translate_x_64 =
+    A.class "tw--translate-x-64"
+
+
+tw_neg_translate_x_px : Html.Attribute msg
+tw_neg_translate_x_px =
+    A.class "tw--translate-x-px"
+
+
+tw_neg_translate_x_full : Html.Attribute msg
+tw_neg_translate_x_full =
+    A.class "tw--translate-x-full"
+
+
+tw_neg_translate_x_1over2 : Html.Attribute msg
+tw_neg_translate_x_1over2 =
+    A.class "tw--translate-x-1/2"
+
+
+tw_translate_x_1over2 : Html.Attribute msg
+tw_translate_x_1over2 =
+    A.class "tw-translate-x-1/2"
+
+
+tw_translate_x_full : Html.Attribute msg
+tw_translate_x_full =
+    A.class "tw-translate-x-full"
+
+
+tw_translate_y_0 : Html.Attribute msg
+tw_translate_y_0 =
+    A.class "tw-translate-y-0"
+
+
+tw_translate_y_1 : Html.Attribute msg
+tw_translate_y_1 =
+    A.class "tw-translate-y-1"
+
+
+tw_translate_y_2 : Html.Attribute msg
+tw_translate_y_2 =
+    A.class "tw-translate-y-2"
+
+
+tw_translate_y_3 : Html.Attribute msg
+tw_translate_y_3 =
+    A.class "tw-translate-y-3"
+
+
+tw_translate_y_4 : Html.Attribute msg
+tw_translate_y_4 =
+    A.class "tw-translate-y-4"
+
+
+tw_translate_y_5 : Html.Attribute msg
+tw_translate_y_5 =
+    A.class "tw-translate-y-5"
+
+
+tw_translate_y_6 : Html.Attribute msg
+tw_translate_y_6 =
+    A.class "tw-translate-y-6"
+
+
+tw_translate_y_8 : Html.Attribute msg
+tw_translate_y_8 =
+    A.class "tw-translate-y-8"
+
+
+tw_translate_y_10 : Html.Attribute msg
+tw_translate_y_10 =
+    A.class "tw-translate-y-10"
+
+
+tw_translate_y_12 : Html.Attribute msg
+tw_translate_y_12 =
+    A.class "tw-translate-y-12"
+
+
+tw_translate_y_16 : Html.Attribute msg
+tw_translate_y_16 =
+    A.class "tw-translate-y-16"
+
+
+tw_translate_y_20 : Html.Attribute msg
+tw_translate_y_20 =
+    A.class "tw-translate-y-20"
+
+
+tw_translate_y_24 : Html.Attribute msg
+tw_translate_y_24 =
+    A.class "tw-translate-y-24"
+
+
+tw_translate_y_32 : Html.Attribute msg
+tw_translate_y_32 =
+    A.class "tw-translate-y-32"
+
+
+tw_translate_y_40 : Html.Attribute msg
+tw_translate_y_40 =
+    A.class "tw-translate-y-40"
+
+
+tw_translate_y_48 : Html.Attribute msg
+tw_translate_y_48 =
+    A.class "tw-translate-y-48"
+
+
+tw_translate_y_56 : Html.Attribute msg
+tw_translate_y_56 =
+    A.class "tw-translate-y-56"
+
+
+tw_translate_y_64 : Html.Attribute msg
+tw_translate_y_64 =
+    A.class "tw-translate-y-64"
+
+
+tw_translate_y_px : Html.Attribute msg
+tw_translate_y_px =
+    A.class "tw-translate-y-px"
+
+
+tw_neg_translate_y_1 : Html.Attribute msg
+tw_neg_translate_y_1 =
+    A.class "tw--translate-y-1"
+
+
+tw_neg_translate_y_2 : Html.Attribute msg
+tw_neg_translate_y_2 =
+    A.class "tw--translate-y-2"
+
+
+tw_neg_translate_y_3 : Html.Attribute msg
+tw_neg_translate_y_3 =
+    A.class "tw--translate-y-3"
+
+
+tw_neg_translate_y_4 : Html.Attribute msg
+tw_neg_translate_y_4 =
+    A.class "tw--translate-y-4"
+
+
+tw_neg_translate_y_5 : Html.Attribute msg
+tw_neg_translate_y_5 =
+    A.class "tw--translate-y-5"
+
+
+tw_neg_translate_y_6 : Html.Attribute msg
+tw_neg_translate_y_6 =
+    A.class "tw--translate-y-6"
+
+
+tw_neg_translate_y_8 : Html.Attribute msg
+tw_neg_translate_y_8 =
+    A.class "tw--translate-y-8"
+
+
+tw_neg_translate_y_10 : Html.Attribute msg
+tw_neg_translate_y_10 =
+    A.class "tw--translate-y-10"
+
+
+tw_neg_translate_y_12 : Html.Attribute msg
+tw_neg_translate_y_12 =
+    A.class "tw--translate-y-12"
+
+
+tw_neg_translate_y_16 : Html.Attribute msg
+tw_neg_translate_y_16 =
+    A.class "tw--translate-y-16"
+
+
+tw_neg_translate_y_20 : Html.Attribute msg
+tw_neg_translate_y_20 =
+    A.class "tw--translate-y-20"
+
+
+tw_neg_translate_y_24 : Html.Attribute msg
+tw_neg_translate_y_24 =
+    A.class "tw--translate-y-24"
+
+
+tw_neg_translate_y_32 : Html.Attribute msg
+tw_neg_translate_y_32 =
+    A.class "tw--translate-y-32"
+
+
+tw_neg_translate_y_40 : Html.Attribute msg
+tw_neg_translate_y_40 =
+    A.class "tw--translate-y-40"
+
+
+tw_neg_translate_y_48 : Html.Attribute msg
+tw_neg_translate_y_48 =
+    A.class "tw--translate-y-48"
+
+
+tw_neg_translate_y_56 : Html.Attribute msg
+tw_neg_translate_y_56 =
+    A.class "tw--translate-y-56"
+
+
+tw_neg_translate_y_64 : Html.Attribute msg
+tw_neg_translate_y_64 =
+    A.class "tw--translate-y-64"
+
+
+tw_neg_translate_y_px : Html.Attribute msg
+tw_neg_translate_y_px =
+    A.class "tw--translate-y-px"
+
+
+tw_neg_translate_y_full : Html.Attribute msg
+tw_neg_translate_y_full =
+    A.class "tw--translate-y-full"
+
+
+tw_neg_translate_y_1over2 : Html.Attribute msg
+tw_neg_translate_y_1over2 =
+    A.class "tw--translate-y-1/2"
+
+
+tw_translate_y_1over2 : Html.Attribute msg
+tw_translate_y_1over2 =
+    A.class "tw-translate-y-1/2"
+
+
+tw_translate_y_full : Html.Attribute msg
+tw_translate_y_full =
+    A.class "tw-translate-y-full"
+
+
+hover_tw_translate_x_0 : Html.Attribute msg
+hover_tw_translate_x_0 =
+    A.class "hover:tw-translate-x-0"
+
+
+hover_tw_translate_x_1 : Html.Attribute msg
+hover_tw_translate_x_1 =
+    A.class "hover:tw-translate-x-1"
+
+
+hover_tw_translate_x_2 : Html.Attribute msg
+hover_tw_translate_x_2 =
+    A.class "hover:tw-translate-x-2"
+
+
+hover_tw_translate_x_3 : Html.Attribute msg
+hover_tw_translate_x_3 =
+    A.class "hover:tw-translate-x-3"
+
+
+hover_tw_translate_x_4 : Html.Attribute msg
+hover_tw_translate_x_4 =
+    A.class "hover:tw-translate-x-4"
+
+
+hover_tw_translate_x_5 : Html.Attribute msg
+hover_tw_translate_x_5 =
+    A.class "hover:tw-translate-x-5"
+
+
+hover_tw_translate_x_6 : Html.Attribute msg
+hover_tw_translate_x_6 =
+    A.class "hover:tw-translate-x-6"
+
+
+hover_tw_translate_x_8 : Html.Attribute msg
+hover_tw_translate_x_8 =
+    A.class "hover:tw-translate-x-8"
+
+
+hover_tw_translate_x_10 : Html.Attribute msg
+hover_tw_translate_x_10 =
+    A.class "hover:tw-translate-x-10"
+
+
+hover_tw_translate_x_12 : Html.Attribute msg
+hover_tw_translate_x_12 =
+    A.class "hover:tw-translate-x-12"
+
+
+hover_tw_translate_x_16 : Html.Attribute msg
+hover_tw_translate_x_16 =
+    A.class "hover:tw-translate-x-16"
+
+
+hover_tw_translate_x_20 : Html.Attribute msg
+hover_tw_translate_x_20 =
+    A.class "hover:tw-translate-x-20"
+
+
+hover_tw_translate_x_24 : Html.Attribute msg
+hover_tw_translate_x_24 =
+    A.class "hover:tw-translate-x-24"
+
+
+hover_tw_translate_x_32 : Html.Attribute msg
+hover_tw_translate_x_32 =
+    A.class "hover:tw-translate-x-32"
+
+
+hover_tw_translate_x_40 : Html.Attribute msg
+hover_tw_translate_x_40 =
+    A.class "hover:tw-translate-x-40"
+
+
+hover_tw_translate_x_48 : Html.Attribute msg
+hover_tw_translate_x_48 =
+    A.class "hover:tw-translate-x-48"
+
+
+hover_tw_translate_x_56 : Html.Attribute msg
+hover_tw_translate_x_56 =
+    A.class "hover:tw-translate-x-56"
+
+
+hover_tw_translate_x_64 : Html.Attribute msg
+hover_tw_translate_x_64 =
+    A.class "hover:tw-translate-x-64"
+
+
+hover_tw_translate_x_px : Html.Attribute msg
+hover_tw_translate_x_px =
+    A.class "hover:tw-translate-x-px"
+
+
+hover_tw_neg_translate_x_1 : Html.Attribute msg
+hover_tw_neg_translate_x_1 =
+    A.class "hover:tw--translate-x-1"
+
+
+hover_tw_neg_translate_x_2 : Html.Attribute msg
+hover_tw_neg_translate_x_2 =
+    A.class "hover:tw--translate-x-2"
+
+
+hover_tw_neg_translate_x_3 : Html.Attribute msg
+hover_tw_neg_translate_x_3 =
+    A.class "hover:tw--translate-x-3"
+
+
+hover_tw_neg_translate_x_4 : Html.Attribute msg
+hover_tw_neg_translate_x_4 =
+    A.class "hover:tw--translate-x-4"
+
+
+hover_tw_neg_translate_x_5 : Html.Attribute msg
+hover_tw_neg_translate_x_5 =
+    A.class "hover:tw--translate-x-5"
+
+
+hover_tw_neg_translate_x_6 : Html.Attribute msg
+hover_tw_neg_translate_x_6 =
+    A.class "hover:tw--translate-x-6"
+
+
+hover_tw_neg_translate_x_8 : Html.Attribute msg
+hover_tw_neg_translate_x_8 =
+    A.class "hover:tw--translate-x-8"
+
+
+hover_tw_neg_translate_x_10 : Html.Attribute msg
+hover_tw_neg_translate_x_10 =
+    A.class "hover:tw--translate-x-10"
+
+
+hover_tw_neg_translate_x_12 : Html.Attribute msg
+hover_tw_neg_translate_x_12 =
+    A.class "hover:tw--translate-x-12"
+
+
+hover_tw_neg_translate_x_16 : Html.Attribute msg
+hover_tw_neg_translate_x_16 =
+    A.class "hover:tw--translate-x-16"
+
+
+hover_tw_neg_translate_x_20 : Html.Attribute msg
+hover_tw_neg_translate_x_20 =
+    A.class "hover:tw--translate-x-20"
+
+
+hover_tw_neg_translate_x_24 : Html.Attribute msg
+hover_tw_neg_translate_x_24 =
+    A.class "hover:tw--translate-x-24"
+
+
+hover_tw_neg_translate_x_32 : Html.Attribute msg
+hover_tw_neg_translate_x_32 =
+    A.class "hover:tw--translate-x-32"
+
+
+hover_tw_neg_translate_x_40 : Html.Attribute msg
+hover_tw_neg_translate_x_40 =
+    A.class "hover:tw--translate-x-40"
+
+
+hover_tw_neg_translate_x_48 : Html.Attribute msg
+hover_tw_neg_translate_x_48 =
+    A.class "hover:tw--translate-x-48"
+
+
+hover_tw_neg_translate_x_56 : Html.Attribute msg
+hover_tw_neg_translate_x_56 =
+    A.class "hover:tw--translate-x-56"
+
+
+hover_tw_neg_translate_x_64 : Html.Attribute msg
+hover_tw_neg_translate_x_64 =
+    A.class "hover:tw--translate-x-64"
+
+
+hover_tw_neg_translate_x_px : Html.Attribute msg
+hover_tw_neg_translate_x_px =
+    A.class "hover:tw--translate-x-px"
+
+
+hover_tw_neg_translate_x_full : Html.Attribute msg
+hover_tw_neg_translate_x_full =
+    A.class "hover:tw--translate-x-full"
+
+
+hover_tw_neg_translate_x_1over2 : Html.Attribute msg
+hover_tw_neg_translate_x_1over2 =
+    A.class "hover:tw--translate-x-1/2"
+
+
+hover_tw_translate_x_1over2 : Html.Attribute msg
+hover_tw_translate_x_1over2 =
+    A.class "hover:tw-translate-x-1/2"
+
+
+hover_tw_translate_x_full : Html.Attribute msg
+hover_tw_translate_x_full =
+    A.class "hover:tw-translate-x-full"
+
+
+hover_tw_translate_y_0 : Html.Attribute msg
+hover_tw_translate_y_0 =
+    A.class "hover:tw-translate-y-0"
+
+
+hover_tw_translate_y_1 : Html.Attribute msg
+hover_tw_translate_y_1 =
+    A.class "hover:tw-translate-y-1"
+
+
+hover_tw_translate_y_2 : Html.Attribute msg
+hover_tw_translate_y_2 =
+    A.class "hover:tw-translate-y-2"
+
+
+hover_tw_translate_y_3 : Html.Attribute msg
+hover_tw_translate_y_3 =
+    A.class "hover:tw-translate-y-3"
+
+
+hover_tw_translate_y_4 : Html.Attribute msg
+hover_tw_translate_y_4 =
+    A.class "hover:tw-translate-y-4"
+
+
+hover_tw_translate_y_5 : Html.Attribute msg
+hover_tw_translate_y_5 =
+    A.class "hover:tw-translate-y-5"
+
+
+hover_tw_translate_y_6 : Html.Attribute msg
+hover_tw_translate_y_6 =
+    A.class "hover:tw-translate-y-6"
+
+
+hover_tw_translate_y_8 : Html.Attribute msg
+hover_tw_translate_y_8 =
+    A.class "hover:tw-translate-y-8"
+
+
+hover_tw_translate_y_10 : Html.Attribute msg
+hover_tw_translate_y_10 =
+    A.class "hover:tw-translate-y-10"
+
+
+hover_tw_translate_y_12 : Html.Attribute msg
+hover_tw_translate_y_12 =
+    A.class "hover:tw-translate-y-12"
+
+
+hover_tw_translate_y_16 : Html.Attribute msg
+hover_tw_translate_y_16 =
+    A.class "hover:tw-translate-y-16"
+
+
+hover_tw_translate_y_20 : Html.Attribute msg
+hover_tw_translate_y_20 =
+    A.class "hover:tw-translate-y-20"
+
+
+hover_tw_translate_y_24 : Html.Attribute msg
+hover_tw_translate_y_24 =
+    A.class "hover:tw-translate-y-24"
+
+
+hover_tw_translate_y_32 : Html.Attribute msg
+hover_tw_translate_y_32 =
+    A.class "hover:tw-translate-y-32"
+
+
+hover_tw_translate_y_40 : Html.Attribute msg
+hover_tw_translate_y_40 =
+    A.class "hover:tw-translate-y-40"
+
+
+hover_tw_translate_y_48 : Html.Attribute msg
+hover_tw_translate_y_48 =
+    A.class "hover:tw-translate-y-48"
+
+
+hover_tw_translate_y_56 : Html.Attribute msg
+hover_tw_translate_y_56 =
+    A.class "hover:tw-translate-y-56"
+
+
+hover_tw_translate_y_64 : Html.Attribute msg
+hover_tw_translate_y_64 =
+    A.class "hover:tw-translate-y-64"
+
+
+hover_tw_translate_y_px : Html.Attribute msg
+hover_tw_translate_y_px =
+    A.class "hover:tw-translate-y-px"
+
+
+hover_tw_neg_translate_y_1 : Html.Attribute msg
+hover_tw_neg_translate_y_1 =
+    A.class "hover:tw--translate-y-1"
+
+
+hover_tw_neg_translate_y_2 : Html.Attribute msg
+hover_tw_neg_translate_y_2 =
+    A.class "hover:tw--translate-y-2"
+
+
+hover_tw_neg_translate_y_3 : Html.Attribute msg
+hover_tw_neg_translate_y_3 =
+    A.class "hover:tw--translate-y-3"
+
+
+hover_tw_neg_translate_y_4 : Html.Attribute msg
+hover_tw_neg_translate_y_4 =
+    A.class "hover:tw--translate-y-4"
+
+
+hover_tw_neg_translate_y_5 : Html.Attribute msg
+hover_tw_neg_translate_y_5 =
+    A.class "hover:tw--translate-y-5"
+
+
+hover_tw_neg_translate_y_6 : Html.Attribute msg
+hover_tw_neg_translate_y_6 =
+    A.class "hover:tw--translate-y-6"
+
+
+hover_tw_neg_translate_y_8 : Html.Attribute msg
+hover_tw_neg_translate_y_8 =
+    A.class "hover:tw--translate-y-8"
+
+
+hover_tw_neg_translate_y_10 : Html.Attribute msg
+hover_tw_neg_translate_y_10 =
+    A.class "hover:tw--translate-y-10"
+
+
+hover_tw_neg_translate_y_12 : Html.Attribute msg
+hover_tw_neg_translate_y_12 =
+    A.class "hover:tw--translate-y-12"
+
+
+hover_tw_neg_translate_y_16 : Html.Attribute msg
+hover_tw_neg_translate_y_16 =
+    A.class "hover:tw--translate-y-16"
+
+
+hover_tw_neg_translate_y_20 : Html.Attribute msg
+hover_tw_neg_translate_y_20 =
+    A.class "hover:tw--translate-y-20"
+
+
+hover_tw_neg_translate_y_24 : Html.Attribute msg
+hover_tw_neg_translate_y_24 =
+    A.class "hover:tw--translate-y-24"
+
+
+hover_tw_neg_translate_y_32 : Html.Attribute msg
+hover_tw_neg_translate_y_32 =
+    A.class "hover:tw--translate-y-32"
+
+
+hover_tw_neg_translate_y_40 : Html.Attribute msg
+hover_tw_neg_translate_y_40 =
+    A.class "hover:tw--translate-y-40"
+
+
+hover_tw_neg_translate_y_48 : Html.Attribute msg
+hover_tw_neg_translate_y_48 =
+    A.class "hover:tw--translate-y-48"
+
+
+hover_tw_neg_translate_y_56 : Html.Attribute msg
+hover_tw_neg_translate_y_56 =
+    A.class "hover:tw--translate-y-56"
+
+
+hover_tw_neg_translate_y_64 : Html.Attribute msg
+hover_tw_neg_translate_y_64 =
+    A.class "hover:tw--translate-y-64"
+
+
+hover_tw_neg_translate_y_px : Html.Attribute msg
+hover_tw_neg_translate_y_px =
+    A.class "hover:tw--translate-y-px"
+
+
+hover_tw_neg_translate_y_full : Html.Attribute msg
+hover_tw_neg_translate_y_full =
+    A.class "hover:tw--translate-y-full"
+
+
+hover_tw_neg_translate_y_1over2 : Html.Attribute msg
+hover_tw_neg_translate_y_1over2 =
+    A.class "hover:tw--translate-y-1/2"
+
+
+hover_tw_translate_y_1over2 : Html.Attribute msg
+hover_tw_translate_y_1over2 =
+    A.class "hover:tw-translate-y-1/2"
+
+
+hover_tw_translate_y_full : Html.Attribute msg
+hover_tw_translate_y_full =
+    A.class "hover:tw-translate-y-full"
+
+
+focus_tw_translate_x_0 : Html.Attribute msg
+focus_tw_translate_x_0 =
+    A.class "focus:tw-translate-x-0"
+
+
+focus_tw_translate_x_1 : Html.Attribute msg
+focus_tw_translate_x_1 =
+    A.class "focus:tw-translate-x-1"
+
+
+focus_tw_translate_x_2 : Html.Attribute msg
+focus_tw_translate_x_2 =
+    A.class "focus:tw-translate-x-2"
+
+
+focus_tw_translate_x_3 : Html.Attribute msg
+focus_tw_translate_x_3 =
+    A.class "focus:tw-translate-x-3"
+
+
+focus_tw_translate_x_4 : Html.Attribute msg
+focus_tw_translate_x_4 =
+    A.class "focus:tw-translate-x-4"
+
+
+focus_tw_translate_x_5 : Html.Attribute msg
+focus_tw_translate_x_5 =
+    A.class "focus:tw-translate-x-5"
+
+
+focus_tw_translate_x_6 : Html.Attribute msg
+focus_tw_translate_x_6 =
+    A.class "focus:tw-translate-x-6"
+
+
+focus_tw_translate_x_8 : Html.Attribute msg
+focus_tw_translate_x_8 =
+    A.class "focus:tw-translate-x-8"
+
+
+focus_tw_translate_x_10 : Html.Attribute msg
+focus_tw_translate_x_10 =
+    A.class "focus:tw-translate-x-10"
+
+
+focus_tw_translate_x_12 : Html.Attribute msg
+focus_tw_translate_x_12 =
+    A.class "focus:tw-translate-x-12"
+
+
+focus_tw_translate_x_16 : Html.Attribute msg
+focus_tw_translate_x_16 =
+    A.class "focus:tw-translate-x-16"
+
+
+focus_tw_translate_x_20 : Html.Attribute msg
+focus_tw_translate_x_20 =
+    A.class "focus:tw-translate-x-20"
+
+
+focus_tw_translate_x_24 : Html.Attribute msg
+focus_tw_translate_x_24 =
+    A.class "focus:tw-translate-x-24"
+
+
+focus_tw_translate_x_32 : Html.Attribute msg
+focus_tw_translate_x_32 =
+    A.class "focus:tw-translate-x-32"
+
+
+focus_tw_translate_x_40 : Html.Attribute msg
+focus_tw_translate_x_40 =
+    A.class "focus:tw-translate-x-40"
+
+
+focus_tw_translate_x_48 : Html.Attribute msg
+focus_tw_translate_x_48 =
+    A.class "focus:tw-translate-x-48"
+
+
+focus_tw_translate_x_56 : Html.Attribute msg
+focus_tw_translate_x_56 =
+    A.class "focus:tw-translate-x-56"
+
+
+focus_tw_translate_x_64 : Html.Attribute msg
+focus_tw_translate_x_64 =
+    A.class "focus:tw-translate-x-64"
+
+
+focus_tw_translate_x_px : Html.Attribute msg
+focus_tw_translate_x_px =
+    A.class "focus:tw-translate-x-px"
+
+
+focus_tw_neg_translate_x_1 : Html.Attribute msg
+focus_tw_neg_translate_x_1 =
+    A.class "focus:tw--translate-x-1"
+
+
+focus_tw_neg_translate_x_2 : Html.Attribute msg
+focus_tw_neg_translate_x_2 =
+    A.class "focus:tw--translate-x-2"
+
+
+focus_tw_neg_translate_x_3 : Html.Attribute msg
+focus_tw_neg_translate_x_3 =
+    A.class "focus:tw--translate-x-3"
+
+
+focus_tw_neg_translate_x_4 : Html.Attribute msg
+focus_tw_neg_translate_x_4 =
+    A.class "focus:tw--translate-x-4"
+
+
+focus_tw_neg_translate_x_5 : Html.Attribute msg
+focus_tw_neg_translate_x_5 =
+    A.class "focus:tw--translate-x-5"
+
+
+focus_tw_neg_translate_x_6 : Html.Attribute msg
+focus_tw_neg_translate_x_6 =
+    A.class "focus:tw--translate-x-6"
+
+
+focus_tw_neg_translate_x_8 : Html.Attribute msg
+focus_tw_neg_translate_x_8 =
+    A.class "focus:tw--translate-x-8"
+
+
+focus_tw_neg_translate_x_10 : Html.Attribute msg
+focus_tw_neg_translate_x_10 =
+    A.class "focus:tw--translate-x-10"
+
+
+focus_tw_neg_translate_x_12 : Html.Attribute msg
+focus_tw_neg_translate_x_12 =
+    A.class "focus:tw--translate-x-12"
+
+
+focus_tw_neg_translate_x_16 : Html.Attribute msg
+focus_tw_neg_translate_x_16 =
+    A.class "focus:tw--translate-x-16"
+
+
+focus_tw_neg_translate_x_20 : Html.Attribute msg
+focus_tw_neg_translate_x_20 =
+    A.class "focus:tw--translate-x-20"
+
+
+focus_tw_neg_translate_x_24 : Html.Attribute msg
+focus_tw_neg_translate_x_24 =
+    A.class "focus:tw--translate-x-24"
+
+
+focus_tw_neg_translate_x_32 : Html.Attribute msg
+focus_tw_neg_translate_x_32 =
+    A.class "focus:tw--translate-x-32"
+
+
+focus_tw_neg_translate_x_40 : Html.Attribute msg
+focus_tw_neg_translate_x_40 =
+    A.class "focus:tw--translate-x-40"
+
+
+focus_tw_neg_translate_x_48 : Html.Attribute msg
+focus_tw_neg_translate_x_48 =
+    A.class "focus:tw--translate-x-48"
+
+
+focus_tw_neg_translate_x_56 : Html.Attribute msg
+focus_tw_neg_translate_x_56 =
+    A.class "focus:tw--translate-x-56"
+
+
+focus_tw_neg_translate_x_64 : Html.Attribute msg
+focus_tw_neg_translate_x_64 =
+    A.class "focus:tw--translate-x-64"
+
+
+focus_tw_neg_translate_x_px : Html.Attribute msg
+focus_tw_neg_translate_x_px =
+    A.class "focus:tw--translate-x-px"
+
+
+focus_tw_neg_translate_x_full : Html.Attribute msg
+focus_tw_neg_translate_x_full =
+    A.class "focus:tw--translate-x-full"
+
+
+focus_tw_neg_translate_x_1over2 : Html.Attribute msg
+focus_tw_neg_translate_x_1over2 =
+    A.class "focus:tw--translate-x-1/2"
+
+
+focus_tw_translate_x_1over2 : Html.Attribute msg
+focus_tw_translate_x_1over2 =
+    A.class "focus:tw-translate-x-1/2"
+
+
+focus_tw_translate_x_full : Html.Attribute msg
+focus_tw_translate_x_full =
+    A.class "focus:tw-translate-x-full"
+
+
+focus_tw_translate_y_0 : Html.Attribute msg
+focus_tw_translate_y_0 =
+    A.class "focus:tw-translate-y-0"
+
+
+focus_tw_translate_y_1 : Html.Attribute msg
+focus_tw_translate_y_1 =
+    A.class "focus:tw-translate-y-1"
+
+
+focus_tw_translate_y_2 : Html.Attribute msg
+focus_tw_translate_y_2 =
+    A.class "focus:tw-translate-y-2"
+
+
+focus_tw_translate_y_3 : Html.Attribute msg
+focus_tw_translate_y_3 =
+    A.class "focus:tw-translate-y-3"
+
+
+focus_tw_translate_y_4 : Html.Attribute msg
+focus_tw_translate_y_4 =
+    A.class "focus:tw-translate-y-4"
+
+
+focus_tw_translate_y_5 : Html.Attribute msg
+focus_tw_translate_y_5 =
+    A.class "focus:tw-translate-y-5"
+
+
+focus_tw_translate_y_6 : Html.Attribute msg
+focus_tw_translate_y_6 =
+    A.class "focus:tw-translate-y-6"
+
+
+focus_tw_translate_y_8 : Html.Attribute msg
+focus_tw_translate_y_8 =
+    A.class "focus:tw-translate-y-8"
+
+
+focus_tw_translate_y_10 : Html.Attribute msg
+focus_tw_translate_y_10 =
+    A.class "focus:tw-translate-y-10"
+
+
+focus_tw_translate_y_12 : Html.Attribute msg
+focus_tw_translate_y_12 =
+    A.class "focus:tw-translate-y-12"
+
+
+focus_tw_translate_y_16 : Html.Attribute msg
+focus_tw_translate_y_16 =
+    A.class "focus:tw-translate-y-16"
+
+
+focus_tw_translate_y_20 : Html.Attribute msg
+focus_tw_translate_y_20 =
+    A.class "focus:tw-translate-y-20"
+
+
+focus_tw_translate_y_24 : Html.Attribute msg
+focus_tw_translate_y_24 =
+    A.class "focus:tw-translate-y-24"
+
+
+focus_tw_translate_y_32 : Html.Attribute msg
+focus_tw_translate_y_32 =
+    A.class "focus:tw-translate-y-32"
+
+
+focus_tw_translate_y_40 : Html.Attribute msg
+focus_tw_translate_y_40 =
+    A.class "focus:tw-translate-y-40"
+
+
+focus_tw_translate_y_48 : Html.Attribute msg
+focus_tw_translate_y_48 =
+    A.class "focus:tw-translate-y-48"
+
+
+focus_tw_translate_y_56 : Html.Attribute msg
+focus_tw_translate_y_56 =
+    A.class "focus:tw-translate-y-56"
+
+
+focus_tw_translate_y_64 : Html.Attribute msg
+focus_tw_translate_y_64 =
+    A.class "focus:tw-translate-y-64"
+
+
+focus_tw_translate_y_px : Html.Attribute msg
+focus_tw_translate_y_px =
+    A.class "focus:tw-translate-y-px"
+
+
+focus_tw_neg_translate_y_1 : Html.Attribute msg
+focus_tw_neg_translate_y_1 =
+    A.class "focus:tw--translate-y-1"
+
+
+focus_tw_neg_translate_y_2 : Html.Attribute msg
+focus_tw_neg_translate_y_2 =
+    A.class "focus:tw--translate-y-2"
+
+
+focus_tw_neg_translate_y_3 : Html.Attribute msg
+focus_tw_neg_translate_y_3 =
+    A.class "focus:tw--translate-y-3"
+
+
+focus_tw_neg_translate_y_4 : Html.Attribute msg
+focus_tw_neg_translate_y_4 =
+    A.class "focus:tw--translate-y-4"
+
+
+focus_tw_neg_translate_y_5 : Html.Attribute msg
+focus_tw_neg_translate_y_5 =
+    A.class "focus:tw--translate-y-5"
+
+
+focus_tw_neg_translate_y_6 : Html.Attribute msg
+focus_tw_neg_translate_y_6 =
+    A.class "focus:tw--translate-y-6"
+
+
+focus_tw_neg_translate_y_8 : Html.Attribute msg
+focus_tw_neg_translate_y_8 =
+    A.class "focus:tw--translate-y-8"
+
+
+focus_tw_neg_translate_y_10 : Html.Attribute msg
+focus_tw_neg_translate_y_10 =
+    A.class "focus:tw--translate-y-10"
+
+
+focus_tw_neg_translate_y_12 : Html.Attribute msg
+focus_tw_neg_translate_y_12 =
+    A.class "focus:tw--translate-y-12"
+
+
+focus_tw_neg_translate_y_16 : Html.Attribute msg
+focus_tw_neg_translate_y_16 =
+    A.class "focus:tw--translate-y-16"
+
+
+focus_tw_neg_translate_y_20 : Html.Attribute msg
+focus_tw_neg_translate_y_20 =
+    A.class "focus:tw--translate-y-20"
+
+
+focus_tw_neg_translate_y_24 : Html.Attribute msg
+focus_tw_neg_translate_y_24 =
+    A.class "focus:tw--translate-y-24"
+
+
+focus_tw_neg_translate_y_32 : Html.Attribute msg
+focus_tw_neg_translate_y_32 =
+    A.class "focus:tw--translate-y-32"
+
+
+focus_tw_neg_translate_y_40 : Html.Attribute msg
+focus_tw_neg_translate_y_40 =
+    A.class "focus:tw--translate-y-40"
+
+
+focus_tw_neg_translate_y_48 : Html.Attribute msg
+focus_tw_neg_translate_y_48 =
+    A.class "focus:tw--translate-y-48"
+
+
+focus_tw_neg_translate_y_56 : Html.Attribute msg
+focus_tw_neg_translate_y_56 =
+    A.class "focus:tw--translate-y-56"
+
+
+focus_tw_neg_translate_y_64 : Html.Attribute msg
+focus_tw_neg_translate_y_64 =
+    A.class "focus:tw--translate-y-64"
+
+
+focus_tw_neg_translate_y_px : Html.Attribute msg
+focus_tw_neg_translate_y_px =
+    A.class "focus:tw--translate-y-px"
+
+
+focus_tw_neg_translate_y_full : Html.Attribute msg
+focus_tw_neg_translate_y_full =
+    A.class "focus:tw--translate-y-full"
+
+
+focus_tw_neg_translate_y_1over2 : Html.Attribute msg
+focus_tw_neg_translate_y_1over2 =
+    A.class "focus:tw--translate-y-1/2"
+
+
+focus_tw_translate_y_1over2 : Html.Attribute msg
+focus_tw_translate_y_1over2 =
+    A.class "focus:tw-translate-y-1/2"
+
+
+focus_tw_translate_y_full : Html.Attribute msg
+focus_tw_translate_y_full =
+    A.class "focus:tw-translate-y-full"
+
+
+tw_skew_x_0 : Html.Attribute msg
+tw_skew_x_0 =
+    A.class "tw-skew-x-0"
+
+
+tw_skew_x_3 : Html.Attribute msg
+tw_skew_x_3 =
+    A.class "tw-skew-x-3"
+
+
+tw_skew_x_6 : Html.Attribute msg
+tw_skew_x_6 =
+    A.class "tw-skew-x-6"
+
+
+tw_skew_x_12 : Html.Attribute msg
+tw_skew_x_12 =
+    A.class "tw-skew-x-12"
+
+
+tw_neg_skew_x_12 : Html.Attribute msg
+tw_neg_skew_x_12 =
+    A.class "tw--skew-x-12"
+
+
+tw_neg_skew_x_6 : Html.Attribute msg
+tw_neg_skew_x_6 =
+    A.class "tw--skew-x-6"
+
+
+tw_neg_skew_x_3 : Html.Attribute msg
+tw_neg_skew_x_3 =
+    A.class "tw--skew-x-3"
+
+
+tw_skew_y_0 : Html.Attribute msg
+tw_skew_y_0 =
+    A.class "tw-skew-y-0"
+
+
+tw_skew_y_3 : Html.Attribute msg
+tw_skew_y_3 =
+    A.class "tw-skew-y-3"
+
+
+tw_skew_y_6 : Html.Attribute msg
+tw_skew_y_6 =
+    A.class "tw-skew-y-6"
+
+
+tw_skew_y_12 : Html.Attribute msg
+tw_skew_y_12 =
+    A.class "tw-skew-y-12"
+
+
+tw_neg_skew_y_12 : Html.Attribute msg
+tw_neg_skew_y_12 =
+    A.class "tw--skew-y-12"
+
+
+tw_neg_skew_y_6 : Html.Attribute msg
+tw_neg_skew_y_6 =
+    A.class "tw--skew-y-6"
+
+
+tw_neg_skew_y_3 : Html.Attribute msg
+tw_neg_skew_y_3 =
+    A.class "tw--skew-y-3"
+
+
+hover_tw_skew_x_0 : Html.Attribute msg
+hover_tw_skew_x_0 =
+    A.class "hover:tw-skew-x-0"
+
+
+hover_tw_skew_x_3 : Html.Attribute msg
+hover_tw_skew_x_3 =
+    A.class "hover:tw-skew-x-3"
+
+
+hover_tw_skew_x_6 : Html.Attribute msg
+hover_tw_skew_x_6 =
+    A.class "hover:tw-skew-x-6"
+
+
+hover_tw_skew_x_12 : Html.Attribute msg
+hover_tw_skew_x_12 =
+    A.class "hover:tw-skew-x-12"
+
+
+hover_tw_neg_skew_x_12 : Html.Attribute msg
+hover_tw_neg_skew_x_12 =
+    A.class "hover:tw--skew-x-12"
+
+
+hover_tw_neg_skew_x_6 : Html.Attribute msg
+hover_tw_neg_skew_x_6 =
+    A.class "hover:tw--skew-x-6"
+
+
+hover_tw_neg_skew_x_3 : Html.Attribute msg
+hover_tw_neg_skew_x_3 =
+    A.class "hover:tw--skew-x-3"
+
+
+hover_tw_skew_y_0 : Html.Attribute msg
+hover_tw_skew_y_0 =
+    A.class "hover:tw-skew-y-0"
+
+
+hover_tw_skew_y_3 : Html.Attribute msg
+hover_tw_skew_y_3 =
+    A.class "hover:tw-skew-y-3"
+
+
+hover_tw_skew_y_6 : Html.Attribute msg
+hover_tw_skew_y_6 =
+    A.class "hover:tw-skew-y-6"
+
+
+hover_tw_skew_y_12 : Html.Attribute msg
+hover_tw_skew_y_12 =
+    A.class "hover:tw-skew-y-12"
+
+
+hover_tw_neg_skew_y_12 : Html.Attribute msg
+hover_tw_neg_skew_y_12 =
+    A.class "hover:tw--skew-y-12"
+
+
+hover_tw_neg_skew_y_6 : Html.Attribute msg
+hover_tw_neg_skew_y_6 =
+    A.class "hover:tw--skew-y-6"
+
+
+hover_tw_neg_skew_y_3 : Html.Attribute msg
+hover_tw_neg_skew_y_3 =
+    A.class "hover:tw--skew-y-3"
+
+
+focus_tw_skew_x_0 : Html.Attribute msg
+focus_tw_skew_x_0 =
+    A.class "focus:tw-skew-x-0"
+
+
+focus_tw_skew_x_3 : Html.Attribute msg
+focus_tw_skew_x_3 =
+    A.class "focus:tw-skew-x-3"
+
+
+focus_tw_skew_x_6 : Html.Attribute msg
+focus_tw_skew_x_6 =
+    A.class "focus:tw-skew-x-6"
+
+
+focus_tw_skew_x_12 : Html.Attribute msg
+focus_tw_skew_x_12 =
+    A.class "focus:tw-skew-x-12"
+
+
+focus_tw_neg_skew_x_12 : Html.Attribute msg
+focus_tw_neg_skew_x_12 =
+    A.class "focus:tw--skew-x-12"
+
+
+focus_tw_neg_skew_x_6 : Html.Attribute msg
+focus_tw_neg_skew_x_6 =
+    A.class "focus:tw--skew-x-6"
+
+
+focus_tw_neg_skew_x_3 : Html.Attribute msg
+focus_tw_neg_skew_x_3 =
+    A.class "focus:tw--skew-x-3"
+
+
+focus_tw_skew_y_0 : Html.Attribute msg
+focus_tw_skew_y_0 =
+    A.class "focus:tw-skew-y-0"
+
+
+focus_tw_skew_y_3 : Html.Attribute msg
+focus_tw_skew_y_3 =
+    A.class "focus:tw-skew-y-3"
+
+
+focus_tw_skew_y_6 : Html.Attribute msg
+focus_tw_skew_y_6 =
+    A.class "focus:tw-skew-y-6"
+
+
+focus_tw_skew_y_12 : Html.Attribute msg
+focus_tw_skew_y_12 =
+    A.class "focus:tw-skew-y-12"
+
+
+focus_tw_neg_skew_y_12 : Html.Attribute msg
+focus_tw_neg_skew_y_12 =
+    A.class "focus:tw--skew-y-12"
+
+
+focus_tw_neg_skew_y_6 : Html.Attribute msg
+focus_tw_neg_skew_y_6 =
+    A.class "focus:tw--skew-y-6"
+
+
+focus_tw_neg_skew_y_3 : Html.Attribute msg
+focus_tw_neg_skew_y_3 =
+    A.class "focus:tw--skew-y-3"
+
+
+tw_transition_none : Html.Attribute msg
+tw_transition_none =
+    A.class "tw-transition-none"
+
+
+tw_transition_all : Html.Attribute msg
+tw_transition_all =
+    A.class "tw-transition-all"
+
+
+tw_transition : Html.Attribute msg
+tw_transition =
+    A.class "tw-transition"
+
+
+tw_transition_colors : Html.Attribute msg
+tw_transition_colors =
+    A.class "tw-transition-colors"
+
+
+tw_transition_opacity : Html.Attribute msg
+tw_transition_opacity =
+    A.class "tw-transition-opacity"
+
+
+tw_transition_shadow : Html.Attribute msg
+tw_transition_shadow =
+    A.class "tw-transition-shadow"
+
+
+tw_transition_transform : Html.Attribute msg
+tw_transition_transform =
+    A.class "tw-transition-transform"
+
+
+tw_ease_linear : Html.Attribute msg
+tw_ease_linear =
+    A.class "tw-ease-linear"
+
+
+tw_ease_in : Html.Attribute msg
+tw_ease_in =
+    A.class "tw-ease-in"
+
+
+tw_ease_out : Html.Attribute msg
+tw_ease_out =
+    A.class "tw-ease-out"
+
+
+tw_ease_in_out : Html.Attribute msg
+tw_ease_in_out =
+    A.class "tw-ease-in-out"
+
+
+tw_duration_75 : Html.Attribute msg
+tw_duration_75 =
+    A.class "tw-duration-75"
+
+
+tw_duration_100 : Html.Attribute msg
+tw_duration_100 =
+    A.class "tw-duration-100"
+
+
+tw_duration_150 : Html.Attribute msg
+tw_duration_150 =
+    A.class "tw-duration-150"
+
+
+tw_duration_200 : Html.Attribute msg
+tw_duration_200 =
+    A.class "tw-duration-200"
+
+
+tw_duration_300 : Html.Attribute msg
+tw_duration_300 =
+    A.class "tw-duration-300"
+
+
+tw_duration_500 : Html.Attribute msg
+tw_duration_500 =
+    A.class "tw-duration-500"
+
+
+tw_duration_700 : Html.Attribute msg
+tw_duration_700 =
+    A.class "tw-duration-700"
+
+
+tw_duration_1000 : Html.Attribute msg
+tw_duration_1000 =
+    A.class "tw-duration-1000"
 
 
 sm_tw_sr_only : Html.Attribute msg
@@ -21898,6 +28078,11 @@ sm_tw_rounded =
     A.class "sm:tw-rounded"
 
 
+sm_tw_rounded_md : Html.Attribute msg
+sm_tw_rounded_md =
+    A.class "sm:tw-rounded-md"
+
+
 sm_tw_rounded_lg : Html.Attribute msg
 sm_tw_rounded_lg =
     A.class "sm:tw-rounded-lg"
@@ -21966,6 +28151,26 @@ sm_tw_rounded_b =
 sm_tw_rounded_l : Html.Attribute msg
 sm_tw_rounded_l =
     A.class "sm:tw-rounded-l"
+
+
+sm_tw_rounded_t_md : Html.Attribute msg
+sm_tw_rounded_t_md =
+    A.class "sm:tw-rounded-t-md"
+
+
+sm_tw_rounded_r_md : Html.Attribute msg
+sm_tw_rounded_r_md =
+    A.class "sm:tw-rounded-r-md"
+
+
+sm_tw_rounded_b_md : Html.Attribute msg
+sm_tw_rounded_b_md =
+    A.class "sm:tw-rounded-b-md"
+
+
+sm_tw_rounded_l_md : Html.Attribute msg
+sm_tw_rounded_l_md =
+    A.class "sm:tw-rounded-l-md"
 
 
 sm_tw_rounded_t_lg : Html.Attribute msg
@@ -22066,6 +28271,26 @@ sm_tw_rounded_br =
 sm_tw_rounded_bl : Html.Attribute msg
 sm_tw_rounded_bl =
     A.class "sm:tw-rounded-bl"
+
+
+sm_tw_rounded_tl_md : Html.Attribute msg
+sm_tw_rounded_tl_md =
+    A.class "sm:tw-rounded-tl-md"
+
+
+sm_tw_rounded_tr_md : Html.Attribute msg
+sm_tw_rounded_tr_md =
+    A.class "sm:tw-rounded-tr-md"
+
+
+sm_tw_rounded_br_md : Html.Attribute msg
+sm_tw_rounded_br_md =
+    A.class "sm:tw-rounded-br-md"
+
+
+sm_tw_rounded_bl_md : Html.Attribute msg
+sm_tw_rounded_bl_md =
+    A.class "sm:tw-rounded-bl-md"
 
 
 sm_tw_rounded_tl_lg : Html.Attribute msg
@@ -22258,6 +28483,16 @@ sm_tw_border_l =
     A.class "sm:tw-border-l"
 
 
+sm_tw_box_border : Html.Attribute msg
+sm_tw_box_border =
+    A.class "sm:tw-box-border"
+
+
+sm_tw_box_content : Html.Attribute msg
+sm_tw_box_content =
+    A.class "sm:tw-box-content"
+
+
 sm_tw_cursor_auto : Html.Attribute msg
 sm_tw_cursor_auto =
     A.class "sm:tw-cursor-auto"
@@ -22318,19 +28553,54 @@ sm_tw_inline_flex =
     A.class "sm:tw-inline-flex"
 
 
+sm_tw_grid : Html.Attribute msg
+sm_tw_grid =
+    A.class "sm:tw-grid"
+
+
 sm_tw_table : Html.Attribute msg
 sm_tw_table =
     A.class "sm:tw-table"
 
 
-sm_tw_table_row : Html.Attribute msg
-sm_tw_table_row =
-    A.class "sm:tw-table-row"
+sm_tw_table_caption : Html.Attribute msg
+sm_tw_table_caption =
+    A.class "sm:tw-table-caption"
 
 
 sm_tw_table_cell : Html.Attribute msg
 sm_tw_table_cell =
     A.class "sm:tw-table-cell"
+
+
+sm_tw_table_column : Html.Attribute msg
+sm_tw_table_column =
+    A.class "sm:tw-table-column"
+
+
+sm_tw_table_column_group : Html.Attribute msg
+sm_tw_table_column_group =
+    A.class "sm:tw-table-column-group"
+
+
+sm_tw_table_footer_group : Html.Attribute msg
+sm_tw_table_footer_group =
+    A.class "sm:tw-table-footer-group"
+
+
+sm_tw_table_header_group : Html.Attribute msg
+sm_tw_table_header_group =
+    A.class "sm:tw-table-header-group"
+
+
+sm_tw_table_row_group : Html.Attribute msg
+sm_tw_table_row_group =
+    A.class "sm:tw-table-row-group"
+
+
+sm_tw_table_row : Html.Attribute msg
+sm_tw_table_row =
+    A.class "sm:tw-table-row"
 
 
 sm_tw_hidden : Html.Attribute msg
@@ -22446,6 +28716,11 @@ sm_tw_justify_between =
 sm_tw_justify_around : Html.Attribute msg
 sm_tw_justify_around =
     A.class "sm:tw-justify-around"
+
+
+sm_tw_justify_evenly : Html.Attribute msg
+sm_tw_justify_evenly =
+    A.class "sm:tw-justify-evenly"
 
 
 sm_tw_content_center : Html.Attribute msg
@@ -22606,6 +28881,21 @@ sm_tw_float_none =
 sm_tw_clearfix_after : Html.Attribute msg
 sm_tw_clearfix_after =
     A.class "sm:tw-clearfix:after"
+
+
+sm_tw_clear_left : Html.Attribute msg
+sm_tw_clear_left =
+    A.class "sm:tw-clear-left"
+
+
+sm_tw_clear_right : Html.Attribute msg
+sm_tw_clear_right =
+    A.class "sm:tw-clear-right"
+
+
+sm_tw_clear_both : Html.Attribute msg
+sm_tw_clear_both =
+    A.class "sm:tw-clear-both"
 
 
 sm_tw_font_sans : Html.Attribute msg
@@ -22866,6 +29156,46 @@ sm_tw_h_full =
 sm_tw_h_screen : Html.Attribute msg
 sm_tw_h_screen =
     A.class "sm:tw-h-screen"
+
+
+sm_tw_leading_3 : Html.Attribute msg
+sm_tw_leading_3 =
+    A.class "sm:tw-leading-3"
+
+
+sm_tw_leading_4 : Html.Attribute msg
+sm_tw_leading_4 =
+    A.class "sm:tw-leading-4"
+
+
+sm_tw_leading_5 : Html.Attribute msg
+sm_tw_leading_5 =
+    A.class "sm:tw-leading-5"
+
+
+sm_tw_leading_6 : Html.Attribute msg
+sm_tw_leading_6 =
+    A.class "sm:tw-leading-6"
+
+
+sm_tw_leading_7 : Html.Attribute msg
+sm_tw_leading_7 =
+    A.class "sm:tw-leading-7"
+
+
+sm_tw_leading_8 : Html.Attribute msg
+sm_tw_leading_8 =
+    A.class "sm:tw-leading-8"
+
+
+sm_tw_leading_9 : Html.Attribute msg
+sm_tw_leading_9 =
+    A.class "sm:tw-leading-9"
+
+
+sm_tw_leading_10 : Html.Attribute msg
+sm_tw_leading_10 =
+    A.class "sm:tw-leading-10"
 
 
 sm_tw_leading_none : Html.Attribute msg
@@ -24263,6 +30593,11 @@ sm_tw_max_h_screen =
     A.class "sm:tw-max-h-screen"
 
 
+sm_tw_max_w_none : Html.Attribute msg
+sm_tw_max_w_none =
+    A.class "sm:tw-max-w-none"
+
+
 sm_tw_max_w_xs : Html.Attribute msg
 sm_tw_max_w_xs =
     A.class "sm:tw-max-w-xs"
@@ -24316,6 +30651,26 @@ sm_tw_max_w_6xl =
 sm_tw_max_w_full : Html.Attribute msg
 sm_tw_max_w_full =
     A.class "sm:tw-max-w-full"
+
+
+sm_tw_max_w_screen_sm : Html.Attribute msg
+sm_tw_max_w_screen_sm =
+    A.class "sm:tw-max-w-screen-sm"
+
+
+sm_tw_max_w_screen_md : Html.Attribute msg
+sm_tw_max_w_screen_md =
+    A.class "sm:tw-max-w-screen-md"
+
+
+sm_tw_max_w_screen_lg : Html.Attribute msg
+sm_tw_max_w_screen_lg =
+    A.class "sm:tw-max-w-screen-lg"
+
+
+sm_tw_max_w_screen_xl : Html.Attribute msg
+sm_tw_max_w_screen_xl =
+    A.class "sm:tw-max-w-screen-xl"
 
 
 sm_tw_min_h_0 : Html.Attribute msg
@@ -26288,6 +32643,16 @@ sm_tw_resize =
     A.class "sm:tw-resize"
 
 
+sm_tw_shadow_xs : Html.Attribute msg
+sm_tw_shadow_xs =
+    A.class "sm:tw-shadow-xs"
+
+
+sm_tw_shadow_sm : Html.Attribute msg
+sm_tw_shadow_sm =
+    A.class "sm:tw-shadow-sm"
+
+
 sm_tw_shadow : Html.Attribute msg
 sm_tw_shadow =
     A.class "sm:tw-shadow"
@@ -26328,6 +32693,16 @@ sm_tw_shadow_none =
     A.class "sm:tw-shadow-none"
 
 
+sm_hover_tw_shadow_xs : Html.Attribute msg
+sm_hover_tw_shadow_xs =
+    A.class "sm:hover:tw-shadow-xs"
+
+
+sm_hover_tw_shadow_sm : Html.Attribute msg
+sm_hover_tw_shadow_sm =
+    A.class "sm:hover:tw-shadow-sm"
+
+
 sm_hover_tw_shadow : Html.Attribute msg
 sm_hover_tw_shadow =
     A.class "sm:hover:tw-shadow"
@@ -26366,6 +32741,16 @@ sm_hover_tw_shadow_outline =
 sm_hover_tw_shadow_none : Html.Attribute msg
 sm_hover_tw_shadow_none =
     A.class "sm:hover:tw-shadow-none"
+
+
+sm_focus_tw_shadow_xs : Html.Attribute msg
+sm_focus_tw_shadow_xs =
+    A.class "sm:focus:tw-shadow-xs"
+
+
+sm_focus_tw_shadow_sm : Html.Attribute msg
+sm_focus_tw_shadow_sm =
+    A.class "sm:focus:tw-shadow-sm"
 
 
 sm_focus_tw_shadow : Html.Attribute msg
@@ -26416,6 +32801,21 @@ sm_tw_fill_current =
 sm_tw_stroke_current : Html.Attribute msg
 sm_tw_stroke_current =
     A.class "sm:tw-stroke-current"
+
+
+sm_tw_stroke_0 : Html.Attribute msg
+sm_tw_stroke_0 =
+    A.class "sm:tw-stroke-0"
+
+
+sm_tw_stroke_1 : Html.Attribute msg
+sm_tw_stroke_1 =
+    A.class "sm:tw-stroke-1"
+
+
+sm_tw_stroke_2 : Html.Attribute msg
+sm_tw_stroke_2 =
+    A.class "sm:tw-stroke-2"
 
 
 sm_tw_table_auto : Html.Attribute msg
@@ -28386,6 +34786,2876 @@ sm_tw_z_50 =
 sm_tw_z_auto : Html.Attribute msg
 sm_tw_z_auto =
     A.class "sm:tw-z-auto"
+
+
+sm_tw_gap_0 : Html.Attribute msg
+sm_tw_gap_0 =
+    A.class "sm:tw-gap-0"
+
+
+sm_tw_gap_1 : Html.Attribute msg
+sm_tw_gap_1 =
+    A.class "sm:tw-gap-1"
+
+
+sm_tw_gap_2 : Html.Attribute msg
+sm_tw_gap_2 =
+    A.class "sm:tw-gap-2"
+
+
+sm_tw_gap_3 : Html.Attribute msg
+sm_tw_gap_3 =
+    A.class "sm:tw-gap-3"
+
+
+sm_tw_gap_4 : Html.Attribute msg
+sm_tw_gap_4 =
+    A.class "sm:tw-gap-4"
+
+
+sm_tw_gap_5 : Html.Attribute msg
+sm_tw_gap_5 =
+    A.class "sm:tw-gap-5"
+
+
+sm_tw_gap_6 : Html.Attribute msg
+sm_tw_gap_6 =
+    A.class "sm:tw-gap-6"
+
+
+sm_tw_gap_8 : Html.Attribute msg
+sm_tw_gap_8 =
+    A.class "sm:tw-gap-8"
+
+
+sm_tw_gap_10 : Html.Attribute msg
+sm_tw_gap_10 =
+    A.class "sm:tw-gap-10"
+
+
+sm_tw_gap_12 : Html.Attribute msg
+sm_tw_gap_12 =
+    A.class "sm:tw-gap-12"
+
+
+sm_tw_gap_16 : Html.Attribute msg
+sm_tw_gap_16 =
+    A.class "sm:tw-gap-16"
+
+
+sm_tw_gap_20 : Html.Attribute msg
+sm_tw_gap_20 =
+    A.class "sm:tw-gap-20"
+
+
+sm_tw_gap_24 : Html.Attribute msg
+sm_tw_gap_24 =
+    A.class "sm:tw-gap-24"
+
+
+sm_tw_gap_32 : Html.Attribute msg
+sm_tw_gap_32 =
+    A.class "sm:tw-gap-32"
+
+
+sm_tw_gap_40 : Html.Attribute msg
+sm_tw_gap_40 =
+    A.class "sm:tw-gap-40"
+
+
+sm_tw_gap_48 : Html.Attribute msg
+sm_tw_gap_48 =
+    A.class "sm:tw-gap-48"
+
+
+sm_tw_gap_56 : Html.Attribute msg
+sm_tw_gap_56 =
+    A.class "sm:tw-gap-56"
+
+
+sm_tw_gap_64 : Html.Attribute msg
+sm_tw_gap_64 =
+    A.class "sm:tw-gap-64"
+
+
+sm_tw_gap_px : Html.Attribute msg
+sm_tw_gap_px =
+    A.class "sm:tw-gap-px"
+
+
+sm_tw_col_gap_0 : Html.Attribute msg
+sm_tw_col_gap_0 =
+    A.class "sm:tw-col-gap-0"
+
+
+sm_tw_col_gap_1 : Html.Attribute msg
+sm_tw_col_gap_1 =
+    A.class "sm:tw-col-gap-1"
+
+
+sm_tw_col_gap_2 : Html.Attribute msg
+sm_tw_col_gap_2 =
+    A.class "sm:tw-col-gap-2"
+
+
+sm_tw_col_gap_3 : Html.Attribute msg
+sm_tw_col_gap_3 =
+    A.class "sm:tw-col-gap-3"
+
+
+sm_tw_col_gap_4 : Html.Attribute msg
+sm_tw_col_gap_4 =
+    A.class "sm:tw-col-gap-4"
+
+
+sm_tw_col_gap_5 : Html.Attribute msg
+sm_tw_col_gap_5 =
+    A.class "sm:tw-col-gap-5"
+
+
+sm_tw_col_gap_6 : Html.Attribute msg
+sm_tw_col_gap_6 =
+    A.class "sm:tw-col-gap-6"
+
+
+sm_tw_col_gap_8 : Html.Attribute msg
+sm_tw_col_gap_8 =
+    A.class "sm:tw-col-gap-8"
+
+
+sm_tw_col_gap_10 : Html.Attribute msg
+sm_tw_col_gap_10 =
+    A.class "sm:tw-col-gap-10"
+
+
+sm_tw_col_gap_12 : Html.Attribute msg
+sm_tw_col_gap_12 =
+    A.class "sm:tw-col-gap-12"
+
+
+sm_tw_col_gap_16 : Html.Attribute msg
+sm_tw_col_gap_16 =
+    A.class "sm:tw-col-gap-16"
+
+
+sm_tw_col_gap_20 : Html.Attribute msg
+sm_tw_col_gap_20 =
+    A.class "sm:tw-col-gap-20"
+
+
+sm_tw_col_gap_24 : Html.Attribute msg
+sm_tw_col_gap_24 =
+    A.class "sm:tw-col-gap-24"
+
+
+sm_tw_col_gap_32 : Html.Attribute msg
+sm_tw_col_gap_32 =
+    A.class "sm:tw-col-gap-32"
+
+
+sm_tw_col_gap_40 : Html.Attribute msg
+sm_tw_col_gap_40 =
+    A.class "sm:tw-col-gap-40"
+
+
+sm_tw_col_gap_48 : Html.Attribute msg
+sm_tw_col_gap_48 =
+    A.class "sm:tw-col-gap-48"
+
+
+sm_tw_col_gap_56 : Html.Attribute msg
+sm_tw_col_gap_56 =
+    A.class "sm:tw-col-gap-56"
+
+
+sm_tw_col_gap_64 : Html.Attribute msg
+sm_tw_col_gap_64 =
+    A.class "sm:tw-col-gap-64"
+
+
+sm_tw_col_gap_px : Html.Attribute msg
+sm_tw_col_gap_px =
+    A.class "sm:tw-col-gap-px"
+
+
+sm_tw_row_gap_0 : Html.Attribute msg
+sm_tw_row_gap_0 =
+    A.class "sm:tw-row-gap-0"
+
+
+sm_tw_row_gap_1 : Html.Attribute msg
+sm_tw_row_gap_1 =
+    A.class "sm:tw-row-gap-1"
+
+
+sm_tw_row_gap_2 : Html.Attribute msg
+sm_tw_row_gap_2 =
+    A.class "sm:tw-row-gap-2"
+
+
+sm_tw_row_gap_3 : Html.Attribute msg
+sm_tw_row_gap_3 =
+    A.class "sm:tw-row-gap-3"
+
+
+sm_tw_row_gap_4 : Html.Attribute msg
+sm_tw_row_gap_4 =
+    A.class "sm:tw-row-gap-4"
+
+
+sm_tw_row_gap_5 : Html.Attribute msg
+sm_tw_row_gap_5 =
+    A.class "sm:tw-row-gap-5"
+
+
+sm_tw_row_gap_6 : Html.Attribute msg
+sm_tw_row_gap_6 =
+    A.class "sm:tw-row-gap-6"
+
+
+sm_tw_row_gap_8 : Html.Attribute msg
+sm_tw_row_gap_8 =
+    A.class "sm:tw-row-gap-8"
+
+
+sm_tw_row_gap_10 : Html.Attribute msg
+sm_tw_row_gap_10 =
+    A.class "sm:tw-row-gap-10"
+
+
+sm_tw_row_gap_12 : Html.Attribute msg
+sm_tw_row_gap_12 =
+    A.class "sm:tw-row-gap-12"
+
+
+sm_tw_row_gap_16 : Html.Attribute msg
+sm_tw_row_gap_16 =
+    A.class "sm:tw-row-gap-16"
+
+
+sm_tw_row_gap_20 : Html.Attribute msg
+sm_tw_row_gap_20 =
+    A.class "sm:tw-row-gap-20"
+
+
+sm_tw_row_gap_24 : Html.Attribute msg
+sm_tw_row_gap_24 =
+    A.class "sm:tw-row-gap-24"
+
+
+sm_tw_row_gap_32 : Html.Attribute msg
+sm_tw_row_gap_32 =
+    A.class "sm:tw-row-gap-32"
+
+
+sm_tw_row_gap_40 : Html.Attribute msg
+sm_tw_row_gap_40 =
+    A.class "sm:tw-row-gap-40"
+
+
+sm_tw_row_gap_48 : Html.Attribute msg
+sm_tw_row_gap_48 =
+    A.class "sm:tw-row-gap-48"
+
+
+sm_tw_row_gap_56 : Html.Attribute msg
+sm_tw_row_gap_56 =
+    A.class "sm:tw-row-gap-56"
+
+
+sm_tw_row_gap_64 : Html.Attribute msg
+sm_tw_row_gap_64 =
+    A.class "sm:tw-row-gap-64"
+
+
+sm_tw_row_gap_px : Html.Attribute msg
+sm_tw_row_gap_px =
+    A.class "sm:tw-row-gap-px"
+
+
+sm_tw_grid_flow_row : Html.Attribute msg
+sm_tw_grid_flow_row =
+    A.class "sm:tw-grid-flow-row"
+
+
+sm_tw_grid_flow_col : Html.Attribute msg
+sm_tw_grid_flow_col =
+    A.class "sm:tw-grid-flow-col"
+
+
+sm_tw_grid_flow_row_dense : Html.Attribute msg
+sm_tw_grid_flow_row_dense =
+    A.class "sm:tw-grid-flow-row-dense"
+
+
+sm_tw_grid_flow_col_dense : Html.Attribute msg
+sm_tw_grid_flow_col_dense =
+    A.class "sm:tw-grid-flow-col-dense"
+
+
+sm_tw_grid_cols_1 : Html.Attribute msg
+sm_tw_grid_cols_1 =
+    A.class "sm:tw-grid-cols-1"
+
+
+sm_tw_grid_cols_2 : Html.Attribute msg
+sm_tw_grid_cols_2 =
+    A.class "sm:tw-grid-cols-2"
+
+
+sm_tw_grid_cols_3 : Html.Attribute msg
+sm_tw_grid_cols_3 =
+    A.class "sm:tw-grid-cols-3"
+
+
+sm_tw_grid_cols_4 : Html.Attribute msg
+sm_tw_grid_cols_4 =
+    A.class "sm:tw-grid-cols-4"
+
+
+sm_tw_grid_cols_5 : Html.Attribute msg
+sm_tw_grid_cols_5 =
+    A.class "sm:tw-grid-cols-5"
+
+
+sm_tw_grid_cols_6 : Html.Attribute msg
+sm_tw_grid_cols_6 =
+    A.class "sm:tw-grid-cols-6"
+
+
+sm_tw_grid_cols_7 : Html.Attribute msg
+sm_tw_grid_cols_7 =
+    A.class "sm:tw-grid-cols-7"
+
+
+sm_tw_grid_cols_8 : Html.Attribute msg
+sm_tw_grid_cols_8 =
+    A.class "sm:tw-grid-cols-8"
+
+
+sm_tw_grid_cols_9 : Html.Attribute msg
+sm_tw_grid_cols_9 =
+    A.class "sm:tw-grid-cols-9"
+
+
+sm_tw_grid_cols_10 : Html.Attribute msg
+sm_tw_grid_cols_10 =
+    A.class "sm:tw-grid-cols-10"
+
+
+sm_tw_grid_cols_11 : Html.Attribute msg
+sm_tw_grid_cols_11 =
+    A.class "sm:tw-grid-cols-11"
+
+
+sm_tw_grid_cols_12 : Html.Attribute msg
+sm_tw_grid_cols_12 =
+    A.class "sm:tw-grid-cols-12"
+
+
+sm_tw_grid_cols_none : Html.Attribute msg
+sm_tw_grid_cols_none =
+    A.class "sm:tw-grid-cols-none"
+
+
+sm_tw_col_auto : Html.Attribute msg
+sm_tw_col_auto =
+    A.class "sm:tw-col-auto"
+
+
+sm_tw_col_span_1 : Html.Attribute msg
+sm_tw_col_span_1 =
+    A.class "sm:tw-col-span-1"
+
+
+sm_tw_col_span_2 : Html.Attribute msg
+sm_tw_col_span_2 =
+    A.class "sm:tw-col-span-2"
+
+
+sm_tw_col_span_3 : Html.Attribute msg
+sm_tw_col_span_3 =
+    A.class "sm:tw-col-span-3"
+
+
+sm_tw_col_span_4 : Html.Attribute msg
+sm_tw_col_span_4 =
+    A.class "sm:tw-col-span-4"
+
+
+sm_tw_col_span_5 : Html.Attribute msg
+sm_tw_col_span_5 =
+    A.class "sm:tw-col-span-5"
+
+
+sm_tw_col_span_6 : Html.Attribute msg
+sm_tw_col_span_6 =
+    A.class "sm:tw-col-span-6"
+
+
+sm_tw_col_span_7 : Html.Attribute msg
+sm_tw_col_span_7 =
+    A.class "sm:tw-col-span-7"
+
+
+sm_tw_col_span_8 : Html.Attribute msg
+sm_tw_col_span_8 =
+    A.class "sm:tw-col-span-8"
+
+
+sm_tw_col_span_9 : Html.Attribute msg
+sm_tw_col_span_9 =
+    A.class "sm:tw-col-span-9"
+
+
+sm_tw_col_span_10 : Html.Attribute msg
+sm_tw_col_span_10 =
+    A.class "sm:tw-col-span-10"
+
+
+sm_tw_col_span_11 : Html.Attribute msg
+sm_tw_col_span_11 =
+    A.class "sm:tw-col-span-11"
+
+
+sm_tw_col_span_12 : Html.Attribute msg
+sm_tw_col_span_12 =
+    A.class "sm:tw-col-span-12"
+
+
+sm_tw_col_start_1 : Html.Attribute msg
+sm_tw_col_start_1 =
+    A.class "sm:tw-col-start-1"
+
+
+sm_tw_col_start_2 : Html.Attribute msg
+sm_tw_col_start_2 =
+    A.class "sm:tw-col-start-2"
+
+
+sm_tw_col_start_3 : Html.Attribute msg
+sm_tw_col_start_3 =
+    A.class "sm:tw-col-start-3"
+
+
+sm_tw_col_start_4 : Html.Attribute msg
+sm_tw_col_start_4 =
+    A.class "sm:tw-col-start-4"
+
+
+sm_tw_col_start_5 : Html.Attribute msg
+sm_tw_col_start_5 =
+    A.class "sm:tw-col-start-5"
+
+
+sm_tw_col_start_6 : Html.Attribute msg
+sm_tw_col_start_6 =
+    A.class "sm:tw-col-start-6"
+
+
+sm_tw_col_start_7 : Html.Attribute msg
+sm_tw_col_start_7 =
+    A.class "sm:tw-col-start-7"
+
+
+sm_tw_col_start_8 : Html.Attribute msg
+sm_tw_col_start_8 =
+    A.class "sm:tw-col-start-8"
+
+
+sm_tw_col_start_9 : Html.Attribute msg
+sm_tw_col_start_9 =
+    A.class "sm:tw-col-start-9"
+
+
+sm_tw_col_start_10 : Html.Attribute msg
+sm_tw_col_start_10 =
+    A.class "sm:tw-col-start-10"
+
+
+sm_tw_col_start_11 : Html.Attribute msg
+sm_tw_col_start_11 =
+    A.class "sm:tw-col-start-11"
+
+
+sm_tw_col_start_12 : Html.Attribute msg
+sm_tw_col_start_12 =
+    A.class "sm:tw-col-start-12"
+
+
+sm_tw_col_start_13 : Html.Attribute msg
+sm_tw_col_start_13 =
+    A.class "sm:tw-col-start-13"
+
+
+sm_tw_col_start_auto : Html.Attribute msg
+sm_tw_col_start_auto =
+    A.class "sm:tw-col-start-auto"
+
+
+sm_tw_col_end_1 : Html.Attribute msg
+sm_tw_col_end_1 =
+    A.class "sm:tw-col-end-1"
+
+
+sm_tw_col_end_2 : Html.Attribute msg
+sm_tw_col_end_2 =
+    A.class "sm:tw-col-end-2"
+
+
+sm_tw_col_end_3 : Html.Attribute msg
+sm_tw_col_end_3 =
+    A.class "sm:tw-col-end-3"
+
+
+sm_tw_col_end_4 : Html.Attribute msg
+sm_tw_col_end_4 =
+    A.class "sm:tw-col-end-4"
+
+
+sm_tw_col_end_5 : Html.Attribute msg
+sm_tw_col_end_5 =
+    A.class "sm:tw-col-end-5"
+
+
+sm_tw_col_end_6 : Html.Attribute msg
+sm_tw_col_end_6 =
+    A.class "sm:tw-col-end-6"
+
+
+sm_tw_col_end_7 : Html.Attribute msg
+sm_tw_col_end_7 =
+    A.class "sm:tw-col-end-7"
+
+
+sm_tw_col_end_8 : Html.Attribute msg
+sm_tw_col_end_8 =
+    A.class "sm:tw-col-end-8"
+
+
+sm_tw_col_end_9 : Html.Attribute msg
+sm_tw_col_end_9 =
+    A.class "sm:tw-col-end-9"
+
+
+sm_tw_col_end_10 : Html.Attribute msg
+sm_tw_col_end_10 =
+    A.class "sm:tw-col-end-10"
+
+
+sm_tw_col_end_11 : Html.Attribute msg
+sm_tw_col_end_11 =
+    A.class "sm:tw-col-end-11"
+
+
+sm_tw_col_end_12 : Html.Attribute msg
+sm_tw_col_end_12 =
+    A.class "sm:tw-col-end-12"
+
+
+sm_tw_col_end_13 : Html.Attribute msg
+sm_tw_col_end_13 =
+    A.class "sm:tw-col-end-13"
+
+
+sm_tw_col_end_auto : Html.Attribute msg
+sm_tw_col_end_auto =
+    A.class "sm:tw-col-end-auto"
+
+
+sm_tw_grid_rows_1 : Html.Attribute msg
+sm_tw_grid_rows_1 =
+    A.class "sm:tw-grid-rows-1"
+
+
+sm_tw_grid_rows_2 : Html.Attribute msg
+sm_tw_grid_rows_2 =
+    A.class "sm:tw-grid-rows-2"
+
+
+sm_tw_grid_rows_3 : Html.Attribute msg
+sm_tw_grid_rows_3 =
+    A.class "sm:tw-grid-rows-3"
+
+
+sm_tw_grid_rows_4 : Html.Attribute msg
+sm_tw_grid_rows_4 =
+    A.class "sm:tw-grid-rows-4"
+
+
+sm_tw_grid_rows_5 : Html.Attribute msg
+sm_tw_grid_rows_5 =
+    A.class "sm:tw-grid-rows-5"
+
+
+sm_tw_grid_rows_6 : Html.Attribute msg
+sm_tw_grid_rows_6 =
+    A.class "sm:tw-grid-rows-6"
+
+
+sm_tw_grid_rows_none : Html.Attribute msg
+sm_tw_grid_rows_none =
+    A.class "sm:tw-grid-rows-none"
+
+
+sm_tw_row_auto : Html.Attribute msg
+sm_tw_row_auto =
+    A.class "sm:tw-row-auto"
+
+
+sm_tw_row_span_1 : Html.Attribute msg
+sm_tw_row_span_1 =
+    A.class "sm:tw-row-span-1"
+
+
+sm_tw_row_span_2 : Html.Attribute msg
+sm_tw_row_span_2 =
+    A.class "sm:tw-row-span-2"
+
+
+sm_tw_row_span_3 : Html.Attribute msg
+sm_tw_row_span_3 =
+    A.class "sm:tw-row-span-3"
+
+
+sm_tw_row_span_4 : Html.Attribute msg
+sm_tw_row_span_4 =
+    A.class "sm:tw-row-span-4"
+
+
+sm_tw_row_span_5 : Html.Attribute msg
+sm_tw_row_span_5 =
+    A.class "sm:tw-row-span-5"
+
+
+sm_tw_row_span_6 : Html.Attribute msg
+sm_tw_row_span_6 =
+    A.class "sm:tw-row-span-6"
+
+
+sm_tw_row_start_1 : Html.Attribute msg
+sm_tw_row_start_1 =
+    A.class "sm:tw-row-start-1"
+
+
+sm_tw_row_start_2 : Html.Attribute msg
+sm_tw_row_start_2 =
+    A.class "sm:tw-row-start-2"
+
+
+sm_tw_row_start_3 : Html.Attribute msg
+sm_tw_row_start_3 =
+    A.class "sm:tw-row-start-3"
+
+
+sm_tw_row_start_4 : Html.Attribute msg
+sm_tw_row_start_4 =
+    A.class "sm:tw-row-start-4"
+
+
+sm_tw_row_start_5 : Html.Attribute msg
+sm_tw_row_start_5 =
+    A.class "sm:tw-row-start-5"
+
+
+sm_tw_row_start_6 : Html.Attribute msg
+sm_tw_row_start_6 =
+    A.class "sm:tw-row-start-6"
+
+
+sm_tw_row_start_7 : Html.Attribute msg
+sm_tw_row_start_7 =
+    A.class "sm:tw-row-start-7"
+
+
+sm_tw_row_start_auto : Html.Attribute msg
+sm_tw_row_start_auto =
+    A.class "sm:tw-row-start-auto"
+
+
+sm_tw_row_end_1 : Html.Attribute msg
+sm_tw_row_end_1 =
+    A.class "sm:tw-row-end-1"
+
+
+sm_tw_row_end_2 : Html.Attribute msg
+sm_tw_row_end_2 =
+    A.class "sm:tw-row-end-2"
+
+
+sm_tw_row_end_3 : Html.Attribute msg
+sm_tw_row_end_3 =
+    A.class "sm:tw-row-end-3"
+
+
+sm_tw_row_end_4 : Html.Attribute msg
+sm_tw_row_end_4 =
+    A.class "sm:tw-row-end-4"
+
+
+sm_tw_row_end_5 : Html.Attribute msg
+sm_tw_row_end_5 =
+    A.class "sm:tw-row-end-5"
+
+
+sm_tw_row_end_6 : Html.Attribute msg
+sm_tw_row_end_6 =
+    A.class "sm:tw-row-end-6"
+
+
+sm_tw_row_end_7 : Html.Attribute msg
+sm_tw_row_end_7 =
+    A.class "sm:tw-row-end-7"
+
+
+sm_tw_row_end_auto : Html.Attribute msg
+sm_tw_row_end_auto =
+    A.class "sm:tw-row-end-auto"
+
+
+sm_tw_transform : Html.Attribute msg
+sm_tw_transform =
+    A.class "sm:tw-transform"
+
+
+sm_tw_transform_none : Html.Attribute msg
+sm_tw_transform_none =
+    A.class "sm:tw-transform-none"
+
+
+sm_tw_origin_center : Html.Attribute msg
+sm_tw_origin_center =
+    A.class "sm:tw-origin-center"
+
+
+sm_tw_origin_top : Html.Attribute msg
+sm_tw_origin_top =
+    A.class "sm:tw-origin-top"
+
+
+sm_tw_origin_top_right : Html.Attribute msg
+sm_tw_origin_top_right =
+    A.class "sm:tw-origin-top-right"
+
+
+sm_tw_origin_right : Html.Attribute msg
+sm_tw_origin_right =
+    A.class "sm:tw-origin-right"
+
+
+sm_tw_origin_bottom_right : Html.Attribute msg
+sm_tw_origin_bottom_right =
+    A.class "sm:tw-origin-bottom-right"
+
+
+sm_tw_origin_bottom : Html.Attribute msg
+sm_tw_origin_bottom =
+    A.class "sm:tw-origin-bottom"
+
+
+sm_tw_origin_bottom_left : Html.Attribute msg
+sm_tw_origin_bottom_left =
+    A.class "sm:tw-origin-bottom-left"
+
+
+sm_tw_origin_left : Html.Attribute msg
+sm_tw_origin_left =
+    A.class "sm:tw-origin-left"
+
+
+sm_tw_origin_top_left : Html.Attribute msg
+sm_tw_origin_top_left =
+    A.class "sm:tw-origin-top-left"
+
+
+sm_tw_scale_0 : Html.Attribute msg
+sm_tw_scale_0 =
+    A.class "sm:tw-scale-0"
+
+
+sm_tw_scale_50 : Html.Attribute msg
+sm_tw_scale_50 =
+    A.class "sm:tw-scale-50"
+
+
+sm_tw_scale_75 : Html.Attribute msg
+sm_tw_scale_75 =
+    A.class "sm:tw-scale-75"
+
+
+sm_tw_scale_90 : Html.Attribute msg
+sm_tw_scale_90 =
+    A.class "sm:tw-scale-90"
+
+
+sm_tw_scale_95 : Html.Attribute msg
+sm_tw_scale_95 =
+    A.class "sm:tw-scale-95"
+
+
+sm_tw_scale_100 : Html.Attribute msg
+sm_tw_scale_100 =
+    A.class "sm:tw-scale-100"
+
+
+sm_tw_scale_105 : Html.Attribute msg
+sm_tw_scale_105 =
+    A.class "sm:tw-scale-105"
+
+
+sm_tw_scale_110 : Html.Attribute msg
+sm_tw_scale_110 =
+    A.class "sm:tw-scale-110"
+
+
+sm_tw_scale_125 : Html.Attribute msg
+sm_tw_scale_125 =
+    A.class "sm:tw-scale-125"
+
+
+sm_tw_scale_150 : Html.Attribute msg
+sm_tw_scale_150 =
+    A.class "sm:tw-scale-150"
+
+
+sm_tw_scale_x_0 : Html.Attribute msg
+sm_tw_scale_x_0 =
+    A.class "sm:tw-scale-x-0"
+
+
+sm_tw_scale_x_50 : Html.Attribute msg
+sm_tw_scale_x_50 =
+    A.class "sm:tw-scale-x-50"
+
+
+sm_tw_scale_x_75 : Html.Attribute msg
+sm_tw_scale_x_75 =
+    A.class "sm:tw-scale-x-75"
+
+
+sm_tw_scale_x_90 : Html.Attribute msg
+sm_tw_scale_x_90 =
+    A.class "sm:tw-scale-x-90"
+
+
+sm_tw_scale_x_95 : Html.Attribute msg
+sm_tw_scale_x_95 =
+    A.class "sm:tw-scale-x-95"
+
+
+sm_tw_scale_x_100 : Html.Attribute msg
+sm_tw_scale_x_100 =
+    A.class "sm:tw-scale-x-100"
+
+
+sm_tw_scale_x_105 : Html.Attribute msg
+sm_tw_scale_x_105 =
+    A.class "sm:tw-scale-x-105"
+
+
+sm_tw_scale_x_110 : Html.Attribute msg
+sm_tw_scale_x_110 =
+    A.class "sm:tw-scale-x-110"
+
+
+sm_tw_scale_x_125 : Html.Attribute msg
+sm_tw_scale_x_125 =
+    A.class "sm:tw-scale-x-125"
+
+
+sm_tw_scale_x_150 : Html.Attribute msg
+sm_tw_scale_x_150 =
+    A.class "sm:tw-scale-x-150"
+
+
+sm_tw_scale_y_0 : Html.Attribute msg
+sm_tw_scale_y_0 =
+    A.class "sm:tw-scale-y-0"
+
+
+sm_tw_scale_y_50 : Html.Attribute msg
+sm_tw_scale_y_50 =
+    A.class "sm:tw-scale-y-50"
+
+
+sm_tw_scale_y_75 : Html.Attribute msg
+sm_tw_scale_y_75 =
+    A.class "sm:tw-scale-y-75"
+
+
+sm_tw_scale_y_90 : Html.Attribute msg
+sm_tw_scale_y_90 =
+    A.class "sm:tw-scale-y-90"
+
+
+sm_tw_scale_y_95 : Html.Attribute msg
+sm_tw_scale_y_95 =
+    A.class "sm:tw-scale-y-95"
+
+
+sm_tw_scale_y_100 : Html.Attribute msg
+sm_tw_scale_y_100 =
+    A.class "sm:tw-scale-y-100"
+
+
+sm_tw_scale_y_105 : Html.Attribute msg
+sm_tw_scale_y_105 =
+    A.class "sm:tw-scale-y-105"
+
+
+sm_tw_scale_y_110 : Html.Attribute msg
+sm_tw_scale_y_110 =
+    A.class "sm:tw-scale-y-110"
+
+
+sm_tw_scale_y_125 : Html.Attribute msg
+sm_tw_scale_y_125 =
+    A.class "sm:tw-scale-y-125"
+
+
+sm_tw_scale_y_150 : Html.Attribute msg
+sm_tw_scale_y_150 =
+    A.class "sm:tw-scale-y-150"
+
+
+sm_hover_tw_scale_0 : Html.Attribute msg
+sm_hover_tw_scale_0 =
+    A.class "sm:hover:tw-scale-0"
+
+
+sm_hover_tw_scale_50 : Html.Attribute msg
+sm_hover_tw_scale_50 =
+    A.class "sm:hover:tw-scale-50"
+
+
+sm_hover_tw_scale_75 : Html.Attribute msg
+sm_hover_tw_scale_75 =
+    A.class "sm:hover:tw-scale-75"
+
+
+sm_hover_tw_scale_90 : Html.Attribute msg
+sm_hover_tw_scale_90 =
+    A.class "sm:hover:tw-scale-90"
+
+
+sm_hover_tw_scale_95 : Html.Attribute msg
+sm_hover_tw_scale_95 =
+    A.class "sm:hover:tw-scale-95"
+
+
+sm_hover_tw_scale_100 : Html.Attribute msg
+sm_hover_tw_scale_100 =
+    A.class "sm:hover:tw-scale-100"
+
+
+sm_hover_tw_scale_105 : Html.Attribute msg
+sm_hover_tw_scale_105 =
+    A.class "sm:hover:tw-scale-105"
+
+
+sm_hover_tw_scale_110 : Html.Attribute msg
+sm_hover_tw_scale_110 =
+    A.class "sm:hover:tw-scale-110"
+
+
+sm_hover_tw_scale_125 : Html.Attribute msg
+sm_hover_tw_scale_125 =
+    A.class "sm:hover:tw-scale-125"
+
+
+sm_hover_tw_scale_150 : Html.Attribute msg
+sm_hover_tw_scale_150 =
+    A.class "sm:hover:tw-scale-150"
+
+
+sm_hover_tw_scale_x_0 : Html.Attribute msg
+sm_hover_tw_scale_x_0 =
+    A.class "sm:hover:tw-scale-x-0"
+
+
+sm_hover_tw_scale_x_50 : Html.Attribute msg
+sm_hover_tw_scale_x_50 =
+    A.class "sm:hover:tw-scale-x-50"
+
+
+sm_hover_tw_scale_x_75 : Html.Attribute msg
+sm_hover_tw_scale_x_75 =
+    A.class "sm:hover:tw-scale-x-75"
+
+
+sm_hover_tw_scale_x_90 : Html.Attribute msg
+sm_hover_tw_scale_x_90 =
+    A.class "sm:hover:tw-scale-x-90"
+
+
+sm_hover_tw_scale_x_95 : Html.Attribute msg
+sm_hover_tw_scale_x_95 =
+    A.class "sm:hover:tw-scale-x-95"
+
+
+sm_hover_tw_scale_x_100 : Html.Attribute msg
+sm_hover_tw_scale_x_100 =
+    A.class "sm:hover:tw-scale-x-100"
+
+
+sm_hover_tw_scale_x_105 : Html.Attribute msg
+sm_hover_tw_scale_x_105 =
+    A.class "sm:hover:tw-scale-x-105"
+
+
+sm_hover_tw_scale_x_110 : Html.Attribute msg
+sm_hover_tw_scale_x_110 =
+    A.class "sm:hover:tw-scale-x-110"
+
+
+sm_hover_tw_scale_x_125 : Html.Attribute msg
+sm_hover_tw_scale_x_125 =
+    A.class "sm:hover:tw-scale-x-125"
+
+
+sm_hover_tw_scale_x_150 : Html.Attribute msg
+sm_hover_tw_scale_x_150 =
+    A.class "sm:hover:tw-scale-x-150"
+
+
+sm_hover_tw_scale_y_0 : Html.Attribute msg
+sm_hover_tw_scale_y_0 =
+    A.class "sm:hover:tw-scale-y-0"
+
+
+sm_hover_tw_scale_y_50 : Html.Attribute msg
+sm_hover_tw_scale_y_50 =
+    A.class "sm:hover:tw-scale-y-50"
+
+
+sm_hover_tw_scale_y_75 : Html.Attribute msg
+sm_hover_tw_scale_y_75 =
+    A.class "sm:hover:tw-scale-y-75"
+
+
+sm_hover_tw_scale_y_90 : Html.Attribute msg
+sm_hover_tw_scale_y_90 =
+    A.class "sm:hover:tw-scale-y-90"
+
+
+sm_hover_tw_scale_y_95 : Html.Attribute msg
+sm_hover_tw_scale_y_95 =
+    A.class "sm:hover:tw-scale-y-95"
+
+
+sm_hover_tw_scale_y_100 : Html.Attribute msg
+sm_hover_tw_scale_y_100 =
+    A.class "sm:hover:tw-scale-y-100"
+
+
+sm_hover_tw_scale_y_105 : Html.Attribute msg
+sm_hover_tw_scale_y_105 =
+    A.class "sm:hover:tw-scale-y-105"
+
+
+sm_hover_tw_scale_y_110 : Html.Attribute msg
+sm_hover_tw_scale_y_110 =
+    A.class "sm:hover:tw-scale-y-110"
+
+
+sm_hover_tw_scale_y_125 : Html.Attribute msg
+sm_hover_tw_scale_y_125 =
+    A.class "sm:hover:tw-scale-y-125"
+
+
+sm_hover_tw_scale_y_150 : Html.Attribute msg
+sm_hover_tw_scale_y_150 =
+    A.class "sm:hover:tw-scale-y-150"
+
+
+sm_focus_tw_scale_0 : Html.Attribute msg
+sm_focus_tw_scale_0 =
+    A.class "sm:focus:tw-scale-0"
+
+
+sm_focus_tw_scale_50 : Html.Attribute msg
+sm_focus_tw_scale_50 =
+    A.class "sm:focus:tw-scale-50"
+
+
+sm_focus_tw_scale_75 : Html.Attribute msg
+sm_focus_tw_scale_75 =
+    A.class "sm:focus:tw-scale-75"
+
+
+sm_focus_tw_scale_90 : Html.Attribute msg
+sm_focus_tw_scale_90 =
+    A.class "sm:focus:tw-scale-90"
+
+
+sm_focus_tw_scale_95 : Html.Attribute msg
+sm_focus_tw_scale_95 =
+    A.class "sm:focus:tw-scale-95"
+
+
+sm_focus_tw_scale_100 : Html.Attribute msg
+sm_focus_tw_scale_100 =
+    A.class "sm:focus:tw-scale-100"
+
+
+sm_focus_tw_scale_105 : Html.Attribute msg
+sm_focus_tw_scale_105 =
+    A.class "sm:focus:tw-scale-105"
+
+
+sm_focus_tw_scale_110 : Html.Attribute msg
+sm_focus_tw_scale_110 =
+    A.class "sm:focus:tw-scale-110"
+
+
+sm_focus_tw_scale_125 : Html.Attribute msg
+sm_focus_tw_scale_125 =
+    A.class "sm:focus:tw-scale-125"
+
+
+sm_focus_tw_scale_150 : Html.Attribute msg
+sm_focus_tw_scale_150 =
+    A.class "sm:focus:tw-scale-150"
+
+
+sm_focus_tw_scale_x_0 : Html.Attribute msg
+sm_focus_tw_scale_x_0 =
+    A.class "sm:focus:tw-scale-x-0"
+
+
+sm_focus_tw_scale_x_50 : Html.Attribute msg
+sm_focus_tw_scale_x_50 =
+    A.class "sm:focus:tw-scale-x-50"
+
+
+sm_focus_tw_scale_x_75 : Html.Attribute msg
+sm_focus_tw_scale_x_75 =
+    A.class "sm:focus:tw-scale-x-75"
+
+
+sm_focus_tw_scale_x_90 : Html.Attribute msg
+sm_focus_tw_scale_x_90 =
+    A.class "sm:focus:tw-scale-x-90"
+
+
+sm_focus_tw_scale_x_95 : Html.Attribute msg
+sm_focus_tw_scale_x_95 =
+    A.class "sm:focus:tw-scale-x-95"
+
+
+sm_focus_tw_scale_x_100 : Html.Attribute msg
+sm_focus_tw_scale_x_100 =
+    A.class "sm:focus:tw-scale-x-100"
+
+
+sm_focus_tw_scale_x_105 : Html.Attribute msg
+sm_focus_tw_scale_x_105 =
+    A.class "sm:focus:tw-scale-x-105"
+
+
+sm_focus_tw_scale_x_110 : Html.Attribute msg
+sm_focus_tw_scale_x_110 =
+    A.class "sm:focus:tw-scale-x-110"
+
+
+sm_focus_tw_scale_x_125 : Html.Attribute msg
+sm_focus_tw_scale_x_125 =
+    A.class "sm:focus:tw-scale-x-125"
+
+
+sm_focus_tw_scale_x_150 : Html.Attribute msg
+sm_focus_tw_scale_x_150 =
+    A.class "sm:focus:tw-scale-x-150"
+
+
+sm_focus_tw_scale_y_0 : Html.Attribute msg
+sm_focus_tw_scale_y_0 =
+    A.class "sm:focus:tw-scale-y-0"
+
+
+sm_focus_tw_scale_y_50 : Html.Attribute msg
+sm_focus_tw_scale_y_50 =
+    A.class "sm:focus:tw-scale-y-50"
+
+
+sm_focus_tw_scale_y_75 : Html.Attribute msg
+sm_focus_tw_scale_y_75 =
+    A.class "sm:focus:tw-scale-y-75"
+
+
+sm_focus_tw_scale_y_90 : Html.Attribute msg
+sm_focus_tw_scale_y_90 =
+    A.class "sm:focus:tw-scale-y-90"
+
+
+sm_focus_tw_scale_y_95 : Html.Attribute msg
+sm_focus_tw_scale_y_95 =
+    A.class "sm:focus:tw-scale-y-95"
+
+
+sm_focus_tw_scale_y_100 : Html.Attribute msg
+sm_focus_tw_scale_y_100 =
+    A.class "sm:focus:tw-scale-y-100"
+
+
+sm_focus_tw_scale_y_105 : Html.Attribute msg
+sm_focus_tw_scale_y_105 =
+    A.class "sm:focus:tw-scale-y-105"
+
+
+sm_focus_tw_scale_y_110 : Html.Attribute msg
+sm_focus_tw_scale_y_110 =
+    A.class "sm:focus:tw-scale-y-110"
+
+
+sm_focus_tw_scale_y_125 : Html.Attribute msg
+sm_focus_tw_scale_y_125 =
+    A.class "sm:focus:tw-scale-y-125"
+
+
+sm_focus_tw_scale_y_150 : Html.Attribute msg
+sm_focus_tw_scale_y_150 =
+    A.class "sm:focus:tw-scale-y-150"
+
+
+sm_tw_rotate_0 : Html.Attribute msg
+sm_tw_rotate_0 =
+    A.class "sm:tw-rotate-0"
+
+
+sm_tw_rotate_45 : Html.Attribute msg
+sm_tw_rotate_45 =
+    A.class "sm:tw-rotate-45"
+
+
+sm_tw_rotate_90 : Html.Attribute msg
+sm_tw_rotate_90 =
+    A.class "sm:tw-rotate-90"
+
+
+sm_tw_rotate_180 : Html.Attribute msg
+sm_tw_rotate_180 =
+    A.class "sm:tw-rotate-180"
+
+
+sm_tw_neg_rotate_180 : Html.Attribute msg
+sm_tw_neg_rotate_180 =
+    A.class "sm:tw--rotate-180"
+
+
+sm_tw_neg_rotate_90 : Html.Attribute msg
+sm_tw_neg_rotate_90 =
+    A.class "sm:tw--rotate-90"
+
+
+sm_tw_neg_rotate_45 : Html.Attribute msg
+sm_tw_neg_rotate_45 =
+    A.class "sm:tw--rotate-45"
+
+
+sm_hover_tw_rotate_0 : Html.Attribute msg
+sm_hover_tw_rotate_0 =
+    A.class "sm:hover:tw-rotate-0"
+
+
+sm_hover_tw_rotate_45 : Html.Attribute msg
+sm_hover_tw_rotate_45 =
+    A.class "sm:hover:tw-rotate-45"
+
+
+sm_hover_tw_rotate_90 : Html.Attribute msg
+sm_hover_tw_rotate_90 =
+    A.class "sm:hover:tw-rotate-90"
+
+
+sm_hover_tw_rotate_180 : Html.Attribute msg
+sm_hover_tw_rotate_180 =
+    A.class "sm:hover:tw-rotate-180"
+
+
+sm_hover_tw_neg_rotate_180 : Html.Attribute msg
+sm_hover_tw_neg_rotate_180 =
+    A.class "sm:hover:tw--rotate-180"
+
+
+sm_hover_tw_neg_rotate_90 : Html.Attribute msg
+sm_hover_tw_neg_rotate_90 =
+    A.class "sm:hover:tw--rotate-90"
+
+
+sm_hover_tw_neg_rotate_45 : Html.Attribute msg
+sm_hover_tw_neg_rotate_45 =
+    A.class "sm:hover:tw--rotate-45"
+
+
+sm_focus_tw_rotate_0 : Html.Attribute msg
+sm_focus_tw_rotate_0 =
+    A.class "sm:focus:tw-rotate-0"
+
+
+sm_focus_tw_rotate_45 : Html.Attribute msg
+sm_focus_tw_rotate_45 =
+    A.class "sm:focus:tw-rotate-45"
+
+
+sm_focus_tw_rotate_90 : Html.Attribute msg
+sm_focus_tw_rotate_90 =
+    A.class "sm:focus:tw-rotate-90"
+
+
+sm_focus_tw_rotate_180 : Html.Attribute msg
+sm_focus_tw_rotate_180 =
+    A.class "sm:focus:tw-rotate-180"
+
+
+sm_focus_tw_neg_rotate_180 : Html.Attribute msg
+sm_focus_tw_neg_rotate_180 =
+    A.class "sm:focus:tw--rotate-180"
+
+
+sm_focus_tw_neg_rotate_90 : Html.Attribute msg
+sm_focus_tw_neg_rotate_90 =
+    A.class "sm:focus:tw--rotate-90"
+
+
+sm_focus_tw_neg_rotate_45 : Html.Attribute msg
+sm_focus_tw_neg_rotate_45 =
+    A.class "sm:focus:tw--rotate-45"
+
+
+sm_tw_translate_x_0 : Html.Attribute msg
+sm_tw_translate_x_0 =
+    A.class "sm:tw-translate-x-0"
+
+
+sm_tw_translate_x_1 : Html.Attribute msg
+sm_tw_translate_x_1 =
+    A.class "sm:tw-translate-x-1"
+
+
+sm_tw_translate_x_2 : Html.Attribute msg
+sm_tw_translate_x_2 =
+    A.class "sm:tw-translate-x-2"
+
+
+sm_tw_translate_x_3 : Html.Attribute msg
+sm_tw_translate_x_3 =
+    A.class "sm:tw-translate-x-3"
+
+
+sm_tw_translate_x_4 : Html.Attribute msg
+sm_tw_translate_x_4 =
+    A.class "sm:tw-translate-x-4"
+
+
+sm_tw_translate_x_5 : Html.Attribute msg
+sm_tw_translate_x_5 =
+    A.class "sm:tw-translate-x-5"
+
+
+sm_tw_translate_x_6 : Html.Attribute msg
+sm_tw_translate_x_6 =
+    A.class "sm:tw-translate-x-6"
+
+
+sm_tw_translate_x_8 : Html.Attribute msg
+sm_tw_translate_x_8 =
+    A.class "sm:tw-translate-x-8"
+
+
+sm_tw_translate_x_10 : Html.Attribute msg
+sm_tw_translate_x_10 =
+    A.class "sm:tw-translate-x-10"
+
+
+sm_tw_translate_x_12 : Html.Attribute msg
+sm_tw_translate_x_12 =
+    A.class "sm:tw-translate-x-12"
+
+
+sm_tw_translate_x_16 : Html.Attribute msg
+sm_tw_translate_x_16 =
+    A.class "sm:tw-translate-x-16"
+
+
+sm_tw_translate_x_20 : Html.Attribute msg
+sm_tw_translate_x_20 =
+    A.class "sm:tw-translate-x-20"
+
+
+sm_tw_translate_x_24 : Html.Attribute msg
+sm_tw_translate_x_24 =
+    A.class "sm:tw-translate-x-24"
+
+
+sm_tw_translate_x_32 : Html.Attribute msg
+sm_tw_translate_x_32 =
+    A.class "sm:tw-translate-x-32"
+
+
+sm_tw_translate_x_40 : Html.Attribute msg
+sm_tw_translate_x_40 =
+    A.class "sm:tw-translate-x-40"
+
+
+sm_tw_translate_x_48 : Html.Attribute msg
+sm_tw_translate_x_48 =
+    A.class "sm:tw-translate-x-48"
+
+
+sm_tw_translate_x_56 : Html.Attribute msg
+sm_tw_translate_x_56 =
+    A.class "sm:tw-translate-x-56"
+
+
+sm_tw_translate_x_64 : Html.Attribute msg
+sm_tw_translate_x_64 =
+    A.class "sm:tw-translate-x-64"
+
+
+sm_tw_translate_x_px : Html.Attribute msg
+sm_tw_translate_x_px =
+    A.class "sm:tw-translate-x-px"
+
+
+sm_tw_neg_translate_x_1 : Html.Attribute msg
+sm_tw_neg_translate_x_1 =
+    A.class "sm:tw--translate-x-1"
+
+
+sm_tw_neg_translate_x_2 : Html.Attribute msg
+sm_tw_neg_translate_x_2 =
+    A.class "sm:tw--translate-x-2"
+
+
+sm_tw_neg_translate_x_3 : Html.Attribute msg
+sm_tw_neg_translate_x_3 =
+    A.class "sm:tw--translate-x-3"
+
+
+sm_tw_neg_translate_x_4 : Html.Attribute msg
+sm_tw_neg_translate_x_4 =
+    A.class "sm:tw--translate-x-4"
+
+
+sm_tw_neg_translate_x_5 : Html.Attribute msg
+sm_tw_neg_translate_x_5 =
+    A.class "sm:tw--translate-x-5"
+
+
+sm_tw_neg_translate_x_6 : Html.Attribute msg
+sm_tw_neg_translate_x_6 =
+    A.class "sm:tw--translate-x-6"
+
+
+sm_tw_neg_translate_x_8 : Html.Attribute msg
+sm_tw_neg_translate_x_8 =
+    A.class "sm:tw--translate-x-8"
+
+
+sm_tw_neg_translate_x_10 : Html.Attribute msg
+sm_tw_neg_translate_x_10 =
+    A.class "sm:tw--translate-x-10"
+
+
+sm_tw_neg_translate_x_12 : Html.Attribute msg
+sm_tw_neg_translate_x_12 =
+    A.class "sm:tw--translate-x-12"
+
+
+sm_tw_neg_translate_x_16 : Html.Attribute msg
+sm_tw_neg_translate_x_16 =
+    A.class "sm:tw--translate-x-16"
+
+
+sm_tw_neg_translate_x_20 : Html.Attribute msg
+sm_tw_neg_translate_x_20 =
+    A.class "sm:tw--translate-x-20"
+
+
+sm_tw_neg_translate_x_24 : Html.Attribute msg
+sm_tw_neg_translate_x_24 =
+    A.class "sm:tw--translate-x-24"
+
+
+sm_tw_neg_translate_x_32 : Html.Attribute msg
+sm_tw_neg_translate_x_32 =
+    A.class "sm:tw--translate-x-32"
+
+
+sm_tw_neg_translate_x_40 : Html.Attribute msg
+sm_tw_neg_translate_x_40 =
+    A.class "sm:tw--translate-x-40"
+
+
+sm_tw_neg_translate_x_48 : Html.Attribute msg
+sm_tw_neg_translate_x_48 =
+    A.class "sm:tw--translate-x-48"
+
+
+sm_tw_neg_translate_x_56 : Html.Attribute msg
+sm_tw_neg_translate_x_56 =
+    A.class "sm:tw--translate-x-56"
+
+
+sm_tw_neg_translate_x_64 : Html.Attribute msg
+sm_tw_neg_translate_x_64 =
+    A.class "sm:tw--translate-x-64"
+
+
+sm_tw_neg_translate_x_px : Html.Attribute msg
+sm_tw_neg_translate_x_px =
+    A.class "sm:tw--translate-x-px"
+
+
+sm_tw_neg_translate_x_full : Html.Attribute msg
+sm_tw_neg_translate_x_full =
+    A.class "sm:tw--translate-x-full"
+
+
+sm_tw_neg_translate_x_1over2 : Html.Attribute msg
+sm_tw_neg_translate_x_1over2 =
+    A.class "sm:tw--translate-x-1/2"
+
+
+sm_tw_translate_x_1over2 : Html.Attribute msg
+sm_tw_translate_x_1over2 =
+    A.class "sm:tw-translate-x-1/2"
+
+
+sm_tw_translate_x_full : Html.Attribute msg
+sm_tw_translate_x_full =
+    A.class "sm:tw-translate-x-full"
+
+
+sm_tw_translate_y_0 : Html.Attribute msg
+sm_tw_translate_y_0 =
+    A.class "sm:tw-translate-y-0"
+
+
+sm_tw_translate_y_1 : Html.Attribute msg
+sm_tw_translate_y_1 =
+    A.class "sm:tw-translate-y-1"
+
+
+sm_tw_translate_y_2 : Html.Attribute msg
+sm_tw_translate_y_2 =
+    A.class "sm:tw-translate-y-2"
+
+
+sm_tw_translate_y_3 : Html.Attribute msg
+sm_tw_translate_y_3 =
+    A.class "sm:tw-translate-y-3"
+
+
+sm_tw_translate_y_4 : Html.Attribute msg
+sm_tw_translate_y_4 =
+    A.class "sm:tw-translate-y-4"
+
+
+sm_tw_translate_y_5 : Html.Attribute msg
+sm_tw_translate_y_5 =
+    A.class "sm:tw-translate-y-5"
+
+
+sm_tw_translate_y_6 : Html.Attribute msg
+sm_tw_translate_y_6 =
+    A.class "sm:tw-translate-y-6"
+
+
+sm_tw_translate_y_8 : Html.Attribute msg
+sm_tw_translate_y_8 =
+    A.class "sm:tw-translate-y-8"
+
+
+sm_tw_translate_y_10 : Html.Attribute msg
+sm_tw_translate_y_10 =
+    A.class "sm:tw-translate-y-10"
+
+
+sm_tw_translate_y_12 : Html.Attribute msg
+sm_tw_translate_y_12 =
+    A.class "sm:tw-translate-y-12"
+
+
+sm_tw_translate_y_16 : Html.Attribute msg
+sm_tw_translate_y_16 =
+    A.class "sm:tw-translate-y-16"
+
+
+sm_tw_translate_y_20 : Html.Attribute msg
+sm_tw_translate_y_20 =
+    A.class "sm:tw-translate-y-20"
+
+
+sm_tw_translate_y_24 : Html.Attribute msg
+sm_tw_translate_y_24 =
+    A.class "sm:tw-translate-y-24"
+
+
+sm_tw_translate_y_32 : Html.Attribute msg
+sm_tw_translate_y_32 =
+    A.class "sm:tw-translate-y-32"
+
+
+sm_tw_translate_y_40 : Html.Attribute msg
+sm_tw_translate_y_40 =
+    A.class "sm:tw-translate-y-40"
+
+
+sm_tw_translate_y_48 : Html.Attribute msg
+sm_tw_translate_y_48 =
+    A.class "sm:tw-translate-y-48"
+
+
+sm_tw_translate_y_56 : Html.Attribute msg
+sm_tw_translate_y_56 =
+    A.class "sm:tw-translate-y-56"
+
+
+sm_tw_translate_y_64 : Html.Attribute msg
+sm_tw_translate_y_64 =
+    A.class "sm:tw-translate-y-64"
+
+
+sm_tw_translate_y_px : Html.Attribute msg
+sm_tw_translate_y_px =
+    A.class "sm:tw-translate-y-px"
+
+
+sm_tw_neg_translate_y_1 : Html.Attribute msg
+sm_tw_neg_translate_y_1 =
+    A.class "sm:tw--translate-y-1"
+
+
+sm_tw_neg_translate_y_2 : Html.Attribute msg
+sm_tw_neg_translate_y_2 =
+    A.class "sm:tw--translate-y-2"
+
+
+sm_tw_neg_translate_y_3 : Html.Attribute msg
+sm_tw_neg_translate_y_3 =
+    A.class "sm:tw--translate-y-3"
+
+
+sm_tw_neg_translate_y_4 : Html.Attribute msg
+sm_tw_neg_translate_y_4 =
+    A.class "sm:tw--translate-y-4"
+
+
+sm_tw_neg_translate_y_5 : Html.Attribute msg
+sm_tw_neg_translate_y_5 =
+    A.class "sm:tw--translate-y-5"
+
+
+sm_tw_neg_translate_y_6 : Html.Attribute msg
+sm_tw_neg_translate_y_6 =
+    A.class "sm:tw--translate-y-6"
+
+
+sm_tw_neg_translate_y_8 : Html.Attribute msg
+sm_tw_neg_translate_y_8 =
+    A.class "sm:tw--translate-y-8"
+
+
+sm_tw_neg_translate_y_10 : Html.Attribute msg
+sm_tw_neg_translate_y_10 =
+    A.class "sm:tw--translate-y-10"
+
+
+sm_tw_neg_translate_y_12 : Html.Attribute msg
+sm_tw_neg_translate_y_12 =
+    A.class "sm:tw--translate-y-12"
+
+
+sm_tw_neg_translate_y_16 : Html.Attribute msg
+sm_tw_neg_translate_y_16 =
+    A.class "sm:tw--translate-y-16"
+
+
+sm_tw_neg_translate_y_20 : Html.Attribute msg
+sm_tw_neg_translate_y_20 =
+    A.class "sm:tw--translate-y-20"
+
+
+sm_tw_neg_translate_y_24 : Html.Attribute msg
+sm_tw_neg_translate_y_24 =
+    A.class "sm:tw--translate-y-24"
+
+
+sm_tw_neg_translate_y_32 : Html.Attribute msg
+sm_tw_neg_translate_y_32 =
+    A.class "sm:tw--translate-y-32"
+
+
+sm_tw_neg_translate_y_40 : Html.Attribute msg
+sm_tw_neg_translate_y_40 =
+    A.class "sm:tw--translate-y-40"
+
+
+sm_tw_neg_translate_y_48 : Html.Attribute msg
+sm_tw_neg_translate_y_48 =
+    A.class "sm:tw--translate-y-48"
+
+
+sm_tw_neg_translate_y_56 : Html.Attribute msg
+sm_tw_neg_translate_y_56 =
+    A.class "sm:tw--translate-y-56"
+
+
+sm_tw_neg_translate_y_64 : Html.Attribute msg
+sm_tw_neg_translate_y_64 =
+    A.class "sm:tw--translate-y-64"
+
+
+sm_tw_neg_translate_y_px : Html.Attribute msg
+sm_tw_neg_translate_y_px =
+    A.class "sm:tw--translate-y-px"
+
+
+sm_tw_neg_translate_y_full : Html.Attribute msg
+sm_tw_neg_translate_y_full =
+    A.class "sm:tw--translate-y-full"
+
+
+sm_tw_neg_translate_y_1over2 : Html.Attribute msg
+sm_tw_neg_translate_y_1over2 =
+    A.class "sm:tw--translate-y-1/2"
+
+
+sm_tw_translate_y_1over2 : Html.Attribute msg
+sm_tw_translate_y_1over2 =
+    A.class "sm:tw-translate-y-1/2"
+
+
+sm_tw_translate_y_full : Html.Attribute msg
+sm_tw_translate_y_full =
+    A.class "sm:tw-translate-y-full"
+
+
+sm_hover_tw_translate_x_0 : Html.Attribute msg
+sm_hover_tw_translate_x_0 =
+    A.class "sm:hover:tw-translate-x-0"
+
+
+sm_hover_tw_translate_x_1 : Html.Attribute msg
+sm_hover_tw_translate_x_1 =
+    A.class "sm:hover:tw-translate-x-1"
+
+
+sm_hover_tw_translate_x_2 : Html.Attribute msg
+sm_hover_tw_translate_x_2 =
+    A.class "sm:hover:tw-translate-x-2"
+
+
+sm_hover_tw_translate_x_3 : Html.Attribute msg
+sm_hover_tw_translate_x_3 =
+    A.class "sm:hover:tw-translate-x-3"
+
+
+sm_hover_tw_translate_x_4 : Html.Attribute msg
+sm_hover_tw_translate_x_4 =
+    A.class "sm:hover:tw-translate-x-4"
+
+
+sm_hover_tw_translate_x_5 : Html.Attribute msg
+sm_hover_tw_translate_x_5 =
+    A.class "sm:hover:tw-translate-x-5"
+
+
+sm_hover_tw_translate_x_6 : Html.Attribute msg
+sm_hover_tw_translate_x_6 =
+    A.class "sm:hover:tw-translate-x-6"
+
+
+sm_hover_tw_translate_x_8 : Html.Attribute msg
+sm_hover_tw_translate_x_8 =
+    A.class "sm:hover:tw-translate-x-8"
+
+
+sm_hover_tw_translate_x_10 : Html.Attribute msg
+sm_hover_tw_translate_x_10 =
+    A.class "sm:hover:tw-translate-x-10"
+
+
+sm_hover_tw_translate_x_12 : Html.Attribute msg
+sm_hover_tw_translate_x_12 =
+    A.class "sm:hover:tw-translate-x-12"
+
+
+sm_hover_tw_translate_x_16 : Html.Attribute msg
+sm_hover_tw_translate_x_16 =
+    A.class "sm:hover:tw-translate-x-16"
+
+
+sm_hover_tw_translate_x_20 : Html.Attribute msg
+sm_hover_tw_translate_x_20 =
+    A.class "sm:hover:tw-translate-x-20"
+
+
+sm_hover_tw_translate_x_24 : Html.Attribute msg
+sm_hover_tw_translate_x_24 =
+    A.class "sm:hover:tw-translate-x-24"
+
+
+sm_hover_tw_translate_x_32 : Html.Attribute msg
+sm_hover_tw_translate_x_32 =
+    A.class "sm:hover:tw-translate-x-32"
+
+
+sm_hover_tw_translate_x_40 : Html.Attribute msg
+sm_hover_tw_translate_x_40 =
+    A.class "sm:hover:tw-translate-x-40"
+
+
+sm_hover_tw_translate_x_48 : Html.Attribute msg
+sm_hover_tw_translate_x_48 =
+    A.class "sm:hover:tw-translate-x-48"
+
+
+sm_hover_tw_translate_x_56 : Html.Attribute msg
+sm_hover_tw_translate_x_56 =
+    A.class "sm:hover:tw-translate-x-56"
+
+
+sm_hover_tw_translate_x_64 : Html.Attribute msg
+sm_hover_tw_translate_x_64 =
+    A.class "sm:hover:tw-translate-x-64"
+
+
+sm_hover_tw_translate_x_px : Html.Attribute msg
+sm_hover_tw_translate_x_px =
+    A.class "sm:hover:tw-translate-x-px"
+
+
+sm_hover_tw_neg_translate_x_1 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_1 =
+    A.class "sm:hover:tw--translate-x-1"
+
+
+sm_hover_tw_neg_translate_x_2 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_2 =
+    A.class "sm:hover:tw--translate-x-2"
+
+
+sm_hover_tw_neg_translate_x_3 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_3 =
+    A.class "sm:hover:tw--translate-x-3"
+
+
+sm_hover_tw_neg_translate_x_4 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_4 =
+    A.class "sm:hover:tw--translate-x-4"
+
+
+sm_hover_tw_neg_translate_x_5 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_5 =
+    A.class "sm:hover:tw--translate-x-5"
+
+
+sm_hover_tw_neg_translate_x_6 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_6 =
+    A.class "sm:hover:tw--translate-x-6"
+
+
+sm_hover_tw_neg_translate_x_8 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_8 =
+    A.class "sm:hover:tw--translate-x-8"
+
+
+sm_hover_tw_neg_translate_x_10 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_10 =
+    A.class "sm:hover:tw--translate-x-10"
+
+
+sm_hover_tw_neg_translate_x_12 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_12 =
+    A.class "sm:hover:tw--translate-x-12"
+
+
+sm_hover_tw_neg_translate_x_16 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_16 =
+    A.class "sm:hover:tw--translate-x-16"
+
+
+sm_hover_tw_neg_translate_x_20 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_20 =
+    A.class "sm:hover:tw--translate-x-20"
+
+
+sm_hover_tw_neg_translate_x_24 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_24 =
+    A.class "sm:hover:tw--translate-x-24"
+
+
+sm_hover_tw_neg_translate_x_32 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_32 =
+    A.class "sm:hover:tw--translate-x-32"
+
+
+sm_hover_tw_neg_translate_x_40 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_40 =
+    A.class "sm:hover:tw--translate-x-40"
+
+
+sm_hover_tw_neg_translate_x_48 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_48 =
+    A.class "sm:hover:tw--translate-x-48"
+
+
+sm_hover_tw_neg_translate_x_56 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_56 =
+    A.class "sm:hover:tw--translate-x-56"
+
+
+sm_hover_tw_neg_translate_x_64 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_64 =
+    A.class "sm:hover:tw--translate-x-64"
+
+
+sm_hover_tw_neg_translate_x_px : Html.Attribute msg
+sm_hover_tw_neg_translate_x_px =
+    A.class "sm:hover:tw--translate-x-px"
+
+
+sm_hover_tw_neg_translate_x_full : Html.Attribute msg
+sm_hover_tw_neg_translate_x_full =
+    A.class "sm:hover:tw--translate-x-full"
+
+
+sm_hover_tw_neg_translate_x_1over2 : Html.Attribute msg
+sm_hover_tw_neg_translate_x_1over2 =
+    A.class "sm:hover:tw--translate-x-1/2"
+
+
+sm_hover_tw_translate_x_1over2 : Html.Attribute msg
+sm_hover_tw_translate_x_1over2 =
+    A.class "sm:hover:tw-translate-x-1/2"
+
+
+sm_hover_tw_translate_x_full : Html.Attribute msg
+sm_hover_tw_translate_x_full =
+    A.class "sm:hover:tw-translate-x-full"
+
+
+sm_hover_tw_translate_y_0 : Html.Attribute msg
+sm_hover_tw_translate_y_0 =
+    A.class "sm:hover:tw-translate-y-0"
+
+
+sm_hover_tw_translate_y_1 : Html.Attribute msg
+sm_hover_tw_translate_y_1 =
+    A.class "sm:hover:tw-translate-y-1"
+
+
+sm_hover_tw_translate_y_2 : Html.Attribute msg
+sm_hover_tw_translate_y_2 =
+    A.class "sm:hover:tw-translate-y-2"
+
+
+sm_hover_tw_translate_y_3 : Html.Attribute msg
+sm_hover_tw_translate_y_3 =
+    A.class "sm:hover:tw-translate-y-3"
+
+
+sm_hover_tw_translate_y_4 : Html.Attribute msg
+sm_hover_tw_translate_y_4 =
+    A.class "sm:hover:tw-translate-y-4"
+
+
+sm_hover_tw_translate_y_5 : Html.Attribute msg
+sm_hover_tw_translate_y_5 =
+    A.class "sm:hover:tw-translate-y-5"
+
+
+sm_hover_tw_translate_y_6 : Html.Attribute msg
+sm_hover_tw_translate_y_6 =
+    A.class "sm:hover:tw-translate-y-6"
+
+
+sm_hover_tw_translate_y_8 : Html.Attribute msg
+sm_hover_tw_translate_y_8 =
+    A.class "sm:hover:tw-translate-y-8"
+
+
+sm_hover_tw_translate_y_10 : Html.Attribute msg
+sm_hover_tw_translate_y_10 =
+    A.class "sm:hover:tw-translate-y-10"
+
+
+sm_hover_tw_translate_y_12 : Html.Attribute msg
+sm_hover_tw_translate_y_12 =
+    A.class "sm:hover:tw-translate-y-12"
+
+
+sm_hover_tw_translate_y_16 : Html.Attribute msg
+sm_hover_tw_translate_y_16 =
+    A.class "sm:hover:tw-translate-y-16"
+
+
+sm_hover_tw_translate_y_20 : Html.Attribute msg
+sm_hover_tw_translate_y_20 =
+    A.class "sm:hover:tw-translate-y-20"
+
+
+sm_hover_tw_translate_y_24 : Html.Attribute msg
+sm_hover_tw_translate_y_24 =
+    A.class "sm:hover:tw-translate-y-24"
+
+
+sm_hover_tw_translate_y_32 : Html.Attribute msg
+sm_hover_tw_translate_y_32 =
+    A.class "sm:hover:tw-translate-y-32"
+
+
+sm_hover_tw_translate_y_40 : Html.Attribute msg
+sm_hover_tw_translate_y_40 =
+    A.class "sm:hover:tw-translate-y-40"
+
+
+sm_hover_tw_translate_y_48 : Html.Attribute msg
+sm_hover_tw_translate_y_48 =
+    A.class "sm:hover:tw-translate-y-48"
+
+
+sm_hover_tw_translate_y_56 : Html.Attribute msg
+sm_hover_tw_translate_y_56 =
+    A.class "sm:hover:tw-translate-y-56"
+
+
+sm_hover_tw_translate_y_64 : Html.Attribute msg
+sm_hover_tw_translate_y_64 =
+    A.class "sm:hover:tw-translate-y-64"
+
+
+sm_hover_tw_translate_y_px : Html.Attribute msg
+sm_hover_tw_translate_y_px =
+    A.class "sm:hover:tw-translate-y-px"
+
+
+sm_hover_tw_neg_translate_y_1 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_1 =
+    A.class "sm:hover:tw--translate-y-1"
+
+
+sm_hover_tw_neg_translate_y_2 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_2 =
+    A.class "sm:hover:tw--translate-y-2"
+
+
+sm_hover_tw_neg_translate_y_3 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_3 =
+    A.class "sm:hover:tw--translate-y-3"
+
+
+sm_hover_tw_neg_translate_y_4 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_4 =
+    A.class "sm:hover:tw--translate-y-4"
+
+
+sm_hover_tw_neg_translate_y_5 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_5 =
+    A.class "sm:hover:tw--translate-y-5"
+
+
+sm_hover_tw_neg_translate_y_6 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_6 =
+    A.class "sm:hover:tw--translate-y-6"
+
+
+sm_hover_tw_neg_translate_y_8 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_8 =
+    A.class "sm:hover:tw--translate-y-8"
+
+
+sm_hover_tw_neg_translate_y_10 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_10 =
+    A.class "sm:hover:tw--translate-y-10"
+
+
+sm_hover_tw_neg_translate_y_12 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_12 =
+    A.class "sm:hover:tw--translate-y-12"
+
+
+sm_hover_tw_neg_translate_y_16 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_16 =
+    A.class "sm:hover:tw--translate-y-16"
+
+
+sm_hover_tw_neg_translate_y_20 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_20 =
+    A.class "sm:hover:tw--translate-y-20"
+
+
+sm_hover_tw_neg_translate_y_24 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_24 =
+    A.class "sm:hover:tw--translate-y-24"
+
+
+sm_hover_tw_neg_translate_y_32 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_32 =
+    A.class "sm:hover:tw--translate-y-32"
+
+
+sm_hover_tw_neg_translate_y_40 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_40 =
+    A.class "sm:hover:tw--translate-y-40"
+
+
+sm_hover_tw_neg_translate_y_48 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_48 =
+    A.class "sm:hover:tw--translate-y-48"
+
+
+sm_hover_tw_neg_translate_y_56 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_56 =
+    A.class "sm:hover:tw--translate-y-56"
+
+
+sm_hover_tw_neg_translate_y_64 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_64 =
+    A.class "sm:hover:tw--translate-y-64"
+
+
+sm_hover_tw_neg_translate_y_px : Html.Attribute msg
+sm_hover_tw_neg_translate_y_px =
+    A.class "sm:hover:tw--translate-y-px"
+
+
+sm_hover_tw_neg_translate_y_full : Html.Attribute msg
+sm_hover_tw_neg_translate_y_full =
+    A.class "sm:hover:tw--translate-y-full"
+
+
+sm_hover_tw_neg_translate_y_1over2 : Html.Attribute msg
+sm_hover_tw_neg_translate_y_1over2 =
+    A.class "sm:hover:tw--translate-y-1/2"
+
+
+sm_hover_tw_translate_y_1over2 : Html.Attribute msg
+sm_hover_tw_translate_y_1over2 =
+    A.class "sm:hover:tw-translate-y-1/2"
+
+
+sm_hover_tw_translate_y_full : Html.Attribute msg
+sm_hover_tw_translate_y_full =
+    A.class "sm:hover:tw-translate-y-full"
+
+
+sm_focus_tw_translate_x_0 : Html.Attribute msg
+sm_focus_tw_translate_x_0 =
+    A.class "sm:focus:tw-translate-x-0"
+
+
+sm_focus_tw_translate_x_1 : Html.Attribute msg
+sm_focus_tw_translate_x_1 =
+    A.class "sm:focus:tw-translate-x-1"
+
+
+sm_focus_tw_translate_x_2 : Html.Attribute msg
+sm_focus_tw_translate_x_2 =
+    A.class "sm:focus:tw-translate-x-2"
+
+
+sm_focus_tw_translate_x_3 : Html.Attribute msg
+sm_focus_tw_translate_x_3 =
+    A.class "sm:focus:tw-translate-x-3"
+
+
+sm_focus_tw_translate_x_4 : Html.Attribute msg
+sm_focus_tw_translate_x_4 =
+    A.class "sm:focus:tw-translate-x-4"
+
+
+sm_focus_tw_translate_x_5 : Html.Attribute msg
+sm_focus_tw_translate_x_5 =
+    A.class "sm:focus:tw-translate-x-5"
+
+
+sm_focus_tw_translate_x_6 : Html.Attribute msg
+sm_focus_tw_translate_x_6 =
+    A.class "sm:focus:tw-translate-x-6"
+
+
+sm_focus_tw_translate_x_8 : Html.Attribute msg
+sm_focus_tw_translate_x_8 =
+    A.class "sm:focus:tw-translate-x-8"
+
+
+sm_focus_tw_translate_x_10 : Html.Attribute msg
+sm_focus_tw_translate_x_10 =
+    A.class "sm:focus:tw-translate-x-10"
+
+
+sm_focus_tw_translate_x_12 : Html.Attribute msg
+sm_focus_tw_translate_x_12 =
+    A.class "sm:focus:tw-translate-x-12"
+
+
+sm_focus_tw_translate_x_16 : Html.Attribute msg
+sm_focus_tw_translate_x_16 =
+    A.class "sm:focus:tw-translate-x-16"
+
+
+sm_focus_tw_translate_x_20 : Html.Attribute msg
+sm_focus_tw_translate_x_20 =
+    A.class "sm:focus:tw-translate-x-20"
+
+
+sm_focus_tw_translate_x_24 : Html.Attribute msg
+sm_focus_tw_translate_x_24 =
+    A.class "sm:focus:tw-translate-x-24"
+
+
+sm_focus_tw_translate_x_32 : Html.Attribute msg
+sm_focus_tw_translate_x_32 =
+    A.class "sm:focus:tw-translate-x-32"
+
+
+sm_focus_tw_translate_x_40 : Html.Attribute msg
+sm_focus_tw_translate_x_40 =
+    A.class "sm:focus:tw-translate-x-40"
+
+
+sm_focus_tw_translate_x_48 : Html.Attribute msg
+sm_focus_tw_translate_x_48 =
+    A.class "sm:focus:tw-translate-x-48"
+
+
+sm_focus_tw_translate_x_56 : Html.Attribute msg
+sm_focus_tw_translate_x_56 =
+    A.class "sm:focus:tw-translate-x-56"
+
+
+sm_focus_tw_translate_x_64 : Html.Attribute msg
+sm_focus_tw_translate_x_64 =
+    A.class "sm:focus:tw-translate-x-64"
+
+
+sm_focus_tw_translate_x_px : Html.Attribute msg
+sm_focus_tw_translate_x_px =
+    A.class "sm:focus:tw-translate-x-px"
+
+
+sm_focus_tw_neg_translate_x_1 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_1 =
+    A.class "sm:focus:tw--translate-x-1"
+
+
+sm_focus_tw_neg_translate_x_2 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_2 =
+    A.class "sm:focus:tw--translate-x-2"
+
+
+sm_focus_tw_neg_translate_x_3 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_3 =
+    A.class "sm:focus:tw--translate-x-3"
+
+
+sm_focus_tw_neg_translate_x_4 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_4 =
+    A.class "sm:focus:tw--translate-x-4"
+
+
+sm_focus_tw_neg_translate_x_5 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_5 =
+    A.class "sm:focus:tw--translate-x-5"
+
+
+sm_focus_tw_neg_translate_x_6 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_6 =
+    A.class "sm:focus:tw--translate-x-6"
+
+
+sm_focus_tw_neg_translate_x_8 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_8 =
+    A.class "sm:focus:tw--translate-x-8"
+
+
+sm_focus_tw_neg_translate_x_10 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_10 =
+    A.class "sm:focus:tw--translate-x-10"
+
+
+sm_focus_tw_neg_translate_x_12 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_12 =
+    A.class "sm:focus:tw--translate-x-12"
+
+
+sm_focus_tw_neg_translate_x_16 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_16 =
+    A.class "sm:focus:tw--translate-x-16"
+
+
+sm_focus_tw_neg_translate_x_20 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_20 =
+    A.class "sm:focus:tw--translate-x-20"
+
+
+sm_focus_tw_neg_translate_x_24 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_24 =
+    A.class "sm:focus:tw--translate-x-24"
+
+
+sm_focus_tw_neg_translate_x_32 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_32 =
+    A.class "sm:focus:tw--translate-x-32"
+
+
+sm_focus_tw_neg_translate_x_40 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_40 =
+    A.class "sm:focus:tw--translate-x-40"
+
+
+sm_focus_tw_neg_translate_x_48 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_48 =
+    A.class "sm:focus:tw--translate-x-48"
+
+
+sm_focus_tw_neg_translate_x_56 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_56 =
+    A.class "sm:focus:tw--translate-x-56"
+
+
+sm_focus_tw_neg_translate_x_64 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_64 =
+    A.class "sm:focus:tw--translate-x-64"
+
+
+sm_focus_tw_neg_translate_x_px : Html.Attribute msg
+sm_focus_tw_neg_translate_x_px =
+    A.class "sm:focus:tw--translate-x-px"
+
+
+sm_focus_tw_neg_translate_x_full : Html.Attribute msg
+sm_focus_tw_neg_translate_x_full =
+    A.class "sm:focus:tw--translate-x-full"
+
+
+sm_focus_tw_neg_translate_x_1over2 : Html.Attribute msg
+sm_focus_tw_neg_translate_x_1over2 =
+    A.class "sm:focus:tw--translate-x-1/2"
+
+
+sm_focus_tw_translate_x_1over2 : Html.Attribute msg
+sm_focus_tw_translate_x_1over2 =
+    A.class "sm:focus:tw-translate-x-1/2"
+
+
+sm_focus_tw_translate_x_full : Html.Attribute msg
+sm_focus_tw_translate_x_full =
+    A.class "sm:focus:tw-translate-x-full"
+
+
+sm_focus_tw_translate_y_0 : Html.Attribute msg
+sm_focus_tw_translate_y_0 =
+    A.class "sm:focus:tw-translate-y-0"
+
+
+sm_focus_tw_translate_y_1 : Html.Attribute msg
+sm_focus_tw_translate_y_1 =
+    A.class "sm:focus:tw-translate-y-1"
+
+
+sm_focus_tw_translate_y_2 : Html.Attribute msg
+sm_focus_tw_translate_y_2 =
+    A.class "sm:focus:tw-translate-y-2"
+
+
+sm_focus_tw_translate_y_3 : Html.Attribute msg
+sm_focus_tw_translate_y_3 =
+    A.class "sm:focus:tw-translate-y-3"
+
+
+sm_focus_tw_translate_y_4 : Html.Attribute msg
+sm_focus_tw_translate_y_4 =
+    A.class "sm:focus:tw-translate-y-4"
+
+
+sm_focus_tw_translate_y_5 : Html.Attribute msg
+sm_focus_tw_translate_y_5 =
+    A.class "sm:focus:tw-translate-y-5"
+
+
+sm_focus_tw_translate_y_6 : Html.Attribute msg
+sm_focus_tw_translate_y_6 =
+    A.class "sm:focus:tw-translate-y-6"
+
+
+sm_focus_tw_translate_y_8 : Html.Attribute msg
+sm_focus_tw_translate_y_8 =
+    A.class "sm:focus:tw-translate-y-8"
+
+
+sm_focus_tw_translate_y_10 : Html.Attribute msg
+sm_focus_tw_translate_y_10 =
+    A.class "sm:focus:tw-translate-y-10"
+
+
+sm_focus_tw_translate_y_12 : Html.Attribute msg
+sm_focus_tw_translate_y_12 =
+    A.class "sm:focus:tw-translate-y-12"
+
+
+sm_focus_tw_translate_y_16 : Html.Attribute msg
+sm_focus_tw_translate_y_16 =
+    A.class "sm:focus:tw-translate-y-16"
+
+
+sm_focus_tw_translate_y_20 : Html.Attribute msg
+sm_focus_tw_translate_y_20 =
+    A.class "sm:focus:tw-translate-y-20"
+
+
+sm_focus_tw_translate_y_24 : Html.Attribute msg
+sm_focus_tw_translate_y_24 =
+    A.class "sm:focus:tw-translate-y-24"
+
+
+sm_focus_tw_translate_y_32 : Html.Attribute msg
+sm_focus_tw_translate_y_32 =
+    A.class "sm:focus:tw-translate-y-32"
+
+
+sm_focus_tw_translate_y_40 : Html.Attribute msg
+sm_focus_tw_translate_y_40 =
+    A.class "sm:focus:tw-translate-y-40"
+
+
+sm_focus_tw_translate_y_48 : Html.Attribute msg
+sm_focus_tw_translate_y_48 =
+    A.class "sm:focus:tw-translate-y-48"
+
+
+sm_focus_tw_translate_y_56 : Html.Attribute msg
+sm_focus_tw_translate_y_56 =
+    A.class "sm:focus:tw-translate-y-56"
+
+
+sm_focus_tw_translate_y_64 : Html.Attribute msg
+sm_focus_tw_translate_y_64 =
+    A.class "sm:focus:tw-translate-y-64"
+
+
+sm_focus_tw_translate_y_px : Html.Attribute msg
+sm_focus_tw_translate_y_px =
+    A.class "sm:focus:tw-translate-y-px"
+
+
+sm_focus_tw_neg_translate_y_1 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_1 =
+    A.class "sm:focus:tw--translate-y-1"
+
+
+sm_focus_tw_neg_translate_y_2 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_2 =
+    A.class "sm:focus:tw--translate-y-2"
+
+
+sm_focus_tw_neg_translate_y_3 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_3 =
+    A.class "sm:focus:tw--translate-y-3"
+
+
+sm_focus_tw_neg_translate_y_4 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_4 =
+    A.class "sm:focus:tw--translate-y-4"
+
+
+sm_focus_tw_neg_translate_y_5 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_5 =
+    A.class "sm:focus:tw--translate-y-5"
+
+
+sm_focus_tw_neg_translate_y_6 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_6 =
+    A.class "sm:focus:tw--translate-y-6"
+
+
+sm_focus_tw_neg_translate_y_8 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_8 =
+    A.class "sm:focus:tw--translate-y-8"
+
+
+sm_focus_tw_neg_translate_y_10 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_10 =
+    A.class "sm:focus:tw--translate-y-10"
+
+
+sm_focus_tw_neg_translate_y_12 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_12 =
+    A.class "sm:focus:tw--translate-y-12"
+
+
+sm_focus_tw_neg_translate_y_16 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_16 =
+    A.class "sm:focus:tw--translate-y-16"
+
+
+sm_focus_tw_neg_translate_y_20 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_20 =
+    A.class "sm:focus:tw--translate-y-20"
+
+
+sm_focus_tw_neg_translate_y_24 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_24 =
+    A.class "sm:focus:tw--translate-y-24"
+
+
+sm_focus_tw_neg_translate_y_32 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_32 =
+    A.class "sm:focus:tw--translate-y-32"
+
+
+sm_focus_tw_neg_translate_y_40 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_40 =
+    A.class "sm:focus:tw--translate-y-40"
+
+
+sm_focus_tw_neg_translate_y_48 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_48 =
+    A.class "sm:focus:tw--translate-y-48"
+
+
+sm_focus_tw_neg_translate_y_56 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_56 =
+    A.class "sm:focus:tw--translate-y-56"
+
+
+sm_focus_tw_neg_translate_y_64 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_64 =
+    A.class "sm:focus:tw--translate-y-64"
+
+
+sm_focus_tw_neg_translate_y_px : Html.Attribute msg
+sm_focus_tw_neg_translate_y_px =
+    A.class "sm:focus:tw--translate-y-px"
+
+
+sm_focus_tw_neg_translate_y_full : Html.Attribute msg
+sm_focus_tw_neg_translate_y_full =
+    A.class "sm:focus:tw--translate-y-full"
+
+
+sm_focus_tw_neg_translate_y_1over2 : Html.Attribute msg
+sm_focus_tw_neg_translate_y_1over2 =
+    A.class "sm:focus:tw--translate-y-1/2"
+
+
+sm_focus_tw_translate_y_1over2 : Html.Attribute msg
+sm_focus_tw_translate_y_1over2 =
+    A.class "sm:focus:tw-translate-y-1/2"
+
+
+sm_focus_tw_translate_y_full : Html.Attribute msg
+sm_focus_tw_translate_y_full =
+    A.class "sm:focus:tw-translate-y-full"
+
+
+sm_tw_skew_x_0 : Html.Attribute msg
+sm_tw_skew_x_0 =
+    A.class "sm:tw-skew-x-0"
+
+
+sm_tw_skew_x_3 : Html.Attribute msg
+sm_tw_skew_x_3 =
+    A.class "sm:tw-skew-x-3"
+
+
+sm_tw_skew_x_6 : Html.Attribute msg
+sm_tw_skew_x_6 =
+    A.class "sm:tw-skew-x-6"
+
+
+sm_tw_skew_x_12 : Html.Attribute msg
+sm_tw_skew_x_12 =
+    A.class "sm:tw-skew-x-12"
+
+
+sm_tw_neg_skew_x_12 : Html.Attribute msg
+sm_tw_neg_skew_x_12 =
+    A.class "sm:tw--skew-x-12"
+
+
+sm_tw_neg_skew_x_6 : Html.Attribute msg
+sm_tw_neg_skew_x_6 =
+    A.class "sm:tw--skew-x-6"
+
+
+sm_tw_neg_skew_x_3 : Html.Attribute msg
+sm_tw_neg_skew_x_3 =
+    A.class "sm:tw--skew-x-3"
+
+
+sm_tw_skew_y_0 : Html.Attribute msg
+sm_tw_skew_y_0 =
+    A.class "sm:tw-skew-y-0"
+
+
+sm_tw_skew_y_3 : Html.Attribute msg
+sm_tw_skew_y_3 =
+    A.class "sm:tw-skew-y-3"
+
+
+sm_tw_skew_y_6 : Html.Attribute msg
+sm_tw_skew_y_6 =
+    A.class "sm:tw-skew-y-6"
+
+
+sm_tw_skew_y_12 : Html.Attribute msg
+sm_tw_skew_y_12 =
+    A.class "sm:tw-skew-y-12"
+
+
+sm_tw_neg_skew_y_12 : Html.Attribute msg
+sm_tw_neg_skew_y_12 =
+    A.class "sm:tw--skew-y-12"
+
+
+sm_tw_neg_skew_y_6 : Html.Attribute msg
+sm_tw_neg_skew_y_6 =
+    A.class "sm:tw--skew-y-6"
+
+
+sm_tw_neg_skew_y_3 : Html.Attribute msg
+sm_tw_neg_skew_y_3 =
+    A.class "sm:tw--skew-y-3"
+
+
+sm_hover_tw_skew_x_0 : Html.Attribute msg
+sm_hover_tw_skew_x_0 =
+    A.class "sm:hover:tw-skew-x-0"
+
+
+sm_hover_tw_skew_x_3 : Html.Attribute msg
+sm_hover_tw_skew_x_3 =
+    A.class "sm:hover:tw-skew-x-3"
+
+
+sm_hover_tw_skew_x_6 : Html.Attribute msg
+sm_hover_tw_skew_x_6 =
+    A.class "sm:hover:tw-skew-x-6"
+
+
+sm_hover_tw_skew_x_12 : Html.Attribute msg
+sm_hover_tw_skew_x_12 =
+    A.class "sm:hover:tw-skew-x-12"
+
+
+sm_hover_tw_neg_skew_x_12 : Html.Attribute msg
+sm_hover_tw_neg_skew_x_12 =
+    A.class "sm:hover:tw--skew-x-12"
+
+
+sm_hover_tw_neg_skew_x_6 : Html.Attribute msg
+sm_hover_tw_neg_skew_x_6 =
+    A.class "sm:hover:tw--skew-x-6"
+
+
+sm_hover_tw_neg_skew_x_3 : Html.Attribute msg
+sm_hover_tw_neg_skew_x_3 =
+    A.class "sm:hover:tw--skew-x-3"
+
+
+sm_hover_tw_skew_y_0 : Html.Attribute msg
+sm_hover_tw_skew_y_0 =
+    A.class "sm:hover:tw-skew-y-0"
+
+
+sm_hover_tw_skew_y_3 : Html.Attribute msg
+sm_hover_tw_skew_y_3 =
+    A.class "sm:hover:tw-skew-y-3"
+
+
+sm_hover_tw_skew_y_6 : Html.Attribute msg
+sm_hover_tw_skew_y_6 =
+    A.class "sm:hover:tw-skew-y-6"
+
+
+sm_hover_tw_skew_y_12 : Html.Attribute msg
+sm_hover_tw_skew_y_12 =
+    A.class "sm:hover:tw-skew-y-12"
+
+
+sm_hover_tw_neg_skew_y_12 : Html.Attribute msg
+sm_hover_tw_neg_skew_y_12 =
+    A.class "sm:hover:tw--skew-y-12"
+
+
+sm_hover_tw_neg_skew_y_6 : Html.Attribute msg
+sm_hover_tw_neg_skew_y_6 =
+    A.class "sm:hover:tw--skew-y-6"
+
+
+sm_hover_tw_neg_skew_y_3 : Html.Attribute msg
+sm_hover_tw_neg_skew_y_3 =
+    A.class "sm:hover:tw--skew-y-3"
+
+
+sm_focus_tw_skew_x_0 : Html.Attribute msg
+sm_focus_tw_skew_x_0 =
+    A.class "sm:focus:tw-skew-x-0"
+
+
+sm_focus_tw_skew_x_3 : Html.Attribute msg
+sm_focus_tw_skew_x_3 =
+    A.class "sm:focus:tw-skew-x-3"
+
+
+sm_focus_tw_skew_x_6 : Html.Attribute msg
+sm_focus_tw_skew_x_6 =
+    A.class "sm:focus:tw-skew-x-6"
+
+
+sm_focus_tw_skew_x_12 : Html.Attribute msg
+sm_focus_tw_skew_x_12 =
+    A.class "sm:focus:tw-skew-x-12"
+
+
+sm_focus_tw_neg_skew_x_12 : Html.Attribute msg
+sm_focus_tw_neg_skew_x_12 =
+    A.class "sm:focus:tw--skew-x-12"
+
+
+sm_focus_tw_neg_skew_x_6 : Html.Attribute msg
+sm_focus_tw_neg_skew_x_6 =
+    A.class "sm:focus:tw--skew-x-6"
+
+
+sm_focus_tw_neg_skew_x_3 : Html.Attribute msg
+sm_focus_tw_neg_skew_x_3 =
+    A.class "sm:focus:tw--skew-x-3"
+
+
+sm_focus_tw_skew_y_0 : Html.Attribute msg
+sm_focus_tw_skew_y_0 =
+    A.class "sm:focus:tw-skew-y-0"
+
+
+sm_focus_tw_skew_y_3 : Html.Attribute msg
+sm_focus_tw_skew_y_3 =
+    A.class "sm:focus:tw-skew-y-3"
+
+
+sm_focus_tw_skew_y_6 : Html.Attribute msg
+sm_focus_tw_skew_y_6 =
+    A.class "sm:focus:tw-skew-y-6"
+
+
+sm_focus_tw_skew_y_12 : Html.Attribute msg
+sm_focus_tw_skew_y_12 =
+    A.class "sm:focus:tw-skew-y-12"
+
+
+sm_focus_tw_neg_skew_y_12 : Html.Attribute msg
+sm_focus_tw_neg_skew_y_12 =
+    A.class "sm:focus:tw--skew-y-12"
+
+
+sm_focus_tw_neg_skew_y_6 : Html.Attribute msg
+sm_focus_tw_neg_skew_y_6 =
+    A.class "sm:focus:tw--skew-y-6"
+
+
+sm_focus_tw_neg_skew_y_3 : Html.Attribute msg
+sm_focus_tw_neg_skew_y_3 =
+    A.class "sm:focus:tw--skew-y-3"
+
+
+sm_tw_transition_none : Html.Attribute msg
+sm_tw_transition_none =
+    A.class "sm:tw-transition-none"
+
+
+sm_tw_transition_all : Html.Attribute msg
+sm_tw_transition_all =
+    A.class "sm:tw-transition-all"
+
+
+sm_tw_transition : Html.Attribute msg
+sm_tw_transition =
+    A.class "sm:tw-transition"
+
+
+sm_tw_transition_colors : Html.Attribute msg
+sm_tw_transition_colors =
+    A.class "sm:tw-transition-colors"
+
+
+sm_tw_transition_opacity : Html.Attribute msg
+sm_tw_transition_opacity =
+    A.class "sm:tw-transition-opacity"
+
+
+sm_tw_transition_shadow : Html.Attribute msg
+sm_tw_transition_shadow =
+    A.class "sm:tw-transition-shadow"
+
+
+sm_tw_transition_transform : Html.Attribute msg
+sm_tw_transition_transform =
+    A.class "sm:tw-transition-transform"
+
+
+sm_tw_ease_linear : Html.Attribute msg
+sm_tw_ease_linear =
+    A.class "sm:tw-ease-linear"
+
+
+sm_tw_ease_in : Html.Attribute msg
+sm_tw_ease_in =
+    A.class "sm:tw-ease-in"
+
+
+sm_tw_ease_out : Html.Attribute msg
+sm_tw_ease_out =
+    A.class "sm:tw-ease-out"
+
+
+sm_tw_ease_in_out : Html.Attribute msg
+sm_tw_ease_in_out =
+    A.class "sm:tw-ease-in-out"
+
+
+sm_tw_duration_75 : Html.Attribute msg
+sm_tw_duration_75 =
+    A.class "sm:tw-duration-75"
+
+
+sm_tw_duration_100 : Html.Attribute msg
+sm_tw_duration_100 =
+    A.class "sm:tw-duration-100"
+
+
+sm_tw_duration_150 : Html.Attribute msg
+sm_tw_duration_150 =
+    A.class "sm:tw-duration-150"
+
+
+sm_tw_duration_200 : Html.Attribute msg
+sm_tw_duration_200 =
+    A.class "sm:tw-duration-200"
+
+
+sm_tw_duration_300 : Html.Attribute msg
+sm_tw_duration_300 =
+    A.class "sm:tw-duration-300"
+
+
+sm_tw_duration_500 : Html.Attribute msg
+sm_tw_duration_500 =
+    A.class "sm:tw-duration-500"
+
+
+sm_tw_duration_700 : Html.Attribute msg
+sm_tw_duration_700 =
+    A.class "sm:tw-duration-700"
+
+
+sm_tw_duration_1000 : Html.Attribute msg
+sm_tw_duration_1000 =
+    A.class "sm:tw-duration-1000"
 
 
 md_tw_sr_only : Html.Attribute msg
@@ -31333,6 +40603,11 @@ md_tw_rounded =
     A.class "md:tw-rounded"
 
 
+md_tw_rounded_md : Html.Attribute msg
+md_tw_rounded_md =
+    A.class "md:tw-rounded-md"
+
+
 md_tw_rounded_lg : Html.Attribute msg
 md_tw_rounded_lg =
     A.class "md:tw-rounded-lg"
@@ -31401,6 +40676,26 @@ md_tw_rounded_b =
 md_tw_rounded_l : Html.Attribute msg
 md_tw_rounded_l =
     A.class "md:tw-rounded-l"
+
+
+md_tw_rounded_t_md : Html.Attribute msg
+md_tw_rounded_t_md =
+    A.class "md:tw-rounded-t-md"
+
+
+md_tw_rounded_r_md : Html.Attribute msg
+md_tw_rounded_r_md =
+    A.class "md:tw-rounded-r-md"
+
+
+md_tw_rounded_b_md : Html.Attribute msg
+md_tw_rounded_b_md =
+    A.class "md:tw-rounded-b-md"
+
+
+md_tw_rounded_l_md : Html.Attribute msg
+md_tw_rounded_l_md =
+    A.class "md:tw-rounded-l-md"
 
 
 md_tw_rounded_t_lg : Html.Attribute msg
@@ -31501,6 +40796,26 @@ md_tw_rounded_br =
 md_tw_rounded_bl : Html.Attribute msg
 md_tw_rounded_bl =
     A.class "md:tw-rounded-bl"
+
+
+md_tw_rounded_tl_md : Html.Attribute msg
+md_tw_rounded_tl_md =
+    A.class "md:tw-rounded-tl-md"
+
+
+md_tw_rounded_tr_md : Html.Attribute msg
+md_tw_rounded_tr_md =
+    A.class "md:tw-rounded-tr-md"
+
+
+md_tw_rounded_br_md : Html.Attribute msg
+md_tw_rounded_br_md =
+    A.class "md:tw-rounded-br-md"
+
+
+md_tw_rounded_bl_md : Html.Attribute msg
+md_tw_rounded_bl_md =
+    A.class "md:tw-rounded-bl-md"
 
 
 md_tw_rounded_tl_lg : Html.Attribute msg
@@ -31693,6 +41008,16 @@ md_tw_border_l =
     A.class "md:tw-border-l"
 
 
+md_tw_box_border : Html.Attribute msg
+md_tw_box_border =
+    A.class "md:tw-box-border"
+
+
+md_tw_box_content : Html.Attribute msg
+md_tw_box_content =
+    A.class "md:tw-box-content"
+
+
 md_tw_cursor_auto : Html.Attribute msg
 md_tw_cursor_auto =
     A.class "md:tw-cursor-auto"
@@ -31753,19 +41078,54 @@ md_tw_inline_flex =
     A.class "md:tw-inline-flex"
 
 
+md_tw_grid : Html.Attribute msg
+md_tw_grid =
+    A.class "md:tw-grid"
+
+
 md_tw_table : Html.Attribute msg
 md_tw_table =
     A.class "md:tw-table"
 
 
-md_tw_table_row : Html.Attribute msg
-md_tw_table_row =
-    A.class "md:tw-table-row"
+md_tw_table_caption : Html.Attribute msg
+md_tw_table_caption =
+    A.class "md:tw-table-caption"
 
 
 md_tw_table_cell : Html.Attribute msg
 md_tw_table_cell =
     A.class "md:tw-table-cell"
+
+
+md_tw_table_column : Html.Attribute msg
+md_tw_table_column =
+    A.class "md:tw-table-column"
+
+
+md_tw_table_column_group : Html.Attribute msg
+md_tw_table_column_group =
+    A.class "md:tw-table-column-group"
+
+
+md_tw_table_footer_group : Html.Attribute msg
+md_tw_table_footer_group =
+    A.class "md:tw-table-footer-group"
+
+
+md_tw_table_header_group : Html.Attribute msg
+md_tw_table_header_group =
+    A.class "md:tw-table-header-group"
+
+
+md_tw_table_row_group : Html.Attribute msg
+md_tw_table_row_group =
+    A.class "md:tw-table-row-group"
+
+
+md_tw_table_row : Html.Attribute msg
+md_tw_table_row =
+    A.class "md:tw-table-row"
 
 
 md_tw_hidden : Html.Attribute msg
@@ -31881,6 +41241,11 @@ md_tw_justify_between =
 md_tw_justify_around : Html.Attribute msg
 md_tw_justify_around =
     A.class "md:tw-justify-around"
+
+
+md_tw_justify_evenly : Html.Attribute msg
+md_tw_justify_evenly =
+    A.class "md:tw-justify-evenly"
 
 
 md_tw_content_center : Html.Attribute msg
@@ -32041,6 +41406,21 @@ md_tw_float_none =
 md_tw_clearfix_after : Html.Attribute msg
 md_tw_clearfix_after =
     A.class "md:tw-clearfix:after"
+
+
+md_tw_clear_left : Html.Attribute msg
+md_tw_clear_left =
+    A.class "md:tw-clear-left"
+
+
+md_tw_clear_right : Html.Attribute msg
+md_tw_clear_right =
+    A.class "md:tw-clear-right"
+
+
+md_tw_clear_both : Html.Attribute msg
+md_tw_clear_both =
+    A.class "md:tw-clear-both"
 
 
 md_tw_font_sans : Html.Attribute msg
@@ -32301,6 +41681,46 @@ md_tw_h_full =
 md_tw_h_screen : Html.Attribute msg
 md_tw_h_screen =
     A.class "md:tw-h-screen"
+
+
+md_tw_leading_3 : Html.Attribute msg
+md_tw_leading_3 =
+    A.class "md:tw-leading-3"
+
+
+md_tw_leading_4 : Html.Attribute msg
+md_tw_leading_4 =
+    A.class "md:tw-leading-4"
+
+
+md_tw_leading_5 : Html.Attribute msg
+md_tw_leading_5 =
+    A.class "md:tw-leading-5"
+
+
+md_tw_leading_6 : Html.Attribute msg
+md_tw_leading_6 =
+    A.class "md:tw-leading-6"
+
+
+md_tw_leading_7 : Html.Attribute msg
+md_tw_leading_7 =
+    A.class "md:tw-leading-7"
+
+
+md_tw_leading_8 : Html.Attribute msg
+md_tw_leading_8 =
+    A.class "md:tw-leading-8"
+
+
+md_tw_leading_9 : Html.Attribute msg
+md_tw_leading_9 =
+    A.class "md:tw-leading-9"
+
+
+md_tw_leading_10 : Html.Attribute msg
+md_tw_leading_10 =
+    A.class "md:tw-leading-10"
 
 
 md_tw_leading_none : Html.Attribute msg
@@ -33698,6 +43118,11 @@ md_tw_max_h_screen =
     A.class "md:tw-max-h-screen"
 
 
+md_tw_max_w_none : Html.Attribute msg
+md_tw_max_w_none =
+    A.class "md:tw-max-w-none"
+
+
 md_tw_max_w_xs : Html.Attribute msg
 md_tw_max_w_xs =
     A.class "md:tw-max-w-xs"
@@ -33751,6 +43176,26 @@ md_tw_max_w_6xl =
 md_tw_max_w_full : Html.Attribute msg
 md_tw_max_w_full =
     A.class "md:tw-max-w-full"
+
+
+md_tw_max_w_screen_sm : Html.Attribute msg
+md_tw_max_w_screen_sm =
+    A.class "md:tw-max-w-screen-sm"
+
+
+md_tw_max_w_screen_md : Html.Attribute msg
+md_tw_max_w_screen_md =
+    A.class "md:tw-max-w-screen-md"
+
+
+md_tw_max_w_screen_lg : Html.Attribute msg
+md_tw_max_w_screen_lg =
+    A.class "md:tw-max-w-screen-lg"
+
+
+md_tw_max_w_screen_xl : Html.Attribute msg
+md_tw_max_w_screen_xl =
+    A.class "md:tw-max-w-screen-xl"
 
 
 md_tw_min_h_0 : Html.Attribute msg
@@ -35723,6 +45168,16 @@ md_tw_resize =
     A.class "md:tw-resize"
 
 
+md_tw_shadow_xs : Html.Attribute msg
+md_tw_shadow_xs =
+    A.class "md:tw-shadow-xs"
+
+
+md_tw_shadow_sm : Html.Attribute msg
+md_tw_shadow_sm =
+    A.class "md:tw-shadow-sm"
+
+
 md_tw_shadow : Html.Attribute msg
 md_tw_shadow =
     A.class "md:tw-shadow"
@@ -35763,6 +45218,16 @@ md_tw_shadow_none =
     A.class "md:tw-shadow-none"
 
 
+md_hover_tw_shadow_xs : Html.Attribute msg
+md_hover_tw_shadow_xs =
+    A.class "md:hover:tw-shadow-xs"
+
+
+md_hover_tw_shadow_sm : Html.Attribute msg
+md_hover_tw_shadow_sm =
+    A.class "md:hover:tw-shadow-sm"
+
+
 md_hover_tw_shadow : Html.Attribute msg
 md_hover_tw_shadow =
     A.class "md:hover:tw-shadow"
@@ -35801,6 +45266,16 @@ md_hover_tw_shadow_outline =
 md_hover_tw_shadow_none : Html.Attribute msg
 md_hover_tw_shadow_none =
     A.class "md:hover:tw-shadow-none"
+
+
+md_focus_tw_shadow_xs : Html.Attribute msg
+md_focus_tw_shadow_xs =
+    A.class "md:focus:tw-shadow-xs"
+
+
+md_focus_tw_shadow_sm : Html.Attribute msg
+md_focus_tw_shadow_sm =
+    A.class "md:focus:tw-shadow-sm"
 
 
 md_focus_tw_shadow : Html.Attribute msg
@@ -35851,6 +45326,21 @@ md_tw_fill_current =
 md_tw_stroke_current : Html.Attribute msg
 md_tw_stroke_current =
     A.class "md:tw-stroke-current"
+
+
+md_tw_stroke_0 : Html.Attribute msg
+md_tw_stroke_0 =
+    A.class "md:tw-stroke-0"
+
+
+md_tw_stroke_1 : Html.Attribute msg
+md_tw_stroke_1 =
+    A.class "md:tw-stroke-1"
+
+
+md_tw_stroke_2 : Html.Attribute msg
+md_tw_stroke_2 =
+    A.class "md:tw-stroke-2"
 
 
 md_tw_table_auto : Html.Attribute msg
@@ -37821,6 +47311,2876 @@ md_tw_z_50 =
 md_tw_z_auto : Html.Attribute msg
 md_tw_z_auto =
     A.class "md:tw-z-auto"
+
+
+md_tw_gap_0 : Html.Attribute msg
+md_tw_gap_0 =
+    A.class "md:tw-gap-0"
+
+
+md_tw_gap_1 : Html.Attribute msg
+md_tw_gap_1 =
+    A.class "md:tw-gap-1"
+
+
+md_tw_gap_2 : Html.Attribute msg
+md_tw_gap_2 =
+    A.class "md:tw-gap-2"
+
+
+md_tw_gap_3 : Html.Attribute msg
+md_tw_gap_3 =
+    A.class "md:tw-gap-3"
+
+
+md_tw_gap_4 : Html.Attribute msg
+md_tw_gap_4 =
+    A.class "md:tw-gap-4"
+
+
+md_tw_gap_5 : Html.Attribute msg
+md_tw_gap_5 =
+    A.class "md:tw-gap-5"
+
+
+md_tw_gap_6 : Html.Attribute msg
+md_tw_gap_6 =
+    A.class "md:tw-gap-6"
+
+
+md_tw_gap_8 : Html.Attribute msg
+md_tw_gap_8 =
+    A.class "md:tw-gap-8"
+
+
+md_tw_gap_10 : Html.Attribute msg
+md_tw_gap_10 =
+    A.class "md:tw-gap-10"
+
+
+md_tw_gap_12 : Html.Attribute msg
+md_tw_gap_12 =
+    A.class "md:tw-gap-12"
+
+
+md_tw_gap_16 : Html.Attribute msg
+md_tw_gap_16 =
+    A.class "md:tw-gap-16"
+
+
+md_tw_gap_20 : Html.Attribute msg
+md_tw_gap_20 =
+    A.class "md:tw-gap-20"
+
+
+md_tw_gap_24 : Html.Attribute msg
+md_tw_gap_24 =
+    A.class "md:tw-gap-24"
+
+
+md_tw_gap_32 : Html.Attribute msg
+md_tw_gap_32 =
+    A.class "md:tw-gap-32"
+
+
+md_tw_gap_40 : Html.Attribute msg
+md_tw_gap_40 =
+    A.class "md:tw-gap-40"
+
+
+md_tw_gap_48 : Html.Attribute msg
+md_tw_gap_48 =
+    A.class "md:tw-gap-48"
+
+
+md_tw_gap_56 : Html.Attribute msg
+md_tw_gap_56 =
+    A.class "md:tw-gap-56"
+
+
+md_tw_gap_64 : Html.Attribute msg
+md_tw_gap_64 =
+    A.class "md:tw-gap-64"
+
+
+md_tw_gap_px : Html.Attribute msg
+md_tw_gap_px =
+    A.class "md:tw-gap-px"
+
+
+md_tw_col_gap_0 : Html.Attribute msg
+md_tw_col_gap_0 =
+    A.class "md:tw-col-gap-0"
+
+
+md_tw_col_gap_1 : Html.Attribute msg
+md_tw_col_gap_1 =
+    A.class "md:tw-col-gap-1"
+
+
+md_tw_col_gap_2 : Html.Attribute msg
+md_tw_col_gap_2 =
+    A.class "md:tw-col-gap-2"
+
+
+md_tw_col_gap_3 : Html.Attribute msg
+md_tw_col_gap_3 =
+    A.class "md:tw-col-gap-3"
+
+
+md_tw_col_gap_4 : Html.Attribute msg
+md_tw_col_gap_4 =
+    A.class "md:tw-col-gap-4"
+
+
+md_tw_col_gap_5 : Html.Attribute msg
+md_tw_col_gap_5 =
+    A.class "md:tw-col-gap-5"
+
+
+md_tw_col_gap_6 : Html.Attribute msg
+md_tw_col_gap_6 =
+    A.class "md:tw-col-gap-6"
+
+
+md_tw_col_gap_8 : Html.Attribute msg
+md_tw_col_gap_8 =
+    A.class "md:tw-col-gap-8"
+
+
+md_tw_col_gap_10 : Html.Attribute msg
+md_tw_col_gap_10 =
+    A.class "md:tw-col-gap-10"
+
+
+md_tw_col_gap_12 : Html.Attribute msg
+md_tw_col_gap_12 =
+    A.class "md:tw-col-gap-12"
+
+
+md_tw_col_gap_16 : Html.Attribute msg
+md_tw_col_gap_16 =
+    A.class "md:tw-col-gap-16"
+
+
+md_tw_col_gap_20 : Html.Attribute msg
+md_tw_col_gap_20 =
+    A.class "md:tw-col-gap-20"
+
+
+md_tw_col_gap_24 : Html.Attribute msg
+md_tw_col_gap_24 =
+    A.class "md:tw-col-gap-24"
+
+
+md_tw_col_gap_32 : Html.Attribute msg
+md_tw_col_gap_32 =
+    A.class "md:tw-col-gap-32"
+
+
+md_tw_col_gap_40 : Html.Attribute msg
+md_tw_col_gap_40 =
+    A.class "md:tw-col-gap-40"
+
+
+md_tw_col_gap_48 : Html.Attribute msg
+md_tw_col_gap_48 =
+    A.class "md:tw-col-gap-48"
+
+
+md_tw_col_gap_56 : Html.Attribute msg
+md_tw_col_gap_56 =
+    A.class "md:tw-col-gap-56"
+
+
+md_tw_col_gap_64 : Html.Attribute msg
+md_tw_col_gap_64 =
+    A.class "md:tw-col-gap-64"
+
+
+md_tw_col_gap_px : Html.Attribute msg
+md_tw_col_gap_px =
+    A.class "md:tw-col-gap-px"
+
+
+md_tw_row_gap_0 : Html.Attribute msg
+md_tw_row_gap_0 =
+    A.class "md:tw-row-gap-0"
+
+
+md_tw_row_gap_1 : Html.Attribute msg
+md_tw_row_gap_1 =
+    A.class "md:tw-row-gap-1"
+
+
+md_tw_row_gap_2 : Html.Attribute msg
+md_tw_row_gap_2 =
+    A.class "md:tw-row-gap-2"
+
+
+md_tw_row_gap_3 : Html.Attribute msg
+md_tw_row_gap_3 =
+    A.class "md:tw-row-gap-3"
+
+
+md_tw_row_gap_4 : Html.Attribute msg
+md_tw_row_gap_4 =
+    A.class "md:tw-row-gap-4"
+
+
+md_tw_row_gap_5 : Html.Attribute msg
+md_tw_row_gap_5 =
+    A.class "md:tw-row-gap-5"
+
+
+md_tw_row_gap_6 : Html.Attribute msg
+md_tw_row_gap_6 =
+    A.class "md:tw-row-gap-6"
+
+
+md_tw_row_gap_8 : Html.Attribute msg
+md_tw_row_gap_8 =
+    A.class "md:tw-row-gap-8"
+
+
+md_tw_row_gap_10 : Html.Attribute msg
+md_tw_row_gap_10 =
+    A.class "md:tw-row-gap-10"
+
+
+md_tw_row_gap_12 : Html.Attribute msg
+md_tw_row_gap_12 =
+    A.class "md:tw-row-gap-12"
+
+
+md_tw_row_gap_16 : Html.Attribute msg
+md_tw_row_gap_16 =
+    A.class "md:tw-row-gap-16"
+
+
+md_tw_row_gap_20 : Html.Attribute msg
+md_tw_row_gap_20 =
+    A.class "md:tw-row-gap-20"
+
+
+md_tw_row_gap_24 : Html.Attribute msg
+md_tw_row_gap_24 =
+    A.class "md:tw-row-gap-24"
+
+
+md_tw_row_gap_32 : Html.Attribute msg
+md_tw_row_gap_32 =
+    A.class "md:tw-row-gap-32"
+
+
+md_tw_row_gap_40 : Html.Attribute msg
+md_tw_row_gap_40 =
+    A.class "md:tw-row-gap-40"
+
+
+md_tw_row_gap_48 : Html.Attribute msg
+md_tw_row_gap_48 =
+    A.class "md:tw-row-gap-48"
+
+
+md_tw_row_gap_56 : Html.Attribute msg
+md_tw_row_gap_56 =
+    A.class "md:tw-row-gap-56"
+
+
+md_tw_row_gap_64 : Html.Attribute msg
+md_tw_row_gap_64 =
+    A.class "md:tw-row-gap-64"
+
+
+md_tw_row_gap_px : Html.Attribute msg
+md_tw_row_gap_px =
+    A.class "md:tw-row-gap-px"
+
+
+md_tw_grid_flow_row : Html.Attribute msg
+md_tw_grid_flow_row =
+    A.class "md:tw-grid-flow-row"
+
+
+md_tw_grid_flow_col : Html.Attribute msg
+md_tw_grid_flow_col =
+    A.class "md:tw-grid-flow-col"
+
+
+md_tw_grid_flow_row_dense : Html.Attribute msg
+md_tw_grid_flow_row_dense =
+    A.class "md:tw-grid-flow-row-dense"
+
+
+md_tw_grid_flow_col_dense : Html.Attribute msg
+md_tw_grid_flow_col_dense =
+    A.class "md:tw-grid-flow-col-dense"
+
+
+md_tw_grid_cols_1 : Html.Attribute msg
+md_tw_grid_cols_1 =
+    A.class "md:tw-grid-cols-1"
+
+
+md_tw_grid_cols_2 : Html.Attribute msg
+md_tw_grid_cols_2 =
+    A.class "md:tw-grid-cols-2"
+
+
+md_tw_grid_cols_3 : Html.Attribute msg
+md_tw_grid_cols_3 =
+    A.class "md:tw-grid-cols-3"
+
+
+md_tw_grid_cols_4 : Html.Attribute msg
+md_tw_grid_cols_4 =
+    A.class "md:tw-grid-cols-4"
+
+
+md_tw_grid_cols_5 : Html.Attribute msg
+md_tw_grid_cols_5 =
+    A.class "md:tw-grid-cols-5"
+
+
+md_tw_grid_cols_6 : Html.Attribute msg
+md_tw_grid_cols_6 =
+    A.class "md:tw-grid-cols-6"
+
+
+md_tw_grid_cols_7 : Html.Attribute msg
+md_tw_grid_cols_7 =
+    A.class "md:tw-grid-cols-7"
+
+
+md_tw_grid_cols_8 : Html.Attribute msg
+md_tw_grid_cols_8 =
+    A.class "md:tw-grid-cols-8"
+
+
+md_tw_grid_cols_9 : Html.Attribute msg
+md_tw_grid_cols_9 =
+    A.class "md:tw-grid-cols-9"
+
+
+md_tw_grid_cols_10 : Html.Attribute msg
+md_tw_grid_cols_10 =
+    A.class "md:tw-grid-cols-10"
+
+
+md_tw_grid_cols_11 : Html.Attribute msg
+md_tw_grid_cols_11 =
+    A.class "md:tw-grid-cols-11"
+
+
+md_tw_grid_cols_12 : Html.Attribute msg
+md_tw_grid_cols_12 =
+    A.class "md:tw-grid-cols-12"
+
+
+md_tw_grid_cols_none : Html.Attribute msg
+md_tw_grid_cols_none =
+    A.class "md:tw-grid-cols-none"
+
+
+md_tw_col_auto : Html.Attribute msg
+md_tw_col_auto =
+    A.class "md:tw-col-auto"
+
+
+md_tw_col_span_1 : Html.Attribute msg
+md_tw_col_span_1 =
+    A.class "md:tw-col-span-1"
+
+
+md_tw_col_span_2 : Html.Attribute msg
+md_tw_col_span_2 =
+    A.class "md:tw-col-span-2"
+
+
+md_tw_col_span_3 : Html.Attribute msg
+md_tw_col_span_3 =
+    A.class "md:tw-col-span-3"
+
+
+md_tw_col_span_4 : Html.Attribute msg
+md_tw_col_span_4 =
+    A.class "md:tw-col-span-4"
+
+
+md_tw_col_span_5 : Html.Attribute msg
+md_tw_col_span_5 =
+    A.class "md:tw-col-span-5"
+
+
+md_tw_col_span_6 : Html.Attribute msg
+md_tw_col_span_6 =
+    A.class "md:tw-col-span-6"
+
+
+md_tw_col_span_7 : Html.Attribute msg
+md_tw_col_span_7 =
+    A.class "md:tw-col-span-7"
+
+
+md_tw_col_span_8 : Html.Attribute msg
+md_tw_col_span_8 =
+    A.class "md:tw-col-span-8"
+
+
+md_tw_col_span_9 : Html.Attribute msg
+md_tw_col_span_9 =
+    A.class "md:tw-col-span-9"
+
+
+md_tw_col_span_10 : Html.Attribute msg
+md_tw_col_span_10 =
+    A.class "md:tw-col-span-10"
+
+
+md_tw_col_span_11 : Html.Attribute msg
+md_tw_col_span_11 =
+    A.class "md:tw-col-span-11"
+
+
+md_tw_col_span_12 : Html.Attribute msg
+md_tw_col_span_12 =
+    A.class "md:tw-col-span-12"
+
+
+md_tw_col_start_1 : Html.Attribute msg
+md_tw_col_start_1 =
+    A.class "md:tw-col-start-1"
+
+
+md_tw_col_start_2 : Html.Attribute msg
+md_tw_col_start_2 =
+    A.class "md:tw-col-start-2"
+
+
+md_tw_col_start_3 : Html.Attribute msg
+md_tw_col_start_3 =
+    A.class "md:tw-col-start-3"
+
+
+md_tw_col_start_4 : Html.Attribute msg
+md_tw_col_start_4 =
+    A.class "md:tw-col-start-4"
+
+
+md_tw_col_start_5 : Html.Attribute msg
+md_tw_col_start_5 =
+    A.class "md:tw-col-start-5"
+
+
+md_tw_col_start_6 : Html.Attribute msg
+md_tw_col_start_6 =
+    A.class "md:tw-col-start-6"
+
+
+md_tw_col_start_7 : Html.Attribute msg
+md_tw_col_start_7 =
+    A.class "md:tw-col-start-7"
+
+
+md_tw_col_start_8 : Html.Attribute msg
+md_tw_col_start_8 =
+    A.class "md:tw-col-start-8"
+
+
+md_tw_col_start_9 : Html.Attribute msg
+md_tw_col_start_9 =
+    A.class "md:tw-col-start-9"
+
+
+md_tw_col_start_10 : Html.Attribute msg
+md_tw_col_start_10 =
+    A.class "md:tw-col-start-10"
+
+
+md_tw_col_start_11 : Html.Attribute msg
+md_tw_col_start_11 =
+    A.class "md:tw-col-start-11"
+
+
+md_tw_col_start_12 : Html.Attribute msg
+md_tw_col_start_12 =
+    A.class "md:tw-col-start-12"
+
+
+md_tw_col_start_13 : Html.Attribute msg
+md_tw_col_start_13 =
+    A.class "md:tw-col-start-13"
+
+
+md_tw_col_start_auto : Html.Attribute msg
+md_tw_col_start_auto =
+    A.class "md:tw-col-start-auto"
+
+
+md_tw_col_end_1 : Html.Attribute msg
+md_tw_col_end_1 =
+    A.class "md:tw-col-end-1"
+
+
+md_tw_col_end_2 : Html.Attribute msg
+md_tw_col_end_2 =
+    A.class "md:tw-col-end-2"
+
+
+md_tw_col_end_3 : Html.Attribute msg
+md_tw_col_end_3 =
+    A.class "md:tw-col-end-3"
+
+
+md_tw_col_end_4 : Html.Attribute msg
+md_tw_col_end_4 =
+    A.class "md:tw-col-end-4"
+
+
+md_tw_col_end_5 : Html.Attribute msg
+md_tw_col_end_5 =
+    A.class "md:tw-col-end-5"
+
+
+md_tw_col_end_6 : Html.Attribute msg
+md_tw_col_end_6 =
+    A.class "md:tw-col-end-6"
+
+
+md_tw_col_end_7 : Html.Attribute msg
+md_tw_col_end_7 =
+    A.class "md:tw-col-end-7"
+
+
+md_tw_col_end_8 : Html.Attribute msg
+md_tw_col_end_8 =
+    A.class "md:tw-col-end-8"
+
+
+md_tw_col_end_9 : Html.Attribute msg
+md_tw_col_end_9 =
+    A.class "md:tw-col-end-9"
+
+
+md_tw_col_end_10 : Html.Attribute msg
+md_tw_col_end_10 =
+    A.class "md:tw-col-end-10"
+
+
+md_tw_col_end_11 : Html.Attribute msg
+md_tw_col_end_11 =
+    A.class "md:tw-col-end-11"
+
+
+md_tw_col_end_12 : Html.Attribute msg
+md_tw_col_end_12 =
+    A.class "md:tw-col-end-12"
+
+
+md_tw_col_end_13 : Html.Attribute msg
+md_tw_col_end_13 =
+    A.class "md:tw-col-end-13"
+
+
+md_tw_col_end_auto : Html.Attribute msg
+md_tw_col_end_auto =
+    A.class "md:tw-col-end-auto"
+
+
+md_tw_grid_rows_1 : Html.Attribute msg
+md_tw_grid_rows_1 =
+    A.class "md:tw-grid-rows-1"
+
+
+md_tw_grid_rows_2 : Html.Attribute msg
+md_tw_grid_rows_2 =
+    A.class "md:tw-grid-rows-2"
+
+
+md_tw_grid_rows_3 : Html.Attribute msg
+md_tw_grid_rows_3 =
+    A.class "md:tw-grid-rows-3"
+
+
+md_tw_grid_rows_4 : Html.Attribute msg
+md_tw_grid_rows_4 =
+    A.class "md:tw-grid-rows-4"
+
+
+md_tw_grid_rows_5 : Html.Attribute msg
+md_tw_grid_rows_5 =
+    A.class "md:tw-grid-rows-5"
+
+
+md_tw_grid_rows_6 : Html.Attribute msg
+md_tw_grid_rows_6 =
+    A.class "md:tw-grid-rows-6"
+
+
+md_tw_grid_rows_none : Html.Attribute msg
+md_tw_grid_rows_none =
+    A.class "md:tw-grid-rows-none"
+
+
+md_tw_row_auto : Html.Attribute msg
+md_tw_row_auto =
+    A.class "md:tw-row-auto"
+
+
+md_tw_row_span_1 : Html.Attribute msg
+md_tw_row_span_1 =
+    A.class "md:tw-row-span-1"
+
+
+md_tw_row_span_2 : Html.Attribute msg
+md_tw_row_span_2 =
+    A.class "md:tw-row-span-2"
+
+
+md_tw_row_span_3 : Html.Attribute msg
+md_tw_row_span_3 =
+    A.class "md:tw-row-span-3"
+
+
+md_tw_row_span_4 : Html.Attribute msg
+md_tw_row_span_4 =
+    A.class "md:tw-row-span-4"
+
+
+md_tw_row_span_5 : Html.Attribute msg
+md_tw_row_span_5 =
+    A.class "md:tw-row-span-5"
+
+
+md_tw_row_span_6 : Html.Attribute msg
+md_tw_row_span_6 =
+    A.class "md:tw-row-span-6"
+
+
+md_tw_row_start_1 : Html.Attribute msg
+md_tw_row_start_1 =
+    A.class "md:tw-row-start-1"
+
+
+md_tw_row_start_2 : Html.Attribute msg
+md_tw_row_start_2 =
+    A.class "md:tw-row-start-2"
+
+
+md_tw_row_start_3 : Html.Attribute msg
+md_tw_row_start_3 =
+    A.class "md:tw-row-start-3"
+
+
+md_tw_row_start_4 : Html.Attribute msg
+md_tw_row_start_4 =
+    A.class "md:tw-row-start-4"
+
+
+md_tw_row_start_5 : Html.Attribute msg
+md_tw_row_start_5 =
+    A.class "md:tw-row-start-5"
+
+
+md_tw_row_start_6 : Html.Attribute msg
+md_tw_row_start_6 =
+    A.class "md:tw-row-start-6"
+
+
+md_tw_row_start_7 : Html.Attribute msg
+md_tw_row_start_7 =
+    A.class "md:tw-row-start-7"
+
+
+md_tw_row_start_auto : Html.Attribute msg
+md_tw_row_start_auto =
+    A.class "md:tw-row-start-auto"
+
+
+md_tw_row_end_1 : Html.Attribute msg
+md_tw_row_end_1 =
+    A.class "md:tw-row-end-1"
+
+
+md_tw_row_end_2 : Html.Attribute msg
+md_tw_row_end_2 =
+    A.class "md:tw-row-end-2"
+
+
+md_tw_row_end_3 : Html.Attribute msg
+md_tw_row_end_3 =
+    A.class "md:tw-row-end-3"
+
+
+md_tw_row_end_4 : Html.Attribute msg
+md_tw_row_end_4 =
+    A.class "md:tw-row-end-4"
+
+
+md_tw_row_end_5 : Html.Attribute msg
+md_tw_row_end_5 =
+    A.class "md:tw-row-end-5"
+
+
+md_tw_row_end_6 : Html.Attribute msg
+md_tw_row_end_6 =
+    A.class "md:tw-row-end-6"
+
+
+md_tw_row_end_7 : Html.Attribute msg
+md_tw_row_end_7 =
+    A.class "md:tw-row-end-7"
+
+
+md_tw_row_end_auto : Html.Attribute msg
+md_tw_row_end_auto =
+    A.class "md:tw-row-end-auto"
+
+
+md_tw_transform : Html.Attribute msg
+md_tw_transform =
+    A.class "md:tw-transform"
+
+
+md_tw_transform_none : Html.Attribute msg
+md_tw_transform_none =
+    A.class "md:tw-transform-none"
+
+
+md_tw_origin_center : Html.Attribute msg
+md_tw_origin_center =
+    A.class "md:tw-origin-center"
+
+
+md_tw_origin_top : Html.Attribute msg
+md_tw_origin_top =
+    A.class "md:tw-origin-top"
+
+
+md_tw_origin_top_right : Html.Attribute msg
+md_tw_origin_top_right =
+    A.class "md:tw-origin-top-right"
+
+
+md_tw_origin_right : Html.Attribute msg
+md_tw_origin_right =
+    A.class "md:tw-origin-right"
+
+
+md_tw_origin_bottom_right : Html.Attribute msg
+md_tw_origin_bottom_right =
+    A.class "md:tw-origin-bottom-right"
+
+
+md_tw_origin_bottom : Html.Attribute msg
+md_tw_origin_bottom =
+    A.class "md:tw-origin-bottom"
+
+
+md_tw_origin_bottom_left : Html.Attribute msg
+md_tw_origin_bottom_left =
+    A.class "md:tw-origin-bottom-left"
+
+
+md_tw_origin_left : Html.Attribute msg
+md_tw_origin_left =
+    A.class "md:tw-origin-left"
+
+
+md_tw_origin_top_left : Html.Attribute msg
+md_tw_origin_top_left =
+    A.class "md:tw-origin-top-left"
+
+
+md_tw_scale_0 : Html.Attribute msg
+md_tw_scale_0 =
+    A.class "md:tw-scale-0"
+
+
+md_tw_scale_50 : Html.Attribute msg
+md_tw_scale_50 =
+    A.class "md:tw-scale-50"
+
+
+md_tw_scale_75 : Html.Attribute msg
+md_tw_scale_75 =
+    A.class "md:tw-scale-75"
+
+
+md_tw_scale_90 : Html.Attribute msg
+md_tw_scale_90 =
+    A.class "md:tw-scale-90"
+
+
+md_tw_scale_95 : Html.Attribute msg
+md_tw_scale_95 =
+    A.class "md:tw-scale-95"
+
+
+md_tw_scale_100 : Html.Attribute msg
+md_tw_scale_100 =
+    A.class "md:tw-scale-100"
+
+
+md_tw_scale_105 : Html.Attribute msg
+md_tw_scale_105 =
+    A.class "md:tw-scale-105"
+
+
+md_tw_scale_110 : Html.Attribute msg
+md_tw_scale_110 =
+    A.class "md:tw-scale-110"
+
+
+md_tw_scale_125 : Html.Attribute msg
+md_tw_scale_125 =
+    A.class "md:tw-scale-125"
+
+
+md_tw_scale_150 : Html.Attribute msg
+md_tw_scale_150 =
+    A.class "md:tw-scale-150"
+
+
+md_tw_scale_x_0 : Html.Attribute msg
+md_tw_scale_x_0 =
+    A.class "md:tw-scale-x-0"
+
+
+md_tw_scale_x_50 : Html.Attribute msg
+md_tw_scale_x_50 =
+    A.class "md:tw-scale-x-50"
+
+
+md_tw_scale_x_75 : Html.Attribute msg
+md_tw_scale_x_75 =
+    A.class "md:tw-scale-x-75"
+
+
+md_tw_scale_x_90 : Html.Attribute msg
+md_tw_scale_x_90 =
+    A.class "md:tw-scale-x-90"
+
+
+md_tw_scale_x_95 : Html.Attribute msg
+md_tw_scale_x_95 =
+    A.class "md:tw-scale-x-95"
+
+
+md_tw_scale_x_100 : Html.Attribute msg
+md_tw_scale_x_100 =
+    A.class "md:tw-scale-x-100"
+
+
+md_tw_scale_x_105 : Html.Attribute msg
+md_tw_scale_x_105 =
+    A.class "md:tw-scale-x-105"
+
+
+md_tw_scale_x_110 : Html.Attribute msg
+md_tw_scale_x_110 =
+    A.class "md:tw-scale-x-110"
+
+
+md_tw_scale_x_125 : Html.Attribute msg
+md_tw_scale_x_125 =
+    A.class "md:tw-scale-x-125"
+
+
+md_tw_scale_x_150 : Html.Attribute msg
+md_tw_scale_x_150 =
+    A.class "md:tw-scale-x-150"
+
+
+md_tw_scale_y_0 : Html.Attribute msg
+md_tw_scale_y_0 =
+    A.class "md:tw-scale-y-0"
+
+
+md_tw_scale_y_50 : Html.Attribute msg
+md_tw_scale_y_50 =
+    A.class "md:tw-scale-y-50"
+
+
+md_tw_scale_y_75 : Html.Attribute msg
+md_tw_scale_y_75 =
+    A.class "md:tw-scale-y-75"
+
+
+md_tw_scale_y_90 : Html.Attribute msg
+md_tw_scale_y_90 =
+    A.class "md:tw-scale-y-90"
+
+
+md_tw_scale_y_95 : Html.Attribute msg
+md_tw_scale_y_95 =
+    A.class "md:tw-scale-y-95"
+
+
+md_tw_scale_y_100 : Html.Attribute msg
+md_tw_scale_y_100 =
+    A.class "md:tw-scale-y-100"
+
+
+md_tw_scale_y_105 : Html.Attribute msg
+md_tw_scale_y_105 =
+    A.class "md:tw-scale-y-105"
+
+
+md_tw_scale_y_110 : Html.Attribute msg
+md_tw_scale_y_110 =
+    A.class "md:tw-scale-y-110"
+
+
+md_tw_scale_y_125 : Html.Attribute msg
+md_tw_scale_y_125 =
+    A.class "md:tw-scale-y-125"
+
+
+md_tw_scale_y_150 : Html.Attribute msg
+md_tw_scale_y_150 =
+    A.class "md:tw-scale-y-150"
+
+
+md_hover_tw_scale_0 : Html.Attribute msg
+md_hover_tw_scale_0 =
+    A.class "md:hover:tw-scale-0"
+
+
+md_hover_tw_scale_50 : Html.Attribute msg
+md_hover_tw_scale_50 =
+    A.class "md:hover:tw-scale-50"
+
+
+md_hover_tw_scale_75 : Html.Attribute msg
+md_hover_tw_scale_75 =
+    A.class "md:hover:tw-scale-75"
+
+
+md_hover_tw_scale_90 : Html.Attribute msg
+md_hover_tw_scale_90 =
+    A.class "md:hover:tw-scale-90"
+
+
+md_hover_tw_scale_95 : Html.Attribute msg
+md_hover_tw_scale_95 =
+    A.class "md:hover:tw-scale-95"
+
+
+md_hover_tw_scale_100 : Html.Attribute msg
+md_hover_tw_scale_100 =
+    A.class "md:hover:tw-scale-100"
+
+
+md_hover_tw_scale_105 : Html.Attribute msg
+md_hover_tw_scale_105 =
+    A.class "md:hover:tw-scale-105"
+
+
+md_hover_tw_scale_110 : Html.Attribute msg
+md_hover_tw_scale_110 =
+    A.class "md:hover:tw-scale-110"
+
+
+md_hover_tw_scale_125 : Html.Attribute msg
+md_hover_tw_scale_125 =
+    A.class "md:hover:tw-scale-125"
+
+
+md_hover_tw_scale_150 : Html.Attribute msg
+md_hover_tw_scale_150 =
+    A.class "md:hover:tw-scale-150"
+
+
+md_hover_tw_scale_x_0 : Html.Attribute msg
+md_hover_tw_scale_x_0 =
+    A.class "md:hover:tw-scale-x-0"
+
+
+md_hover_tw_scale_x_50 : Html.Attribute msg
+md_hover_tw_scale_x_50 =
+    A.class "md:hover:tw-scale-x-50"
+
+
+md_hover_tw_scale_x_75 : Html.Attribute msg
+md_hover_tw_scale_x_75 =
+    A.class "md:hover:tw-scale-x-75"
+
+
+md_hover_tw_scale_x_90 : Html.Attribute msg
+md_hover_tw_scale_x_90 =
+    A.class "md:hover:tw-scale-x-90"
+
+
+md_hover_tw_scale_x_95 : Html.Attribute msg
+md_hover_tw_scale_x_95 =
+    A.class "md:hover:tw-scale-x-95"
+
+
+md_hover_tw_scale_x_100 : Html.Attribute msg
+md_hover_tw_scale_x_100 =
+    A.class "md:hover:tw-scale-x-100"
+
+
+md_hover_tw_scale_x_105 : Html.Attribute msg
+md_hover_tw_scale_x_105 =
+    A.class "md:hover:tw-scale-x-105"
+
+
+md_hover_tw_scale_x_110 : Html.Attribute msg
+md_hover_tw_scale_x_110 =
+    A.class "md:hover:tw-scale-x-110"
+
+
+md_hover_tw_scale_x_125 : Html.Attribute msg
+md_hover_tw_scale_x_125 =
+    A.class "md:hover:tw-scale-x-125"
+
+
+md_hover_tw_scale_x_150 : Html.Attribute msg
+md_hover_tw_scale_x_150 =
+    A.class "md:hover:tw-scale-x-150"
+
+
+md_hover_tw_scale_y_0 : Html.Attribute msg
+md_hover_tw_scale_y_0 =
+    A.class "md:hover:tw-scale-y-0"
+
+
+md_hover_tw_scale_y_50 : Html.Attribute msg
+md_hover_tw_scale_y_50 =
+    A.class "md:hover:tw-scale-y-50"
+
+
+md_hover_tw_scale_y_75 : Html.Attribute msg
+md_hover_tw_scale_y_75 =
+    A.class "md:hover:tw-scale-y-75"
+
+
+md_hover_tw_scale_y_90 : Html.Attribute msg
+md_hover_tw_scale_y_90 =
+    A.class "md:hover:tw-scale-y-90"
+
+
+md_hover_tw_scale_y_95 : Html.Attribute msg
+md_hover_tw_scale_y_95 =
+    A.class "md:hover:tw-scale-y-95"
+
+
+md_hover_tw_scale_y_100 : Html.Attribute msg
+md_hover_tw_scale_y_100 =
+    A.class "md:hover:tw-scale-y-100"
+
+
+md_hover_tw_scale_y_105 : Html.Attribute msg
+md_hover_tw_scale_y_105 =
+    A.class "md:hover:tw-scale-y-105"
+
+
+md_hover_tw_scale_y_110 : Html.Attribute msg
+md_hover_tw_scale_y_110 =
+    A.class "md:hover:tw-scale-y-110"
+
+
+md_hover_tw_scale_y_125 : Html.Attribute msg
+md_hover_tw_scale_y_125 =
+    A.class "md:hover:tw-scale-y-125"
+
+
+md_hover_tw_scale_y_150 : Html.Attribute msg
+md_hover_tw_scale_y_150 =
+    A.class "md:hover:tw-scale-y-150"
+
+
+md_focus_tw_scale_0 : Html.Attribute msg
+md_focus_tw_scale_0 =
+    A.class "md:focus:tw-scale-0"
+
+
+md_focus_tw_scale_50 : Html.Attribute msg
+md_focus_tw_scale_50 =
+    A.class "md:focus:tw-scale-50"
+
+
+md_focus_tw_scale_75 : Html.Attribute msg
+md_focus_tw_scale_75 =
+    A.class "md:focus:tw-scale-75"
+
+
+md_focus_tw_scale_90 : Html.Attribute msg
+md_focus_tw_scale_90 =
+    A.class "md:focus:tw-scale-90"
+
+
+md_focus_tw_scale_95 : Html.Attribute msg
+md_focus_tw_scale_95 =
+    A.class "md:focus:tw-scale-95"
+
+
+md_focus_tw_scale_100 : Html.Attribute msg
+md_focus_tw_scale_100 =
+    A.class "md:focus:tw-scale-100"
+
+
+md_focus_tw_scale_105 : Html.Attribute msg
+md_focus_tw_scale_105 =
+    A.class "md:focus:tw-scale-105"
+
+
+md_focus_tw_scale_110 : Html.Attribute msg
+md_focus_tw_scale_110 =
+    A.class "md:focus:tw-scale-110"
+
+
+md_focus_tw_scale_125 : Html.Attribute msg
+md_focus_tw_scale_125 =
+    A.class "md:focus:tw-scale-125"
+
+
+md_focus_tw_scale_150 : Html.Attribute msg
+md_focus_tw_scale_150 =
+    A.class "md:focus:tw-scale-150"
+
+
+md_focus_tw_scale_x_0 : Html.Attribute msg
+md_focus_tw_scale_x_0 =
+    A.class "md:focus:tw-scale-x-0"
+
+
+md_focus_tw_scale_x_50 : Html.Attribute msg
+md_focus_tw_scale_x_50 =
+    A.class "md:focus:tw-scale-x-50"
+
+
+md_focus_tw_scale_x_75 : Html.Attribute msg
+md_focus_tw_scale_x_75 =
+    A.class "md:focus:tw-scale-x-75"
+
+
+md_focus_tw_scale_x_90 : Html.Attribute msg
+md_focus_tw_scale_x_90 =
+    A.class "md:focus:tw-scale-x-90"
+
+
+md_focus_tw_scale_x_95 : Html.Attribute msg
+md_focus_tw_scale_x_95 =
+    A.class "md:focus:tw-scale-x-95"
+
+
+md_focus_tw_scale_x_100 : Html.Attribute msg
+md_focus_tw_scale_x_100 =
+    A.class "md:focus:tw-scale-x-100"
+
+
+md_focus_tw_scale_x_105 : Html.Attribute msg
+md_focus_tw_scale_x_105 =
+    A.class "md:focus:tw-scale-x-105"
+
+
+md_focus_tw_scale_x_110 : Html.Attribute msg
+md_focus_tw_scale_x_110 =
+    A.class "md:focus:tw-scale-x-110"
+
+
+md_focus_tw_scale_x_125 : Html.Attribute msg
+md_focus_tw_scale_x_125 =
+    A.class "md:focus:tw-scale-x-125"
+
+
+md_focus_tw_scale_x_150 : Html.Attribute msg
+md_focus_tw_scale_x_150 =
+    A.class "md:focus:tw-scale-x-150"
+
+
+md_focus_tw_scale_y_0 : Html.Attribute msg
+md_focus_tw_scale_y_0 =
+    A.class "md:focus:tw-scale-y-0"
+
+
+md_focus_tw_scale_y_50 : Html.Attribute msg
+md_focus_tw_scale_y_50 =
+    A.class "md:focus:tw-scale-y-50"
+
+
+md_focus_tw_scale_y_75 : Html.Attribute msg
+md_focus_tw_scale_y_75 =
+    A.class "md:focus:tw-scale-y-75"
+
+
+md_focus_tw_scale_y_90 : Html.Attribute msg
+md_focus_tw_scale_y_90 =
+    A.class "md:focus:tw-scale-y-90"
+
+
+md_focus_tw_scale_y_95 : Html.Attribute msg
+md_focus_tw_scale_y_95 =
+    A.class "md:focus:tw-scale-y-95"
+
+
+md_focus_tw_scale_y_100 : Html.Attribute msg
+md_focus_tw_scale_y_100 =
+    A.class "md:focus:tw-scale-y-100"
+
+
+md_focus_tw_scale_y_105 : Html.Attribute msg
+md_focus_tw_scale_y_105 =
+    A.class "md:focus:tw-scale-y-105"
+
+
+md_focus_tw_scale_y_110 : Html.Attribute msg
+md_focus_tw_scale_y_110 =
+    A.class "md:focus:tw-scale-y-110"
+
+
+md_focus_tw_scale_y_125 : Html.Attribute msg
+md_focus_tw_scale_y_125 =
+    A.class "md:focus:tw-scale-y-125"
+
+
+md_focus_tw_scale_y_150 : Html.Attribute msg
+md_focus_tw_scale_y_150 =
+    A.class "md:focus:tw-scale-y-150"
+
+
+md_tw_rotate_0 : Html.Attribute msg
+md_tw_rotate_0 =
+    A.class "md:tw-rotate-0"
+
+
+md_tw_rotate_45 : Html.Attribute msg
+md_tw_rotate_45 =
+    A.class "md:tw-rotate-45"
+
+
+md_tw_rotate_90 : Html.Attribute msg
+md_tw_rotate_90 =
+    A.class "md:tw-rotate-90"
+
+
+md_tw_rotate_180 : Html.Attribute msg
+md_tw_rotate_180 =
+    A.class "md:tw-rotate-180"
+
+
+md_tw_neg_rotate_180 : Html.Attribute msg
+md_tw_neg_rotate_180 =
+    A.class "md:tw--rotate-180"
+
+
+md_tw_neg_rotate_90 : Html.Attribute msg
+md_tw_neg_rotate_90 =
+    A.class "md:tw--rotate-90"
+
+
+md_tw_neg_rotate_45 : Html.Attribute msg
+md_tw_neg_rotate_45 =
+    A.class "md:tw--rotate-45"
+
+
+md_hover_tw_rotate_0 : Html.Attribute msg
+md_hover_tw_rotate_0 =
+    A.class "md:hover:tw-rotate-0"
+
+
+md_hover_tw_rotate_45 : Html.Attribute msg
+md_hover_tw_rotate_45 =
+    A.class "md:hover:tw-rotate-45"
+
+
+md_hover_tw_rotate_90 : Html.Attribute msg
+md_hover_tw_rotate_90 =
+    A.class "md:hover:tw-rotate-90"
+
+
+md_hover_tw_rotate_180 : Html.Attribute msg
+md_hover_tw_rotate_180 =
+    A.class "md:hover:tw-rotate-180"
+
+
+md_hover_tw_neg_rotate_180 : Html.Attribute msg
+md_hover_tw_neg_rotate_180 =
+    A.class "md:hover:tw--rotate-180"
+
+
+md_hover_tw_neg_rotate_90 : Html.Attribute msg
+md_hover_tw_neg_rotate_90 =
+    A.class "md:hover:tw--rotate-90"
+
+
+md_hover_tw_neg_rotate_45 : Html.Attribute msg
+md_hover_tw_neg_rotate_45 =
+    A.class "md:hover:tw--rotate-45"
+
+
+md_focus_tw_rotate_0 : Html.Attribute msg
+md_focus_tw_rotate_0 =
+    A.class "md:focus:tw-rotate-0"
+
+
+md_focus_tw_rotate_45 : Html.Attribute msg
+md_focus_tw_rotate_45 =
+    A.class "md:focus:tw-rotate-45"
+
+
+md_focus_tw_rotate_90 : Html.Attribute msg
+md_focus_tw_rotate_90 =
+    A.class "md:focus:tw-rotate-90"
+
+
+md_focus_tw_rotate_180 : Html.Attribute msg
+md_focus_tw_rotate_180 =
+    A.class "md:focus:tw-rotate-180"
+
+
+md_focus_tw_neg_rotate_180 : Html.Attribute msg
+md_focus_tw_neg_rotate_180 =
+    A.class "md:focus:tw--rotate-180"
+
+
+md_focus_tw_neg_rotate_90 : Html.Attribute msg
+md_focus_tw_neg_rotate_90 =
+    A.class "md:focus:tw--rotate-90"
+
+
+md_focus_tw_neg_rotate_45 : Html.Attribute msg
+md_focus_tw_neg_rotate_45 =
+    A.class "md:focus:tw--rotate-45"
+
+
+md_tw_translate_x_0 : Html.Attribute msg
+md_tw_translate_x_0 =
+    A.class "md:tw-translate-x-0"
+
+
+md_tw_translate_x_1 : Html.Attribute msg
+md_tw_translate_x_1 =
+    A.class "md:tw-translate-x-1"
+
+
+md_tw_translate_x_2 : Html.Attribute msg
+md_tw_translate_x_2 =
+    A.class "md:tw-translate-x-2"
+
+
+md_tw_translate_x_3 : Html.Attribute msg
+md_tw_translate_x_3 =
+    A.class "md:tw-translate-x-3"
+
+
+md_tw_translate_x_4 : Html.Attribute msg
+md_tw_translate_x_4 =
+    A.class "md:tw-translate-x-4"
+
+
+md_tw_translate_x_5 : Html.Attribute msg
+md_tw_translate_x_5 =
+    A.class "md:tw-translate-x-5"
+
+
+md_tw_translate_x_6 : Html.Attribute msg
+md_tw_translate_x_6 =
+    A.class "md:tw-translate-x-6"
+
+
+md_tw_translate_x_8 : Html.Attribute msg
+md_tw_translate_x_8 =
+    A.class "md:tw-translate-x-8"
+
+
+md_tw_translate_x_10 : Html.Attribute msg
+md_tw_translate_x_10 =
+    A.class "md:tw-translate-x-10"
+
+
+md_tw_translate_x_12 : Html.Attribute msg
+md_tw_translate_x_12 =
+    A.class "md:tw-translate-x-12"
+
+
+md_tw_translate_x_16 : Html.Attribute msg
+md_tw_translate_x_16 =
+    A.class "md:tw-translate-x-16"
+
+
+md_tw_translate_x_20 : Html.Attribute msg
+md_tw_translate_x_20 =
+    A.class "md:tw-translate-x-20"
+
+
+md_tw_translate_x_24 : Html.Attribute msg
+md_tw_translate_x_24 =
+    A.class "md:tw-translate-x-24"
+
+
+md_tw_translate_x_32 : Html.Attribute msg
+md_tw_translate_x_32 =
+    A.class "md:tw-translate-x-32"
+
+
+md_tw_translate_x_40 : Html.Attribute msg
+md_tw_translate_x_40 =
+    A.class "md:tw-translate-x-40"
+
+
+md_tw_translate_x_48 : Html.Attribute msg
+md_tw_translate_x_48 =
+    A.class "md:tw-translate-x-48"
+
+
+md_tw_translate_x_56 : Html.Attribute msg
+md_tw_translate_x_56 =
+    A.class "md:tw-translate-x-56"
+
+
+md_tw_translate_x_64 : Html.Attribute msg
+md_tw_translate_x_64 =
+    A.class "md:tw-translate-x-64"
+
+
+md_tw_translate_x_px : Html.Attribute msg
+md_tw_translate_x_px =
+    A.class "md:tw-translate-x-px"
+
+
+md_tw_neg_translate_x_1 : Html.Attribute msg
+md_tw_neg_translate_x_1 =
+    A.class "md:tw--translate-x-1"
+
+
+md_tw_neg_translate_x_2 : Html.Attribute msg
+md_tw_neg_translate_x_2 =
+    A.class "md:tw--translate-x-2"
+
+
+md_tw_neg_translate_x_3 : Html.Attribute msg
+md_tw_neg_translate_x_3 =
+    A.class "md:tw--translate-x-3"
+
+
+md_tw_neg_translate_x_4 : Html.Attribute msg
+md_tw_neg_translate_x_4 =
+    A.class "md:tw--translate-x-4"
+
+
+md_tw_neg_translate_x_5 : Html.Attribute msg
+md_tw_neg_translate_x_5 =
+    A.class "md:tw--translate-x-5"
+
+
+md_tw_neg_translate_x_6 : Html.Attribute msg
+md_tw_neg_translate_x_6 =
+    A.class "md:tw--translate-x-6"
+
+
+md_tw_neg_translate_x_8 : Html.Attribute msg
+md_tw_neg_translate_x_8 =
+    A.class "md:tw--translate-x-8"
+
+
+md_tw_neg_translate_x_10 : Html.Attribute msg
+md_tw_neg_translate_x_10 =
+    A.class "md:tw--translate-x-10"
+
+
+md_tw_neg_translate_x_12 : Html.Attribute msg
+md_tw_neg_translate_x_12 =
+    A.class "md:tw--translate-x-12"
+
+
+md_tw_neg_translate_x_16 : Html.Attribute msg
+md_tw_neg_translate_x_16 =
+    A.class "md:tw--translate-x-16"
+
+
+md_tw_neg_translate_x_20 : Html.Attribute msg
+md_tw_neg_translate_x_20 =
+    A.class "md:tw--translate-x-20"
+
+
+md_tw_neg_translate_x_24 : Html.Attribute msg
+md_tw_neg_translate_x_24 =
+    A.class "md:tw--translate-x-24"
+
+
+md_tw_neg_translate_x_32 : Html.Attribute msg
+md_tw_neg_translate_x_32 =
+    A.class "md:tw--translate-x-32"
+
+
+md_tw_neg_translate_x_40 : Html.Attribute msg
+md_tw_neg_translate_x_40 =
+    A.class "md:tw--translate-x-40"
+
+
+md_tw_neg_translate_x_48 : Html.Attribute msg
+md_tw_neg_translate_x_48 =
+    A.class "md:tw--translate-x-48"
+
+
+md_tw_neg_translate_x_56 : Html.Attribute msg
+md_tw_neg_translate_x_56 =
+    A.class "md:tw--translate-x-56"
+
+
+md_tw_neg_translate_x_64 : Html.Attribute msg
+md_tw_neg_translate_x_64 =
+    A.class "md:tw--translate-x-64"
+
+
+md_tw_neg_translate_x_px : Html.Attribute msg
+md_tw_neg_translate_x_px =
+    A.class "md:tw--translate-x-px"
+
+
+md_tw_neg_translate_x_full : Html.Attribute msg
+md_tw_neg_translate_x_full =
+    A.class "md:tw--translate-x-full"
+
+
+md_tw_neg_translate_x_1over2 : Html.Attribute msg
+md_tw_neg_translate_x_1over2 =
+    A.class "md:tw--translate-x-1/2"
+
+
+md_tw_translate_x_1over2 : Html.Attribute msg
+md_tw_translate_x_1over2 =
+    A.class "md:tw-translate-x-1/2"
+
+
+md_tw_translate_x_full : Html.Attribute msg
+md_tw_translate_x_full =
+    A.class "md:tw-translate-x-full"
+
+
+md_tw_translate_y_0 : Html.Attribute msg
+md_tw_translate_y_0 =
+    A.class "md:tw-translate-y-0"
+
+
+md_tw_translate_y_1 : Html.Attribute msg
+md_tw_translate_y_1 =
+    A.class "md:tw-translate-y-1"
+
+
+md_tw_translate_y_2 : Html.Attribute msg
+md_tw_translate_y_2 =
+    A.class "md:tw-translate-y-2"
+
+
+md_tw_translate_y_3 : Html.Attribute msg
+md_tw_translate_y_3 =
+    A.class "md:tw-translate-y-3"
+
+
+md_tw_translate_y_4 : Html.Attribute msg
+md_tw_translate_y_4 =
+    A.class "md:tw-translate-y-4"
+
+
+md_tw_translate_y_5 : Html.Attribute msg
+md_tw_translate_y_5 =
+    A.class "md:tw-translate-y-5"
+
+
+md_tw_translate_y_6 : Html.Attribute msg
+md_tw_translate_y_6 =
+    A.class "md:tw-translate-y-6"
+
+
+md_tw_translate_y_8 : Html.Attribute msg
+md_tw_translate_y_8 =
+    A.class "md:tw-translate-y-8"
+
+
+md_tw_translate_y_10 : Html.Attribute msg
+md_tw_translate_y_10 =
+    A.class "md:tw-translate-y-10"
+
+
+md_tw_translate_y_12 : Html.Attribute msg
+md_tw_translate_y_12 =
+    A.class "md:tw-translate-y-12"
+
+
+md_tw_translate_y_16 : Html.Attribute msg
+md_tw_translate_y_16 =
+    A.class "md:tw-translate-y-16"
+
+
+md_tw_translate_y_20 : Html.Attribute msg
+md_tw_translate_y_20 =
+    A.class "md:tw-translate-y-20"
+
+
+md_tw_translate_y_24 : Html.Attribute msg
+md_tw_translate_y_24 =
+    A.class "md:tw-translate-y-24"
+
+
+md_tw_translate_y_32 : Html.Attribute msg
+md_tw_translate_y_32 =
+    A.class "md:tw-translate-y-32"
+
+
+md_tw_translate_y_40 : Html.Attribute msg
+md_tw_translate_y_40 =
+    A.class "md:tw-translate-y-40"
+
+
+md_tw_translate_y_48 : Html.Attribute msg
+md_tw_translate_y_48 =
+    A.class "md:tw-translate-y-48"
+
+
+md_tw_translate_y_56 : Html.Attribute msg
+md_tw_translate_y_56 =
+    A.class "md:tw-translate-y-56"
+
+
+md_tw_translate_y_64 : Html.Attribute msg
+md_tw_translate_y_64 =
+    A.class "md:tw-translate-y-64"
+
+
+md_tw_translate_y_px : Html.Attribute msg
+md_tw_translate_y_px =
+    A.class "md:tw-translate-y-px"
+
+
+md_tw_neg_translate_y_1 : Html.Attribute msg
+md_tw_neg_translate_y_1 =
+    A.class "md:tw--translate-y-1"
+
+
+md_tw_neg_translate_y_2 : Html.Attribute msg
+md_tw_neg_translate_y_2 =
+    A.class "md:tw--translate-y-2"
+
+
+md_tw_neg_translate_y_3 : Html.Attribute msg
+md_tw_neg_translate_y_3 =
+    A.class "md:tw--translate-y-3"
+
+
+md_tw_neg_translate_y_4 : Html.Attribute msg
+md_tw_neg_translate_y_4 =
+    A.class "md:tw--translate-y-4"
+
+
+md_tw_neg_translate_y_5 : Html.Attribute msg
+md_tw_neg_translate_y_5 =
+    A.class "md:tw--translate-y-5"
+
+
+md_tw_neg_translate_y_6 : Html.Attribute msg
+md_tw_neg_translate_y_6 =
+    A.class "md:tw--translate-y-6"
+
+
+md_tw_neg_translate_y_8 : Html.Attribute msg
+md_tw_neg_translate_y_8 =
+    A.class "md:tw--translate-y-8"
+
+
+md_tw_neg_translate_y_10 : Html.Attribute msg
+md_tw_neg_translate_y_10 =
+    A.class "md:tw--translate-y-10"
+
+
+md_tw_neg_translate_y_12 : Html.Attribute msg
+md_tw_neg_translate_y_12 =
+    A.class "md:tw--translate-y-12"
+
+
+md_tw_neg_translate_y_16 : Html.Attribute msg
+md_tw_neg_translate_y_16 =
+    A.class "md:tw--translate-y-16"
+
+
+md_tw_neg_translate_y_20 : Html.Attribute msg
+md_tw_neg_translate_y_20 =
+    A.class "md:tw--translate-y-20"
+
+
+md_tw_neg_translate_y_24 : Html.Attribute msg
+md_tw_neg_translate_y_24 =
+    A.class "md:tw--translate-y-24"
+
+
+md_tw_neg_translate_y_32 : Html.Attribute msg
+md_tw_neg_translate_y_32 =
+    A.class "md:tw--translate-y-32"
+
+
+md_tw_neg_translate_y_40 : Html.Attribute msg
+md_tw_neg_translate_y_40 =
+    A.class "md:tw--translate-y-40"
+
+
+md_tw_neg_translate_y_48 : Html.Attribute msg
+md_tw_neg_translate_y_48 =
+    A.class "md:tw--translate-y-48"
+
+
+md_tw_neg_translate_y_56 : Html.Attribute msg
+md_tw_neg_translate_y_56 =
+    A.class "md:tw--translate-y-56"
+
+
+md_tw_neg_translate_y_64 : Html.Attribute msg
+md_tw_neg_translate_y_64 =
+    A.class "md:tw--translate-y-64"
+
+
+md_tw_neg_translate_y_px : Html.Attribute msg
+md_tw_neg_translate_y_px =
+    A.class "md:tw--translate-y-px"
+
+
+md_tw_neg_translate_y_full : Html.Attribute msg
+md_tw_neg_translate_y_full =
+    A.class "md:tw--translate-y-full"
+
+
+md_tw_neg_translate_y_1over2 : Html.Attribute msg
+md_tw_neg_translate_y_1over2 =
+    A.class "md:tw--translate-y-1/2"
+
+
+md_tw_translate_y_1over2 : Html.Attribute msg
+md_tw_translate_y_1over2 =
+    A.class "md:tw-translate-y-1/2"
+
+
+md_tw_translate_y_full : Html.Attribute msg
+md_tw_translate_y_full =
+    A.class "md:tw-translate-y-full"
+
+
+md_hover_tw_translate_x_0 : Html.Attribute msg
+md_hover_tw_translate_x_0 =
+    A.class "md:hover:tw-translate-x-0"
+
+
+md_hover_tw_translate_x_1 : Html.Attribute msg
+md_hover_tw_translate_x_1 =
+    A.class "md:hover:tw-translate-x-1"
+
+
+md_hover_tw_translate_x_2 : Html.Attribute msg
+md_hover_tw_translate_x_2 =
+    A.class "md:hover:tw-translate-x-2"
+
+
+md_hover_tw_translate_x_3 : Html.Attribute msg
+md_hover_tw_translate_x_3 =
+    A.class "md:hover:tw-translate-x-3"
+
+
+md_hover_tw_translate_x_4 : Html.Attribute msg
+md_hover_tw_translate_x_4 =
+    A.class "md:hover:tw-translate-x-4"
+
+
+md_hover_tw_translate_x_5 : Html.Attribute msg
+md_hover_tw_translate_x_5 =
+    A.class "md:hover:tw-translate-x-5"
+
+
+md_hover_tw_translate_x_6 : Html.Attribute msg
+md_hover_tw_translate_x_6 =
+    A.class "md:hover:tw-translate-x-6"
+
+
+md_hover_tw_translate_x_8 : Html.Attribute msg
+md_hover_tw_translate_x_8 =
+    A.class "md:hover:tw-translate-x-8"
+
+
+md_hover_tw_translate_x_10 : Html.Attribute msg
+md_hover_tw_translate_x_10 =
+    A.class "md:hover:tw-translate-x-10"
+
+
+md_hover_tw_translate_x_12 : Html.Attribute msg
+md_hover_tw_translate_x_12 =
+    A.class "md:hover:tw-translate-x-12"
+
+
+md_hover_tw_translate_x_16 : Html.Attribute msg
+md_hover_tw_translate_x_16 =
+    A.class "md:hover:tw-translate-x-16"
+
+
+md_hover_tw_translate_x_20 : Html.Attribute msg
+md_hover_tw_translate_x_20 =
+    A.class "md:hover:tw-translate-x-20"
+
+
+md_hover_tw_translate_x_24 : Html.Attribute msg
+md_hover_tw_translate_x_24 =
+    A.class "md:hover:tw-translate-x-24"
+
+
+md_hover_tw_translate_x_32 : Html.Attribute msg
+md_hover_tw_translate_x_32 =
+    A.class "md:hover:tw-translate-x-32"
+
+
+md_hover_tw_translate_x_40 : Html.Attribute msg
+md_hover_tw_translate_x_40 =
+    A.class "md:hover:tw-translate-x-40"
+
+
+md_hover_tw_translate_x_48 : Html.Attribute msg
+md_hover_tw_translate_x_48 =
+    A.class "md:hover:tw-translate-x-48"
+
+
+md_hover_tw_translate_x_56 : Html.Attribute msg
+md_hover_tw_translate_x_56 =
+    A.class "md:hover:tw-translate-x-56"
+
+
+md_hover_tw_translate_x_64 : Html.Attribute msg
+md_hover_tw_translate_x_64 =
+    A.class "md:hover:tw-translate-x-64"
+
+
+md_hover_tw_translate_x_px : Html.Attribute msg
+md_hover_tw_translate_x_px =
+    A.class "md:hover:tw-translate-x-px"
+
+
+md_hover_tw_neg_translate_x_1 : Html.Attribute msg
+md_hover_tw_neg_translate_x_1 =
+    A.class "md:hover:tw--translate-x-1"
+
+
+md_hover_tw_neg_translate_x_2 : Html.Attribute msg
+md_hover_tw_neg_translate_x_2 =
+    A.class "md:hover:tw--translate-x-2"
+
+
+md_hover_tw_neg_translate_x_3 : Html.Attribute msg
+md_hover_tw_neg_translate_x_3 =
+    A.class "md:hover:tw--translate-x-3"
+
+
+md_hover_tw_neg_translate_x_4 : Html.Attribute msg
+md_hover_tw_neg_translate_x_4 =
+    A.class "md:hover:tw--translate-x-4"
+
+
+md_hover_tw_neg_translate_x_5 : Html.Attribute msg
+md_hover_tw_neg_translate_x_5 =
+    A.class "md:hover:tw--translate-x-5"
+
+
+md_hover_tw_neg_translate_x_6 : Html.Attribute msg
+md_hover_tw_neg_translate_x_6 =
+    A.class "md:hover:tw--translate-x-6"
+
+
+md_hover_tw_neg_translate_x_8 : Html.Attribute msg
+md_hover_tw_neg_translate_x_8 =
+    A.class "md:hover:tw--translate-x-8"
+
+
+md_hover_tw_neg_translate_x_10 : Html.Attribute msg
+md_hover_tw_neg_translate_x_10 =
+    A.class "md:hover:tw--translate-x-10"
+
+
+md_hover_tw_neg_translate_x_12 : Html.Attribute msg
+md_hover_tw_neg_translate_x_12 =
+    A.class "md:hover:tw--translate-x-12"
+
+
+md_hover_tw_neg_translate_x_16 : Html.Attribute msg
+md_hover_tw_neg_translate_x_16 =
+    A.class "md:hover:tw--translate-x-16"
+
+
+md_hover_tw_neg_translate_x_20 : Html.Attribute msg
+md_hover_tw_neg_translate_x_20 =
+    A.class "md:hover:tw--translate-x-20"
+
+
+md_hover_tw_neg_translate_x_24 : Html.Attribute msg
+md_hover_tw_neg_translate_x_24 =
+    A.class "md:hover:tw--translate-x-24"
+
+
+md_hover_tw_neg_translate_x_32 : Html.Attribute msg
+md_hover_tw_neg_translate_x_32 =
+    A.class "md:hover:tw--translate-x-32"
+
+
+md_hover_tw_neg_translate_x_40 : Html.Attribute msg
+md_hover_tw_neg_translate_x_40 =
+    A.class "md:hover:tw--translate-x-40"
+
+
+md_hover_tw_neg_translate_x_48 : Html.Attribute msg
+md_hover_tw_neg_translate_x_48 =
+    A.class "md:hover:tw--translate-x-48"
+
+
+md_hover_tw_neg_translate_x_56 : Html.Attribute msg
+md_hover_tw_neg_translate_x_56 =
+    A.class "md:hover:tw--translate-x-56"
+
+
+md_hover_tw_neg_translate_x_64 : Html.Attribute msg
+md_hover_tw_neg_translate_x_64 =
+    A.class "md:hover:tw--translate-x-64"
+
+
+md_hover_tw_neg_translate_x_px : Html.Attribute msg
+md_hover_tw_neg_translate_x_px =
+    A.class "md:hover:tw--translate-x-px"
+
+
+md_hover_tw_neg_translate_x_full : Html.Attribute msg
+md_hover_tw_neg_translate_x_full =
+    A.class "md:hover:tw--translate-x-full"
+
+
+md_hover_tw_neg_translate_x_1over2 : Html.Attribute msg
+md_hover_tw_neg_translate_x_1over2 =
+    A.class "md:hover:tw--translate-x-1/2"
+
+
+md_hover_tw_translate_x_1over2 : Html.Attribute msg
+md_hover_tw_translate_x_1over2 =
+    A.class "md:hover:tw-translate-x-1/2"
+
+
+md_hover_tw_translate_x_full : Html.Attribute msg
+md_hover_tw_translate_x_full =
+    A.class "md:hover:tw-translate-x-full"
+
+
+md_hover_tw_translate_y_0 : Html.Attribute msg
+md_hover_tw_translate_y_0 =
+    A.class "md:hover:tw-translate-y-0"
+
+
+md_hover_tw_translate_y_1 : Html.Attribute msg
+md_hover_tw_translate_y_1 =
+    A.class "md:hover:tw-translate-y-1"
+
+
+md_hover_tw_translate_y_2 : Html.Attribute msg
+md_hover_tw_translate_y_2 =
+    A.class "md:hover:tw-translate-y-2"
+
+
+md_hover_tw_translate_y_3 : Html.Attribute msg
+md_hover_tw_translate_y_3 =
+    A.class "md:hover:tw-translate-y-3"
+
+
+md_hover_tw_translate_y_4 : Html.Attribute msg
+md_hover_tw_translate_y_4 =
+    A.class "md:hover:tw-translate-y-4"
+
+
+md_hover_tw_translate_y_5 : Html.Attribute msg
+md_hover_tw_translate_y_5 =
+    A.class "md:hover:tw-translate-y-5"
+
+
+md_hover_tw_translate_y_6 : Html.Attribute msg
+md_hover_tw_translate_y_6 =
+    A.class "md:hover:tw-translate-y-6"
+
+
+md_hover_tw_translate_y_8 : Html.Attribute msg
+md_hover_tw_translate_y_8 =
+    A.class "md:hover:tw-translate-y-8"
+
+
+md_hover_tw_translate_y_10 : Html.Attribute msg
+md_hover_tw_translate_y_10 =
+    A.class "md:hover:tw-translate-y-10"
+
+
+md_hover_tw_translate_y_12 : Html.Attribute msg
+md_hover_tw_translate_y_12 =
+    A.class "md:hover:tw-translate-y-12"
+
+
+md_hover_tw_translate_y_16 : Html.Attribute msg
+md_hover_tw_translate_y_16 =
+    A.class "md:hover:tw-translate-y-16"
+
+
+md_hover_tw_translate_y_20 : Html.Attribute msg
+md_hover_tw_translate_y_20 =
+    A.class "md:hover:tw-translate-y-20"
+
+
+md_hover_tw_translate_y_24 : Html.Attribute msg
+md_hover_tw_translate_y_24 =
+    A.class "md:hover:tw-translate-y-24"
+
+
+md_hover_tw_translate_y_32 : Html.Attribute msg
+md_hover_tw_translate_y_32 =
+    A.class "md:hover:tw-translate-y-32"
+
+
+md_hover_tw_translate_y_40 : Html.Attribute msg
+md_hover_tw_translate_y_40 =
+    A.class "md:hover:tw-translate-y-40"
+
+
+md_hover_tw_translate_y_48 : Html.Attribute msg
+md_hover_tw_translate_y_48 =
+    A.class "md:hover:tw-translate-y-48"
+
+
+md_hover_tw_translate_y_56 : Html.Attribute msg
+md_hover_tw_translate_y_56 =
+    A.class "md:hover:tw-translate-y-56"
+
+
+md_hover_tw_translate_y_64 : Html.Attribute msg
+md_hover_tw_translate_y_64 =
+    A.class "md:hover:tw-translate-y-64"
+
+
+md_hover_tw_translate_y_px : Html.Attribute msg
+md_hover_tw_translate_y_px =
+    A.class "md:hover:tw-translate-y-px"
+
+
+md_hover_tw_neg_translate_y_1 : Html.Attribute msg
+md_hover_tw_neg_translate_y_1 =
+    A.class "md:hover:tw--translate-y-1"
+
+
+md_hover_tw_neg_translate_y_2 : Html.Attribute msg
+md_hover_tw_neg_translate_y_2 =
+    A.class "md:hover:tw--translate-y-2"
+
+
+md_hover_tw_neg_translate_y_3 : Html.Attribute msg
+md_hover_tw_neg_translate_y_3 =
+    A.class "md:hover:tw--translate-y-3"
+
+
+md_hover_tw_neg_translate_y_4 : Html.Attribute msg
+md_hover_tw_neg_translate_y_4 =
+    A.class "md:hover:tw--translate-y-4"
+
+
+md_hover_tw_neg_translate_y_5 : Html.Attribute msg
+md_hover_tw_neg_translate_y_5 =
+    A.class "md:hover:tw--translate-y-5"
+
+
+md_hover_tw_neg_translate_y_6 : Html.Attribute msg
+md_hover_tw_neg_translate_y_6 =
+    A.class "md:hover:tw--translate-y-6"
+
+
+md_hover_tw_neg_translate_y_8 : Html.Attribute msg
+md_hover_tw_neg_translate_y_8 =
+    A.class "md:hover:tw--translate-y-8"
+
+
+md_hover_tw_neg_translate_y_10 : Html.Attribute msg
+md_hover_tw_neg_translate_y_10 =
+    A.class "md:hover:tw--translate-y-10"
+
+
+md_hover_tw_neg_translate_y_12 : Html.Attribute msg
+md_hover_tw_neg_translate_y_12 =
+    A.class "md:hover:tw--translate-y-12"
+
+
+md_hover_tw_neg_translate_y_16 : Html.Attribute msg
+md_hover_tw_neg_translate_y_16 =
+    A.class "md:hover:tw--translate-y-16"
+
+
+md_hover_tw_neg_translate_y_20 : Html.Attribute msg
+md_hover_tw_neg_translate_y_20 =
+    A.class "md:hover:tw--translate-y-20"
+
+
+md_hover_tw_neg_translate_y_24 : Html.Attribute msg
+md_hover_tw_neg_translate_y_24 =
+    A.class "md:hover:tw--translate-y-24"
+
+
+md_hover_tw_neg_translate_y_32 : Html.Attribute msg
+md_hover_tw_neg_translate_y_32 =
+    A.class "md:hover:tw--translate-y-32"
+
+
+md_hover_tw_neg_translate_y_40 : Html.Attribute msg
+md_hover_tw_neg_translate_y_40 =
+    A.class "md:hover:tw--translate-y-40"
+
+
+md_hover_tw_neg_translate_y_48 : Html.Attribute msg
+md_hover_tw_neg_translate_y_48 =
+    A.class "md:hover:tw--translate-y-48"
+
+
+md_hover_tw_neg_translate_y_56 : Html.Attribute msg
+md_hover_tw_neg_translate_y_56 =
+    A.class "md:hover:tw--translate-y-56"
+
+
+md_hover_tw_neg_translate_y_64 : Html.Attribute msg
+md_hover_tw_neg_translate_y_64 =
+    A.class "md:hover:tw--translate-y-64"
+
+
+md_hover_tw_neg_translate_y_px : Html.Attribute msg
+md_hover_tw_neg_translate_y_px =
+    A.class "md:hover:tw--translate-y-px"
+
+
+md_hover_tw_neg_translate_y_full : Html.Attribute msg
+md_hover_tw_neg_translate_y_full =
+    A.class "md:hover:tw--translate-y-full"
+
+
+md_hover_tw_neg_translate_y_1over2 : Html.Attribute msg
+md_hover_tw_neg_translate_y_1over2 =
+    A.class "md:hover:tw--translate-y-1/2"
+
+
+md_hover_tw_translate_y_1over2 : Html.Attribute msg
+md_hover_tw_translate_y_1over2 =
+    A.class "md:hover:tw-translate-y-1/2"
+
+
+md_hover_tw_translate_y_full : Html.Attribute msg
+md_hover_tw_translate_y_full =
+    A.class "md:hover:tw-translate-y-full"
+
+
+md_focus_tw_translate_x_0 : Html.Attribute msg
+md_focus_tw_translate_x_0 =
+    A.class "md:focus:tw-translate-x-0"
+
+
+md_focus_tw_translate_x_1 : Html.Attribute msg
+md_focus_tw_translate_x_1 =
+    A.class "md:focus:tw-translate-x-1"
+
+
+md_focus_tw_translate_x_2 : Html.Attribute msg
+md_focus_tw_translate_x_2 =
+    A.class "md:focus:tw-translate-x-2"
+
+
+md_focus_tw_translate_x_3 : Html.Attribute msg
+md_focus_tw_translate_x_3 =
+    A.class "md:focus:tw-translate-x-3"
+
+
+md_focus_tw_translate_x_4 : Html.Attribute msg
+md_focus_tw_translate_x_4 =
+    A.class "md:focus:tw-translate-x-4"
+
+
+md_focus_tw_translate_x_5 : Html.Attribute msg
+md_focus_tw_translate_x_5 =
+    A.class "md:focus:tw-translate-x-5"
+
+
+md_focus_tw_translate_x_6 : Html.Attribute msg
+md_focus_tw_translate_x_6 =
+    A.class "md:focus:tw-translate-x-6"
+
+
+md_focus_tw_translate_x_8 : Html.Attribute msg
+md_focus_tw_translate_x_8 =
+    A.class "md:focus:tw-translate-x-8"
+
+
+md_focus_tw_translate_x_10 : Html.Attribute msg
+md_focus_tw_translate_x_10 =
+    A.class "md:focus:tw-translate-x-10"
+
+
+md_focus_tw_translate_x_12 : Html.Attribute msg
+md_focus_tw_translate_x_12 =
+    A.class "md:focus:tw-translate-x-12"
+
+
+md_focus_tw_translate_x_16 : Html.Attribute msg
+md_focus_tw_translate_x_16 =
+    A.class "md:focus:tw-translate-x-16"
+
+
+md_focus_tw_translate_x_20 : Html.Attribute msg
+md_focus_tw_translate_x_20 =
+    A.class "md:focus:tw-translate-x-20"
+
+
+md_focus_tw_translate_x_24 : Html.Attribute msg
+md_focus_tw_translate_x_24 =
+    A.class "md:focus:tw-translate-x-24"
+
+
+md_focus_tw_translate_x_32 : Html.Attribute msg
+md_focus_tw_translate_x_32 =
+    A.class "md:focus:tw-translate-x-32"
+
+
+md_focus_tw_translate_x_40 : Html.Attribute msg
+md_focus_tw_translate_x_40 =
+    A.class "md:focus:tw-translate-x-40"
+
+
+md_focus_tw_translate_x_48 : Html.Attribute msg
+md_focus_tw_translate_x_48 =
+    A.class "md:focus:tw-translate-x-48"
+
+
+md_focus_tw_translate_x_56 : Html.Attribute msg
+md_focus_tw_translate_x_56 =
+    A.class "md:focus:tw-translate-x-56"
+
+
+md_focus_tw_translate_x_64 : Html.Attribute msg
+md_focus_tw_translate_x_64 =
+    A.class "md:focus:tw-translate-x-64"
+
+
+md_focus_tw_translate_x_px : Html.Attribute msg
+md_focus_tw_translate_x_px =
+    A.class "md:focus:tw-translate-x-px"
+
+
+md_focus_tw_neg_translate_x_1 : Html.Attribute msg
+md_focus_tw_neg_translate_x_1 =
+    A.class "md:focus:tw--translate-x-1"
+
+
+md_focus_tw_neg_translate_x_2 : Html.Attribute msg
+md_focus_tw_neg_translate_x_2 =
+    A.class "md:focus:tw--translate-x-2"
+
+
+md_focus_tw_neg_translate_x_3 : Html.Attribute msg
+md_focus_tw_neg_translate_x_3 =
+    A.class "md:focus:tw--translate-x-3"
+
+
+md_focus_tw_neg_translate_x_4 : Html.Attribute msg
+md_focus_tw_neg_translate_x_4 =
+    A.class "md:focus:tw--translate-x-4"
+
+
+md_focus_tw_neg_translate_x_5 : Html.Attribute msg
+md_focus_tw_neg_translate_x_5 =
+    A.class "md:focus:tw--translate-x-5"
+
+
+md_focus_tw_neg_translate_x_6 : Html.Attribute msg
+md_focus_tw_neg_translate_x_6 =
+    A.class "md:focus:tw--translate-x-6"
+
+
+md_focus_tw_neg_translate_x_8 : Html.Attribute msg
+md_focus_tw_neg_translate_x_8 =
+    A.class "md:focus:tw--translate-x-8"
+
+
+md_focus_tw_neg_translate_x_10 : Html.Attribute msg
+md_focus_tw_neg_translate_x_10 =
+    A.class "md:focus:tw--translate-x-10"
+
+
+md_focus_tw_neg_translate_x_12 : Html.Attribute msg
+md_focus_tw_neg_translate_x_12 =
+    A.class "md:focus:tw--translate-x-12"
+
+
+md_focus_tw_neg_translate_x_16 : Html.Attribute msg
+md_focus_tw_neg_translate_x_16 =
+    A.class "md:focus:tw--translate-x-16"
+
+
+md_focus_tw_neg_translate_x_20 : Html.Attribute msg
+md_focus_tw_neg_translate_x_20 =
+    A.class "md:focus:tw--translate-x-20"
+
+
+md_focus_tw_neg_translate_x_24 : Html.Attribute msg
+md_focus_tw_neg_translate_x_24 =
+    A.class "md:focus:tw--translate-x-24"
+
+
+md_focus_tw_neg_translate_x_32 : Html.Attribute msg
+md_focus_tw_neg_translate_x_32 =
+    A.class "md:focus:tw--translate-x-32"
+
+
+md_focus_tw_neg_translate_x_40 : Html.Attribute msg
+md_focus_tw_neg_translate_x_40 =
+    A.class "md:focus:tw--translate-x-40"
+
+
+md_focus_tw_neg_translate_x_48 : Html.Attribute msg
+md_focus_tw_neg_translate_x_48 =
+    A.class "md:focus:tw--translate-x-48"
+
+
+md_focus_tw_neg_translate_x_56 : Html.Attribute msg
+md_focus_tw_neg_translate_x_56 =
+    A.class "md:focus:tw--translate-x-56"
+
+
+md_focus_tw_neg_translate_x_64 : Html.Attribute msg
+md_focus_tw_neg_translate_x_64 =
+    A.class "md:focus:tw--translate-x-64"
+
+
+md_focus_tw_neg_translate_x_px : Html.Attribute msg
+md_focus_tw_neg_translate_x_px =
+    A.class "md:focus:tw--translate-x-px"
+
+
+md_focus_tw_neg_translate_x_full : Html.Attribute msg
+md_focus_tw_neg_translate_x_full =
+    A.class "md:focus:tw--translate-x-full"
+
+
+md_focus_tw_neg_translate_x_1over2 : Html.Attribute msg
+md_focus_tw_neg_translate_x_1over2 =
+    A.class "md:focus:tw--translate-x-1/2"
+
+
+md_focus_tw_translate_x_1over2 : Html.Attribute msg
+md_focus_tw_translate_x_1over2 =
+    A.class "md:focus:tw-translate-x-1/2"
+
+
+md_focus_tw_translate_x_full : Html.Attribute msg
+md_focus_tw_translate_x_full =
+    A.class "md:focus:tw-translate-x-full"
+
+
+md_focus_tw_translate_y_0 : Html.Attribute msg
+md_focus_tw_translate_y_0 =
+    A.class "md:focus:tw-translate-y-0"
+
+
+md_focus_tw_translate_y_1 : Html.Attribute msg
+md_focus_tw_translate_y_1 =
+    A.class "md:focus:tw-translate-y-1"
+
+
+md_focus_tw_translate_y_2 : Html.Attribute msg
+md_focus_tw_translate_y_2 =
+    A.class "md:focus:tw-translate-y-2"
+
+
+md_focus_tw_translate_y_3 : Html.Attribute msg
+md_focus_tw_translate_y_3 =
+    A.class "md:focus:tw-translate-y-3"
+
+
+md_focus_tw_translate_y_4 : Html.Attribute msg
+md_focus_tw_translate_y_4 =
+    A.class "md:focus:tw-translate-y-4"
+
+
+md_focus_tw_translate_y_5 : Html.Attribute msg
+md_focus_tw_translate_y_5 =
+    A.class "md:focus:tw-translate-y-5"
+
+
+md_focus_tw_translate_y_6 : Html.Attribute msg
+md_focus_tw_translate_y_6 =
+    A.class "md:focus:tw-translate-y-6"
+
+
+md_focus_tw_translate_y_8 : Html.Attribute msg
+md_focus_tw_translate_y_8 =
+    A.class "md:focus:tw-translate-y-8"
+
+
+md_focus_tw_translate_y_10 : Html.Attribute msg
+md_focus_tw_translate_y_10 =
+    A.class "md:focus:tw-translate-y-10"
+
+
+md_focus_tw_translate_y_12 : Html.Attribute msg
+md_focus_tw_translate_y_12 =
+    A.class "md:focus:tw-translate-y-12"
+
+
+md_focus_tw_translate_y_16 : Html.Attribute msg
+md_focus_tw_translate_y_16 =
+    A.class "md:focus:tw-translate-y-16"
+
+
+md_focus_tw_translate_y_20 : Html.Attribute msg
+md_focus_tw_translate_y_20 =
+    A.class "md:focus:tw-translate-y-20"
+
+
+md_focus_tw_translate_y_24 : Html.Attribute msg
+md_focus_tw_translate_y_24 =
+    A.class "md:focus:tw-translate-y-24"
+
+
+md_focus_tw_translate_y_32 : Html.Attribute msg
+md_focus_tw_translate_y_32 =
+    A.class "md:focus:tw-translate-y-32"
+
+
+md_focus_tw_translate_y_40 : Html.Attribute msg
+md_focus_tw_translate_y_40 =
+    A.class "md:focus:tw-translate-y-40"
+
+
+md_focus_tw_translate_y_48 : Html.Attribute msg
+md_focus_tw_translate_y_48 =
+    A.class "md:focus:tw-translate-y-48"
+
+
+md_focus_tw_translate_y_56 : Html.Attribute msg
+md_focus_tw_translate_y_56 =
+    A.class "md:focus:tw-translate-y-56"
+
+
+md_focus_tw_translate_y_64 : Html.Attribute msg
+md_focus_tw_translate_y_64 =
+    A.class "md:focus:tw-translate-y-64"
+
+
+md_focus_tw_translate_y_px : Html.Attribute msg
+md_focus_tw_translate_y_px =
+    A.class "md:focus:tw-translate-y-px"
+
+
+md_focus_tw_neg_translate_y_1 : Html.Attribute msg
+md_focus_tw_neg_translate_y_1 =
+    A.class "md:focus:tw--translate-y-1"
+
+
+md_focus_tw_neg_translate_y_2 : Html.Attribute msg
+md_focus_tw_neg_translate_y_2 =
+    A.class "md:focus:tw--translate-y-2"
+
+
+md_focus_tw_neg_translate_y_3 : Html.Attribute msg
+md_focus_tw_neg_translate_y_3 =
+    A.class "md:focus:tw--translate-y-3"
+
+
+md_focus_tw_neg_translate_y_4 : Html.Attribute msg
+md_focus_tw_neg_translate_y_4 =
+    A.class "md:focus:tw--translate-y-4"
+
+
+md_focus_tw_neg_translate_y_5 : Html.Attribute msg
+md_focus_tw_neg_translate_y_5 =
+    A.class "md:focus:tw--translate-y-5"
+
+
+md_focus_tw_neg_translate_y_6 : Html.Attribute msg
+md_focus_tw_neg_translate_y_6 =
+    A.class "md:focus:tw--translate-y-6"
+
+
+md_focus_tw_neg_translate_y_8 : Html.Attribute msg
+md_focus_tw_neg_translate_y_8 =
+    A.class "md:focus:tw--translate-y-8"
+
+
+md_focus_tw_neg_translate_y_10 : Html.Attribute msg
+md_focus_tw_neg_translate_y_10 =
+    A.class "md:focus:tw--translate-y-10"
+
+
+md_focus_tw_neg_translate_y_12 : Html.Attribute msg
+md_focus_tw_neg_translate_y_12 =
+    A.class "md:focus:tw--translate-y-12"
+
+
+md_focus_tw_neg_translate_y_16 : Html.Attribute msg
+md_focus_tw_neg_translate_y_16 =
+    A.class "md:focus:tw--translate-y-16"
+
+
+md_focus_tw_neg_translate_y_20 : Html.Attribute msg
+md_focus_tw_neg_translate_y_20 =
+    A.class "md:focus:tw--translate-y-20"
+
+
+md_focus_tw_neg_translate_y_24 : Html.Attribute msg
+md_focus_tw_neg_translate_y_24 =
+    A.class "md:focus:tw--translate-y-24"
+
+
+md_focus_tw_neg_translate_y_32 : Html.Attribute msg
+md_focus_tw_neg_translate_y_32 =
+    A.class "md:focus:tw--translate-y-32"
+
+
+md_focus_tw_neg_translate_y_40 : Html.Attribute msg
+md_focus_tw_neg_translate_y_40 =
+    A.class "md:focus:tw--translate-y-40"
+
+
+md_focus_tw_neg_translate_y_48 : Html.Attribute msg
+md_focus_tw_neg_translate_y_48 =
+    A.class "md:focus:tw--translate-y-48"
+
+
+md_focus_tw_neg_translate_y_56 : Html.Attribute msg
+md_focus_tw_neg_translate_y_56 =
+    A.class "md:focus:tw--translate-y-56"
+
+
+md_focus_tw_neg_translate_y_64 : Html.Attribute msg
+md_focus_tw_neg_translate_y_64 =
+    A.class "md:focus:tw--translate-y-64"
+
+
+md_focus_tw_neg_translate_y_px : Html.Attribute msg
+md_focus_tw_neg_translate_y_px =
+    A.class "md:focus:tw--translate-y-px"
+
+
+md_focus_tw_neg_translate_y_full : Html.Attribute msg
+md_focus_tw_neg_translate_y_full =
+    A.class "md:focus:tw--translate-y-full"
+
+
+md_focus_tw_neg_translate_y_1over2 : Html.Attribute msg
+md_focus_tw_neg_translate_y_1over2 =
+    A.class "md:focus:tw--translate-y-1/2"
+
+
+md_focus_tw_translate_y_1over2 : Html.Attribute msg
+md_focus_tw_translate_y_1over2 =
+    A.class "md:focus:tw-translate-y-1/2"
+
+
+md_focus_tw_translate_y_full : Html.Attribute msg
+md_focus_tw_translate_y_full =
+    A.class "md:focus:tw-translate-y-full"
+
+
+md_tw_skew_x_0 : Html.Attribute msg
+md_tw_skew_x_0 =
+    A.class "md:tw-skew-x-0"
+
+
+md_tw_skew_x_3 : Html.Attribute msg
+md_tw_skew_x_3 =
+    A.class "md:tw-skew-x-3"
+
+
+md_tw_skew_x_6 : Html.Attribute msg
+md_tw_skew_x_6 =
+    A.class "md:tw-skew-x-6"
+
+
+md_tw_skew_x_12 : Html.Attribute msg
+md_tw_skew_x_12 =
+    A.class "md:tw-skew-x-12"
+
+
+md_tw_neg_skew_x_12 : Html.Attribute msg
+md_tw_neg_skew_x_12 =
+    A.class "md:tw--skew-x-12"
+
+
+md_tw_neg_skew_x_6 : Html.Attribute msg
+md_tw_neg_skew_x_6 =
+    A.class "md:tw--skew-x-6"
+
+
+md_tw_neg_skew_x_3 : Html.Attribute msg
+md_tw_neg_skew_x_3 =
+    A.class "md:tw--skew-x-3"
+
+
+md_tw_skew_y_0 : Html.Attribute msg
+md_tw_skew_y_0 =
+    A.class "md:tw-skew-y-0"
+
+
+md_tw_skew_y_3 : Html.Attribute msg
+md_tw_skew_y_3 =
+    A.class "md:tw-skew-y-3"
+
+
+md_tw_skew_y_6 : Html.Attribute msg
+md_tw_skew_y_6 =
+    A.class "md:tw-skew-y-6"
+
+
+md_tw_skew_y_12 : Html.Attribute msg
+md_tw_skew_y_12 =
+    A.class "md:tw-skew-y-12"
+
+
+md_tw_neg_skew_y_12 : Html.Attribute msg
+md_tw_neg_skew_y_12 =
+    A.class "md:tw--skew-y-12"
+
+
+md_tw_neg_skew_y_6 : Html.Attribute msg
+md_tw_neg_skew_y_6 =
+    A.class "md:tw--skew-y-6"
+
+
+md_tw_neg_skew_y_3 : Html.Attribute msg
+md_tw_neg_skew_y_3 =
+    A.class "md:tw--skew-y-3"
+
+
+md_hover_tw_skew_x_0 : Html.Attribute msg
+md_hover_tw_skew_x_0 =
+    A.class "md:hover:tw-skew-x-0"
+
+
+md_hover_tw_skew_x_3 : Html.Attribute msg
+md_hover_tw_skew_x_3 =
+    A.class "md:hover:tw-skew-x-3"
+
+
+md_hover_tw_skew_x_6 : Html.Attribute msg
+md_hover_tw_skew_x_6 =
+    A.class "md:hover:tw-skew-x-6"
+
+
+md_hover_tw_skew_x_12 : Html.Attribute msg
+md_hover_tw_skew_x_12 =
+    A.class "md:hover:tw-skew-x-12"
+
+
+md_hover_tw_neg_skew_x_12 : Html.Attribute msg
+md_hover_tw_neg_skew_x_12 =
+    A.class "md:hover:tw--skew-x-12"
+
+
+md_hover_tw_neg_skew_x_6 : Html.Attribute msg
+md_hover_tw_neg_skew_x_6 =
+    A.class "md:hover:tw--skew-x-6"
+
+
+md_hover_tw_neg_skew_x_3 : Html.Attribute msg
+md_hover_tw_neg_skew_x_3 =
+    A.class "md:hover:tw--skew-x-3"
+
+
+md_hover_tw_skew_y_0 : Html.Attribute msg
+md_hover_tw_skew_y_0 =
+    A.class "md:hover:tw-skew-y-0"
+
+
+md_hover_tw_skew_y_3 : Html.Attribute msg
+md_hover_tw_skew_y_3 =
+    A.class "md:hover:tw-skew-y-3"
+
+
+md_hover_tw_skew_y_6 : Html.Attribute msg
+md_hover_tw_skew_y_6 =
+    A.class "md:hover:tw-skew-y-6"
+
+
+md_hover_tw_skew_y_12 : Html.Attribute msg
+md_hover_tw_skew_y_12 =
+    A.class "md:hover:tw-skew-y-12"
+
+
+md_hover_tw_neg_skew_y_12 : Html.Attribute msg
+md_hover_tw_neg_skew_y_12 =
+    A.class "md:hover:tw--skew-y-12"
+
+
+md_hover_tw_neg_skew_y_6 : Html.Attribute msg
+md_hover_tw_neg_skew_y_6 =
+    A.class "md:hover:tw--skew-y-6"
+
+
+md_hover_tw_neg_skew_y_3 : Html.Attribute msg
+md_hover_tw_neg_skew_y_3 =
+    A.class "md:hover:tw--skew-y-3"
+
+
+md_focus_tw_skew_x_0 : Html.Attribute msg
+md_focus_tw_skew_x_0 =
+    A.class "md:focus:tw-skew-x-0"
+
+
+md_focus_tw_skew_x_3 : Html.Attribute msg
+md_focus_tw_skew_x_3 =
+    A.class "md:focus:tw-skew-x-3"
+
+
+md_focus_tw_skew_x_6 : Html.Attribute msg
+md_focus_tw_skew_x_6 =
+    A.class "md:focus:tw-skew-x-6"
+
+
+md_focus_tw_skew_x_12 : Html.Attribute msg
+md_focus_tw_skew_x_12 =
+    A.class "md:focus:tw-skew-x-12"
+
+
+md_focus_tw_neg_skew_x_12 : Html.Attribute msg
+md_focus_tw_neg_skew_x_12 =
+    A.class "md:focus:tw--skew-x-12"
+
+
+md_focus_tw_neg_skew_x_6 : Html.Attribute msg
+md_focus_tw_neg_skew_x_6 =
+    A.class "md:focus:tw--skew-x-6"
+
+
+md_focus_tw_neg_skew_x_3 : Html.Attribute msg
+md_focus_tw_neg_skew_x_3 =
+    A.class "md:focus:tw--skew-x-3"
+
+
+md_focus_tw_skew_y_0 : Html.Attribute msg
+md_focus_tw_skew_y_0 =
+    A.class "md:focus:tw-skew-y-0"
+
+
+md_focus_tw_skew_y_3 : Html.Attribute msg
+md_focus_tw_skew_y_3 =
+    A.class "md:focus:tw-skew-y-3"
+
+
+md_focus_tw_skew_y_6 : Html.Attribute msg
+md_focus_tw_skew_y_6 =
+    A.class "md:focus:tw-skew-y-6"
+
+
+md_focus_tw_skew_y_12 : Html.Attribute msg
+md_focus_tw_skew_y_12 =
+    A.class "md:focus:tw-skew-y-12"
+
+
+md_focus_tw_neg_skew_y_12 : Html.Attribute msg
+md_focus_tw_neg_skew_y_12 =
+    A.class "md:focus:tw--skew-y-12"
+
+
+md_focus_tw_neg_skew_y_6 : Html.Attribute msg
+md_focus_tw_neg_skew_y_6 =
+    A.class "md:focus:tw--skew-y-6"
+
+
+md_focus_tw_neg_skew_y_3 : Html.Attribute msg
+md_focus_tw_neg_skew_y_3 =
+    A.class "md:focus:tw--skew-y-3"
+
+
+md_tw_transition_none : Html.Attribute msg
+md_tw_transition_none =
+    A.class "md:tw-transition-none"
+
+
+md_tw_transition_all : Html.Attribute msg
+md_tw_transition_all =
+    A.class "md:tw-transition-all"
+
+
+md_tw_transition : Html.Attribute msg
+md_tw_transition =
+    A.class "md:tw-transition"
+
+
+md_tw_transition_colors : Html.Attribute msg
+md_tw_transition_colors =
+    A.class "md:tw-transition-colors"
+
+
+md_tw_transition_opacity : Html.Attribute msg
+md_tw_transition_opacity =
+    A.class "md:tw-transition-opacity"
+
+
+md_tw_transition_shadow : Html.Attribute msg
+md_tw_transition_shadow =
+    A.class "md:tw-transition-shadow"
+
+
+md_tw_transition_transform : Html.Attribute msg
+md_tw_transition_transform =
+    A.class "md:tw-transition-transform"
+
+
+md_tw_ease_linear : Html.Attribute msg
+md_tw_ease_linear =
+    A.class "md:tw-ease-linear"
+
+
+md_tw_ease_in : Html.Attribute msg
+md_tw_ease_in =
+    A.class "md:tw-ease-in"
+
+
+md_tw_ease_out : Html.Attribute msg
+md_tw_ease_out =
+    A.class "md:tw-ease-out"
+
+
+md_tw_ease_in_out : Html.Attribute msg
+md_tw_ease_in_out =
+    A.class "md:tw-ease-in-out"
+
+
+md_tw_duration_75 : Html.Attribute msg
+md_tw_duration_75 =
+    A.class "md:tw-duration-75"
+
+
+md_tw_duration_100 : Html.Attribute msg
+md_tw_duration_100 =
+    A.class "md:tw-duration-100"
+
+
+md_tw_duration_150 : Html.Attribute msg
+md_tw_duration_150 =
+    A.class "md:tw-duration-150"
+
+
+md_tw_duration_200 : Html.Attribute msg
+md_tw_duration_200 =
+    A.class "md:tw-duration-200"
+
+
+md_tw_duration_300 : Html.Attribute msg
+md_tw_duration_300 =
+    A.class "md:tw-duration-300"
+
+
+md_tw_duration_500 : Html.Attribute msg
+md_tw_duration_500 =
+    A.class "md:tw-duration-500"
+
+
+md_tw_duration_700 : Html.Attribute msg
+md_tw_duration_700 =
+    A.class "md:tw-duration-700"
+
+
+md_tw_duration_1000 : Html.Attribute msg
+md_tw_duration_1000 =
+    A.class "md:tw-duration-1000"
 
 
 lg_tw_sr_only : Html.Attribute msg
@@ -40768,6 +53128,11 @@ lg_tw_rounded =
     A.class "lg:tw-rounded"
 
 
+lg_tw_rounded_md : Html.Attribute msg
+lg_tw_rounded_md =
+    A.class "lg:tw-rounded-md"
+
+
 lg_tw_rounded_lg : Html.Attribute msg
 lg_tw_rounded_lg =
     A.class "lg:tw-rounded-lg"
@@ -40836,6 +53201,26 @@ lg_tw_rounded_b =
 lg_tw_rounded_l : Html.Attribute msg
 lg_tw_rounded_l =
     A.class "lg:tw-rounded-l"
+
+
+lg_tw_rounded_t_md : Html.Attribute msg
+lg_tw_rounded_t_md =
+    A.class "lg:tw-rounded-t-md"
+
+
+lg_tw_rounded_r_md : Html.Attribute msg
+lg_tw_rounded_r_md =
+    A.class "lg:tw-rounded-r-md"
+
+
+lg_tw_rounded_b_md : Html.Attribute msg
+lg_tw_rounded_b_md =
+    A.class "lg:tw-rounded-b-md"
+
+
+lg_tw_rounded_l_md : Html.Attribute msg
+lg_tw_rounded_l_md =
+    A.class "lg:tw-rounded-l-md"
 
 
 lg_tw_rounded_t_lg : Html.Attribute msg
@@ -40936,6 +53321,26 @@ lg_tw_rounded_br =
 lg_tw_rounded_bl : Html.Attribute msg
 lg_tw_rounded_bl =
     A.class "lg:tw-rounded-bl"
+
+
+lg_tw_rounded_tl_md : Html.Attribute msg
+lg_tw_rounded_tl_md =
+    A.class "lg:tw-rounded-tl-md"
+
+
+lg_tw_rounded_tr_md : Html.Attribute msg
+lg_tw_rounded_tr_md =
+    A.class "lg:tw-rounded-tr-md"
+
+
+lg_tw_rounded_br_md : Html.Attribute msg
+lg_tw_rounded_br_md =
+    A.class "lg:tw-rounded-br-md"
+
+
+lg_tw_rounded_bl_md : Html.Attribute msg
+lg_tw_rounded_bl_md =
+    A.class "lg:tw-rounded-bl-md"
 
 
 lg_tw_rounded_tl_lg : Html.Attribute msg
@@ -41128,6 +53533,16 @@ lg_tw_border_l =
     A.class "lg:tw-border-l"
 
 
+lg_tw_box_border : Html.Attribute msg
+lg_tw_box_border =
+    A.class "lg:tw-box-border"
+
+
+lg_tw_box_content : Html.Attribute msg
+lg_tw_box_content =
+    A.class "lg:tw-box-content"
+
+
 lg_tw_cursor_auto : Html.Attribute msg
 lg_tw_cursor_auto =
     A.class "lg:tw-cursor-auto"
@@ -41188,19 +53603,54 @@ lg_tw_inline_flex =
     A.class "lg:tw-inline-flex"
 
 
+lg_tw_grid : Html.Attribute msg
+lg_tw_grid =
+    A.class "lg:tw-grid"
+
+
 lg_tw_table : Html.Attribute msg
 lg_tw_table =
     A.class "lg:tw-table"
 
 
-lg_tw_table_row : Html.Attribute msg
-lg_tw_table_row =
-    A.class "lg:tw-table-row"
+lg_tw_table_caption : Html.Attribute msg
+lg_tw_table_caption =
+    A.class "lg:tw-table-caption"
 
 
 lg_tw_table_cell : Html.Attribute msg
 lg_tw_table_cell =
     A.class "lg:tw-table-cell"
+
+
+lg_tw_table_column : Html.Attribute msg
+lg_tw_table_column =
+    A.class "lg:tw-table-column"
+
+
+lg_tw_table_column_group : Html.Attribute msg
+lg_tw_table_column_group =
+    A.class "lg:tw-table-column-group"
+
+
+lg_tw_table_footer_group : Html.Attribute msg
+lg_tw_table_footer_group =
+    A.class "lg:tw-table-footer-group"
+
+
+lg_tw_table_header_group : Html.Attribute msg
+lg_tw_table_header_group =
+    A.class "lg:tw-table-header-group"
+
+
+lg_tw_table_row_group : Html.Attribute msg
+lg_tw_table_row_group =
+    A.class "lg:tw-table-row-group"
+
+
+lg_tw_table_row : Html.Attribute msg
+lg_tw_table_row =
+    A.class "lg:tw-table-row"
 
 
 lg_tw_hidden : Html.Attribute msg
@@ -41316,6 +53766,11 @@ lg_tw_justify_between =
 lg_tw_justify_around : Html.Attribute msg
 lg_tw_justify_around =
     A.class "lg:tw-justify-around"
+
+
+lg_tw_justify_evenly : Html.Attribute msg
+lg_tw_justify_evenly =
+    A.class "lg:tw-justify-evenly"
 
 
 lg_tw_content_center : Html.Attribute msg
@@ -41476,6 +53931,21 @@ lg_tw_float_none =
 lg_tw_clearfix_after : Html.Attribute msg
 lg_tw_clearfix_after =
     A.class "lg:tw-clearfix:after"
+
+
+lg_tw_clear_left : Html.Attribute msg
+lg_tw_clear_left =
+    A.class "lg:tw-clear-left"
+
+
+lg_tw_clear_right : Html.Attribute msg
+lg_tw_clear_right =
+    A.class "lg:tw-clear-right"
+
+
+lg_tw_clear_both : Html.Attribute msg
+lg_tw_clear_both =
+    A.class "lg:tw-clear-both"
 
 
 lg_tw_font_sans : Html.Attribute msg
@@ -41736,6 +54206,46 @@ lg_tw_h_full =
 lg_tw_h_screen : Html.Attribute msg
 lg_tw_h_screen =
     A.class "lg:tw-h-screen"
+
+
+lg_tw_leading_3 : Html.Attribute msg
+lg_tw_leading_3 =
+    A.class "lg:tw-leading-3"
+
+
+lg_tw_leading_4 : Html.Attribute msg
+lg_tw_leading_4 =
+    A.class "lg:tw-leading-4"
+
+
+lg_tw_leading_5 : Html.Attribute msg
+lg_tw_leading_5 =
+    A.class "lg:tw-leading-5"
+
+
+lg_tw_leading_6 : Html.Attribute msg
+lg_tw_leading_6 =
+    A.class "lg:tw-leading-6"
+
+
+lg_tw_leading_7 : Html.Attribute msg
+lg_tw_leading_7 =
+    A.class "lg:tw-leading-7"
+
+
+lg_tw_leading_8 : Html.Attribute msg
+lg_tw_leading_8 =
+    A.class "lg:tw-leading-8"
+
+
+lg_tw_leading_9 : Html.Attribute msg
+lg_tw_leading_9 =
+    A.class "lg:tw-leading-9"
+
+
+lg_tw_leading_10 : Html.Attribute msg
+lg_tw_leading_10 =
+    A.class "lg:tw-leading-10"
 
 
 lg_tw_leading_none : Html.Attribute msg
@@ -43133,6 +55643,11 @@ lg_tw_max_h_screen =
     A.class "lg:tw-max-h-screen"
 
 
+lg_tw_max_w_none : Html.Attribute msg
+lg_tw_max_w_none =
+    A.class "lg:tw-max-w-none"
+
+
 lg_tw_max_w_xs : Html.Attribute msg
 lg_tw_max_w_xs =
     A.class "lg:tw-max-w-xs"
@@ -43186,6 +55701,26 @@ lg_tw_max_w_6xl =
 lg_tw_max_w_full : Html.Attribute msg
 lg_tw_max_w_full =
     A.class "lg:tw-max-w-full"
+
+
+lg_tw_max_w_screen_sm : Html.Attribute msg
+lg_tw_max_w_screen_sm =
+    A.class "lg:tw-max-w-screen-sm"
+
+
+lg_tw_max_w_screen_md : Html.Attribute msg
+lg_tw_max_w_screen_md =
+    A.class "lg:tw-max-w-screen-md"
+
+
+lg_tw_max_w_screen_lg : Html.Attribute msg
+lg_tw_max_w_screen_lg =
+    A.class "lg:tw-max-w-screen-lg"
+
+
+lg_tw_max_w_screen_xl : Html.Attribute msg
+lg_tw_max_w_screen_xl =
+    A.class "lg:tw-max-w-screen-xl"
 
 
 lg_tw_min_h_0 : Html.Attribute msg
@@ -45158,6 +57693,16 @@ lg_tw_resize =
     A.class "lg:tw-resize"
 
 
+lg_tw_shadow_xs : Html.Attribute msg
+lg_tw_shadow_xs =
+    A.class "lg:tw-shadow-xs"
+
+
+lg_tw_shadow_sm : Html.Attribute msg
+lg_tw_shadow_sm =
+    A.class "lg:tw-shadow-sm"
+
+
 lg_tw_shadow : Html.Attribute msg
 lg_tw_shadow =
     A.class "lg:tw-shadow"
@@ -45198,6 +57743,16 @@ lg_tw_shadow_none =
     A.class "lg:tw-shadow-none"
 
 
+lg_hover_tw_shadow_xs : Html.Attribute msg
+lg_hover_tw_shadow_xs =
+    A.class "lg:hover:tw-shadow-xs"
+
+
+lg_hover_tw_shadow_sm : Html.Attribute msg
+lg_hover_tw_shadow_sm =
+    A.class "lg:hover:tw-shadow-sm"
+
+
 lg_hover_tw_shadow : Html.Attribute msg
 lg_hover_tw_shadow =
     A.class "lg:hover:tw-shadow"
@@ -45236,6 +57791,16 @@ lg_hover_tw_shadow_outline =
 lg_hover_tw_shadow_none : Html.Attribute msg
 lg_hover_tw_shadow_none =
     A.class "lg:hover:tw-shadow-none"
+
+
+lg_focus_tw_shadow_xs : Html.Attribute msg
+lg_focus_tw_shadow_xs =
+    A.class "lg:focus:tw-shadow-xs"
+
+
+lg_focus_tw_shadow_sm : Html.Attribute msg
+lg_focus_tw_shadow_sm =
+    A.class "lg:focus:tw-shadow-sm"
 
 
 lg_focus_tw_shadow : Html.Attribute msg
@@ -45286,6 +57851,21 @@ lg_tw_fill_current =
 lg_tw_stroke_current : Html.Attribute msg
 lg_tw_stroke_current =
     A.class "lg:tw-stroke-current"
+
+
+lg_tw_stroke_0 : Html.Attribute msg
+lg_tw_stroke_0 =
+    A.class "lg:tw-stroke-0"
+
+
+lg_tw_stroke_1 : Html.Attribute msg
+lg_tw_stroke_1 =
+    A.class "lg:tw-stroke-1"
+
+
+lg_tw_stroke_2 : Html.Attribute msg
+lg_tw_stroke_2 =
+    A.class "lg:tw-stroke-2"
 
 
 lg_tw_table_auto : Html.Attribute msg
@@ -47256,6 +59836,2876 @@ lg_tw_z_50 =
 lg_tw_z_auto : Html.Attribute msg
 lg_tw_z_auto =
     A.class "lg:tw-z-auto"
+
+
+lg_tw_gap_0 : Html.Attribute msg
+lg_tw_gap_0 =
+    A.class "lg:tw-gap-0"
+
+
+lg_tw_gap_1 : Html.Attribute msg
+lg_tw_gap_1 =
+    A.class "lg:tw-gap-1"
+
+
+lg_tw_gap_2 : Html.Attribute msg
+lg_tw_gap_2 =
+    A.class "lg:tw-gap-2"
+
+
+lg_tw_gap_3 : Html.Attribute msg
+lg_tw_gap_3 =
+    A.class "lg:tw-gap-3"
+
+
+lg_tw_gap_4 : Html.Attribute msg
+lg_tw_gap_4 =
+    A.class "lg:tw-gap-4"
+
+
+lg_tw_gap_5 : Html.Attribute msg
+lg_tw_gap_5 =
+    A.class "lg:tw-gap-5"
+
+
+lg_tw_gap_6 : Html.Attribute msg
+lg_tw_gap_6 =
+    A.class "lg:tw-gap-6"
+
+
+lg_tw_gap_8 : Html.Attribute msg
+lg_tw_gap_8 =
+    A.class "lg:tw-gap-8"
+
+
+lg_tw_gap_10 : Html.Attribute msg
+lg_tw_gap_10 =
+    A.class "lg:tw-gap-10"
+
+
+lg_tw_gap_12 : Html.Attribute msg
+lg_tw_gap_12 =
+    A.class "lg:tw-gap-12"
+
+
+lg_tw_gap_16 : Html.Attribute msg
+lg_tw_gap_16 =
+    A.class "lg:tw-gap-16"
+
+
+lg_tw_gap_20 : Html.Attribute msg
+lg_tw_gap_20 =
+    A.class "lg:tw-gap-20"
+
+
+lg_tw_gap_24 : Html.Attribute msg
+lg_tw_gap_24 =
+    A.class "lg:tw-gap-24"
+
+
+lg_tw_gap_32 : Html.Attribute msg
+lg_tw_gap_32 =
+    A.class "lg:tw-gap-32"
+
+
+lg_tw_gap_40 : Html.Attribute msg
+lg_tw_gap_40 =
+    A.class "lg:tw-gap-40"
+
+
+lg_tw_gap_48 : Html.Attribute msg
+lg_tw_gap_48 =
+    A.class "lg:tw-gap-48"
+
+
+lg_tw_gap_56 : Html.Attribute msg
+lg_tw_gap_56 =
+    A.class "lg:tw-gap-56"
+
+
+lg_tw_gap_64 : Html.Attribute msg
+lg_tw_gap_64 =
+    A.class "lg:tw-gap-64"
+
+
+lg_tw_gap_px : Html.Attribute msg
+lg_tw_gap_px =
+    A.class "lg:tw-gap-px"
+
+
+lg_tw_col_gap_0 : Html.Attribute msg
+lg_tw_col_gap_0 =
+    A.class "lg:tw-col-gap-0"
+
+
+lg_tw_col_gap_1 : Html.Attribute msg
+lg_tw_col_gap_1 =
+    A.class "lg:tw-col-gap-1"
+
+
+lg_tw_col_gap_2 : Html.Attribute msg
+lg_tw_col_gap_2 =
+    A.class "lg:tw-col-gap-2"
+
+
+lg_tw_col_gap_3 : Html.Attribute msg
+lg_tw_col_gap_3 =
+    A.class "lg:tw-col-gap-3"
+
+
+lg_tw_col_gap_4 : Html.Attribute msg
+lg_tw_col_gap_4 =
+    A.class "lg:tw-col-gap-4"
+
+
+lg_tw_col_gap_5 : Html.Attribute msg
+lg_tw_col_gap_5 =
+    A.class "lg:tw-col-gap-5"
+
+
+lg_tw_col_gap_6 : Html.Attribute msg
+lg_tw_col_gap_6 =
+    A.class "lg:tw-col-gap-6"
+
+
+lg_tw_col_gap_8 : Html.Attribute msg
+lg_tw_col_gap_8 =
+    A.class "lg:tw-col-gap-8"
+
+
+lg_tw_col_gap_10 : Html.Attribute msg
+lg_tw_col_gap_10 =
+    A.class "lg:tw-col-gap-10"
+
+
+lg_tw_col_gap_12 : Html.Attribute msg
+lg_tw_col_gap_12 =
+    A.class "lg:tw-col-gap-12"
+
+
+lg_tw_col_gap_16 : Html.Attribute msg
+lg_tw_col_gap_16 =
+    A.class "lg:tw-col-gap-16"
+
+
+lg_tw_col_gap_20 : Html.Attribute msg
+lg_tw_col_gap_20 =
+    A.class "lg:tw-col-gap-20"
+
+
+lg_tw_col_gap_24 : Html.Attribute msg
+lg_tw_col_gap_24 =
+    A.class "lg:tw-col-gap-24"
+
+
+lg_tw_col_gap_32 : Html.Attribute msg
+lg_tw_col_gap_32 =
+    A.class "lg:tw-col-gap-32"
+
+
+lg_tw_col_gap_40 : Html.Attribute msg
+lg_tw_col_gap_40 =
+    A.class "lg:tw-col-gap-40"
+
+
+lg_tw_col_gap_48 : Html.Attribute msg
+lg_tw_col_gap_48 =
+    A.class "lg:tw-col-gap-48"
+
+
+lg_tw_col_gap_56 : Html.Attribute msg
+lg_tw_col_gap_56 =
+    A.class "lg:tw-col-gap-56"
+
+
+lg_tw_col_gap_64 : Html.Attribute msg
+lg_tw_col_gap_64 =
+    A.class "lg:tw-col-gap-64"
+
+
+lg_tw_col_gap_px : Html.Attribute msg
+lg_tw_col_gap_px =
+    A.class "lg:tw-col-gap-px"
+
+
+lg_tw_row_gap_0 : Html.Attribute msg
+lg_tw_row_gap_0 =
+    A.class "lg:tw-row-gap-0"
+
+
+lg_tw_row_gap_1 : Html.Attribute msg
+lg_tw_row_gap_1 =
+    A.class "lg:tw-row-gap-1"
+
+
+lg_tw_row_gap_2 : Html.Attribute msg
+lg_tw_row_gap_2 =
+    A.class "lg:tw-row-gap-2"
+
+
+lg_tw_row_gap_3 : Html.Attribute msg
+lg_tw_row_gap_3 =
+    A.class "lg:tw-row-gap-3"
+
+
+lg_tw_row_gap_4 : Html.Attribute msg
+lg_tw_row_gap_4 =
+    A.class "lg:tw-row-gap-4"
+
+
+lg_tw_row_gap_5 : Html.Attribute msg
+lg_tw_row_gap_5 =
+    A.class "lg:tw-row-gap-5"
+
+
+lg_tw_row_gap_6 : Html.Attribute msg
+lg_tw_row_gap_6 =
+    A.class "lg:tw-row-gap-6"
+
+
+lg_tw_row_gap_8 : Html.Attribute msg
+lg_tw_row_gap_8 =
+    A.class "lg:tw-row-gap-8"
+
+
+lg_tw_row_gap_10 : Html.Attribute msg
+lg_tw_row_gap_10 =
+    A.class "lg:tw-row-gap-10"
+
+
+lg_tw_row_gap_12 : Html.Attribute msg
+lg_tw_row_gap_12 =
+    A.class "lg:tw-row-gap-12"
+
+
+lg_tw_row_gap_16 : Html.Attribute msg
+lg_tw_row_gap_16 =
+    A.class "lg:tw-row-gap-16"
+
+
+lg_tw_row_gap_20 : Html.Attribute msg
+lg_tw_row_gap_20 =
+    A.class "lg:tw-row-gap-20"
+
+
+lg_tw_row_gap_24 : Html.Attribute msg
+lg_tw_row_gap_24 =
+    A.class "lg:tw-row-gap-24"
+
+
+lg_tw_row_gap_32 : Html.Attribute msg
+lg_tw_row_gap_32 =
+    A.class "lg:tw-row-gap-32"
+
+
+lg_tw_row_gap_40 : Html.Attribute msg
+lg_tw_row_gap_40 =
+    A.class "lg:tw-row-gap-40"
+
+
+lg_tw_row_gap_48 : Html.Attribute msg
+lg_tw_row_gap_48 =
+    A.class "lg:tw-row-gap-48"
+
+
+lg_tw_row_gap_56 : Html.Attribute msg
+lg_tw_row_gap_56 =
+    A.class "lg:tw-row-gap-56"
+
+
+lg_tw_row_gap_64 : Html.Attribute msg
+lg_tw_row_gap_64 =
+    A.class "lg:tw-row-gap-64"
+
+
+lg_tw_row_gap_px : Html.Attribute msg
+lg_tw_row_gap_px =
+    A.class "lg:tw-row-gap-px"
+
+
+lg_tw_grid_flow_row : Html.Attribute msg
+lg_tw_grid_flow_row =
+    A.class "lg:tw-grid-flow-row"
+
+
+lg_tw_grid_flow_col : Html.Attribute msg
+lg_tw_grid_flow_col =
+    A.class "lg:tw-grid-flow-col"
+
+
+lg_tw_grid_flow_row_dense : Html.Attribute msg
+lg_tw_grid_flow_row_dense =
+    A.class "lg:tw-grid-flow-row-dense"
+
+
+lg_tw_grid_flow_col_dense : Html.Attribute msg
+lg_tw_grid_flow_col_dense =
+    A.class "lg:tw-grid-flow-col-dense"
+
+
+lg_tw_grid_cols_1 : Html.Attribute msg
+lg_tw_grid_cols_1 =
+    A.class "lg:tw-grid-cols-1"
+
+
+lg_tw_grid_cols_2 : Html.Attribute msg
+lg_tw_grid_cols_2 =
+    A.class "lg:tw-grid-cols-2"
+
+
+lg_tw_grid_cols_3 : Html.Attribute msg
+lg_tw_grid_cols_3 =
+    A.class "lg:tw-grid-cols-3"
+
+
+lg_tw_grid_cols_4 : Html.Attribute msg
+lg_tw_grid_cols_4 =
+    A.class "lg:tw-grid-cols-4"
+
+
+lg_tw_grid_cols_5 : Html.Attribute msg
+lg_tw_grid_cols_5 =
+    A.class "lg:tw-grid-cols-5"
+
+
+lg_tw_grid_cols_6 : Html.Attribute msg
+lg_tw_grid_cols_6 =
+    A.class "lg:tw-grid-cols-6"
+
+
+lg_tw_grid_cols_7 : Html.Attribute msg
+lg_tw_grid_cols_7 =
+    A.class "lg:tw-grid-cols-7"
+
+
+lg_tw_grid_cols_8 : Html.Attribute msg
+lg_tw_grid_cols_8 =
+    A.class "lg:tw-grid-cols-8"
+
+
+lg_tw_grid_cols_9 : Html.Attribute msg
+lg_tw_grid_cols_9 =
+    A.class "lg:tw-grid-cols-9"
+
+
+lg_tw_grid_cols_10 : Html.Attribute msg
+lg_tw_grid_cols_10 =
+    A.class "lg:tw-grid-cols-10"
+
+
+lg_tw_grid_cols_11 : Html.Attribute msg
+lg_tw_grid_cols_11 =
+    A.class "lg:tw-grid-cols-11"
+
+
+lg_tw_grid_cols_12 : Html.Attribute msg
+lg_tw_grid_cols_12 =
+    A.class "lg:tw-grid-cols-12"
+
+
+lg_tw_grid_cols_none : Html.Attribute msg
+lg_tw_grid_cols_none =
+    A.class "lg:tw-grid-cols-none"
+
+
+lg_tw_col_auto : Html.Attribute msg
+lg_tw_col_auto =
+    A.class "lg:tw-col-auto"
+
+
+lg_tw_col_span_1 : Html.Attribute msg
+lg_tw_col_span_1 =
+    A.class "lg:tw-col-span-1"
+
+
+lg_tw_col_span_2 : Html.Attribute msg
+lg_tw_col_span_2 =
+    A.class "lg:tw-col-span-2"
+
+
+lg_tw_col_span_3 : Html.Attribute msg
+lg_tw_col_span_3 =
+    A.class "lg:tw-col-span-3"
+
+
+lg_tw_col_span_4 : Html.Attribute msg
+lg_tw_col_span_4 =
+    A.class "lg:tw-col-span-4"
+
+
+lg_tw_col_span_5 : Html.Attribute msg
+lg_tw_col_span_5 =
+    A.class "lg:tw-col-span-5"
+
+
+lg_tw_col_span_6 : Html.Attribute msg
+lg_tw_col_span_6 =
+    A.class "lg:tw-col-span-6"
+
+
+lg_tw_col_span_7 : Html.Attribute msg
+lg_tw_col_span_7 =
+    A.class "lg:tw-col-span-7"
+
+
+lg_tw_col_span_8 : Html.Attribute msg
+lg_tw_col_span_8 =
+    A.class "lg:tw-col-span-8"
+
+
+lg_tw_col_span_9 : Html.Attribute msg
+lg_tw_col_span_9 =
+    A.class "lg:tw-col-span-9"
+
+
+lg_tw_col_span_10 : Html.Attribute msg
+lg_tw_col_span_10 =
+    A.class "lg:tw-col-span-10"
+
+
+lg_tw_col_span_11 : Html.Attribute msg
+lg_tw_col_span_11 =
+    A.class "lg:tw-col-span-11"
+
+
+lg_tw_col_span_12 : Html.Attribute msg
+lg_tw_col_span_12 =
+    A.class "lg:tw-col-span-12"
+
+
+lg_tw_col_start_1 : Html.Attribute msg
+lg_tw_col_start_1 =
+    A.class "lg:tw-col-start-1"
+
+
+lg_tw_col_start_2 : Html.Attribute msg
+lg_tw_col_start_2 =
+    A.class "lg:tw-col-start-2"
+
+
+lg_tw_col_start_3 : Html.Attribute msg
+lg_tw_col_start_3 =
+    A.class "lg:tw-col-start-3"
+
+
+lg_tw_col_start_4 : Html.Attribute msg
+lg_tw_col_start_4 =
+    A.class "lg:tw-col-start-4"
+
+
+lg_tw_col_start_5 : Html.Attribute msg
+lg_tw_col_start_5 =
+    A.class "lg:tw-col-start-5"
+
+
+lg_tw_col_start_6 : Html.Attribute msg
+lg_tw_col_start_6 =
+    A.class "lg:tw-col-start-6"
+
+
+lg_tw_col_start_7 : Html.Attribute msg
+lg_tw_col_start_7 =
+    A.class "lg:tw-col-start-7"
+
+
+lg_tw_col_start_8 : Html.Attribute msg
+lg_tw_col_start_8 =
+    A.class "lg:tw-col-start-8"
+
+
+lg_tw_col_start_9 : Html.Attribute msg
+lg_tw_col_start_9 =
+    A.class "lg:tw-col-start-9"
+
+
+lg_tw_col_start_10 : Html.Attribute msg
+lg_tw_col_start_10 =
+    A.class "lg:tw-col-start-10"
+
+
+lg_tw_col_start_11 : Html.Attribute msg
+lg_tw_col_start_11 =
+    A.class "lg:tw-col-start-11"
+
+
+lg_tw_col_start_12 : Html.Attribute msg
+lg_tw_col_start_12 =
+    A.class "lg:tw-col-start-12"
+
+
+lg_tw_col_start_13 : Html.Attribute msg
+lg_tw_col_start_13 =
+    A.class "lg:tw-col-start-13"
+
+
+lg_tw_col_start_auto : Html.Attribute msg
+lg_tw_col_start_auto =
+    A.class "lg:tw-col-start-auto"
+
+
+lg_tw_col_end_1 : Html.Attribute msg
+lg_tw_col_end_1 =
+    A.class "lg:tw-col-end-1"
+
+
+lg_tw_col_end_2 : Html.Attribute msg
+lg_tw_col_end_2 =
+    A.class "lg:tw-col-end-2"
+
+
+lg_tw_col_end_3 : Html.Attribute msg
+lg_tw_col_end_3 =
+    A.class "lg:tw-col-end-3"
+
+
+lg_tw_col_end_4 : Html.Attribute msg
+lg_tw_col_end_4 =
+    A.class "lg:tw-col-end-4"
+
+
+lg_tw_col_end_5 : Html.Attribute msg
+lg_tw_col_end_5 =
+    A.class "lg:tw-col-end-5"
+
+
+lg_tw_col_end_6 : Html.Attribute msg
+lg_tw_col_end_6 =
+    A.class "lg:tw-col-end-6"
+
+
+lg_tw_col_end_7 : Html.Attribute msg
+lg_tw_col_end_7 =
+    A.class "lg:tw-col-end-7"
+
+
+lg_tw_col_end_8 : Html.Attribute msg
+lg_tw_col_end_8 =
+    A.class "lg:tw-col-end-8"
+
+
+lg_tw_col_end_9 : Html.Attribute msg
+lg_tw_col_end_9 =
+    A.class "lg:tw-col-end-9"
+
+
+lg_tw_col_end_10 : Html.Attribute msg
+lg_tw_col_end_10 =
+    A.class "lg:tw-col-end-10"
+
+
+lg_tw_col_end_11 : Html.Attribute msg
+lg_tw_col_end_11 =
+    A.class "lg:tw-col-end-11"
+
+
+lg_tw_col_end_12 : Html.Attribute msg
+lg_tw_col_end_12 =
+    A.class "lg:tw-col-end-12"
+
+
+lg_tw_col_end_13 : Html.Attribute msg
+lg_tw_col_end_13 =
+    A.class "lg:tw-col-end-13"
+
+
+lg_tw_col_end_auto : Html.Attribute msg
+lg_tw_col_end_auto =
+    A.class "lg:tw-col-end-auto"
+
+
+lg_tw_grid_rows_1 : Html.Attribute msg
+lg_tw_grid_rows_1 =
+    A.class "lg:tw-grid-rows-1"
+
+
+lg_tw_grid_rows_2 : Html.Attribute msg
+lg_tw_grid_rows_2 =
+    A.class "lg:tw-grid-rows-2"
+
+
+lg_tw_grid_rows_3 : Html.Attribute msg
+lg_tw_grid_rows_3 =
+    A.class "lg:tw-grid-rows-3"
+
+
+lg_tw_grid_rows_4 : Html.Attribute msg
+lg_tw_grid_rows_4 =
+    A.class "lg:tw-grid-rows-4"
+
+
+lg_tw_grid_rows_5 : Html.Attribute msg
+lg_tw_grid_rows_5 =
+    A.class "lg:tw-grid-rows-5"
+
+
+lg_tw_grid_rows_6 : Html.Attribute msg
+lg_tw_grid_rows_6 =
+    A.class "lg:tw-grid-rows-6"
+
+
+lg_tw_grid_rows_none : Html.Attribute msg
+lg_tw_grid_rows_none =
+    A.class "lg:tw-grid-rows-none"
+
+
+lg_tw_row_auto : Html.Attribute msg
+lg_tw_row_auto =
+    A.class "lg:tw-row-auto"
+
+
+lg_tw_row_span_1 : Html.Attribute msg
+lg_tw_row_span_1 =
+    A.class "lg:tw-row-span-1"
+
+
+lg_tw_row_span_2 : Html.Attribute msg
+lg_tw_row_span_2 =
+    A.class "lg:tw-row-span-2"
+
+
+lg_tw_row_span_3 : Html.Attribute msg
+lg_tw_row_span_3 =
+    A.class "lg:tw-row-span-3"
+
+
+lg_tw_row_span_4 : Html.Attribute msg
+lg_tw_row_span_4 =
+    A.class "lg:tw-row-span-4"
+
+
+lg_tw_row_span_5 : Html.Attribute msg
+lg_tw_row_span_5 =
+    A.class "lg:tw-row-span-5"
+
+
+lg_tw_row_span_6 : Html.Attribute msg
+lg_tw_row_span_6 =
+    A.class "lg:tw-row-span-6"
+
+
+lg_tw_row_start_1 : Html.Attribute msg
+lg_tw_row_start_1 =
+    A.class "lg:tw-row-start-1"
+
+
+lg_tw_row_start_2 : Html.Attribute msg
+lg_tw_row_start_2 =
+    A.class "lg:tw-row-start-2"
+
+
+lg_tw_row_start_3 : Html.Attribute msg
+lg_tw_row_start_3 =
+    A.class "lg:tw-row-start-3"
+
+
+lg_tw_row_start_4 : Html.Attribute msg
+lg_tw_row_start_4 =
+    A.class "lg:tw-row-start-4"
+
+
+lg_tw_row_start_5 : Html.Attribute msg
+lg_tw_row_start_5 =
+    A.class "lg:tw-row-start-5"
+
+
+lg_tw_row_start_6 : Html.Attribute msg
+lg_tw_row_start_6 =
+    A.class "lg:tw-row-start-6"
+
+
+lg_tw_row_start_7 : Html.Attribute msg
+lg_tw_row_start_7 =
+    A.class "lg:tw-row-start-7"
+
+
+lg_tw_row_start_auto : Html.Attribute msg
+lg_tw_row_start_auto =
+    A.class "lg:tw-row-start-auto"
+
+
+lg_tw_row_end_1 : Html.Attribute msg
+lg_tw_row_end_1 =
+    A.class "lg:tw-row-end-1"
+
+
+lg_tw_row_end_2 : Html.Attribute msg
+lg_tw_row_end_2 =
+    A.class "lg:tw-row-end-2"
+
+
+lg_tw_row_end_3 : Html.Attribute msg
+lg_tw_row_end_3 =
+    A.class "lg:tw-row-end-3"
+
+
+lg_tw_row_end_4 : Html.Attribute msg
+lg_tw_row_end_4 =
+    A.class "lg:tw-row-end-4"
+
+
+lg_tw_row_end_5 : Html.Attribute msg
+lg_tw_row_end_5 =
+    A.class "lg:tw-row-end-5"
+
+
+lg_tw_row_end_6 : Html.Attribute msg
+lg_tw_row_end_6 =
+    A.class "lg:tw-row-end-6"
+
+
+lg_tw_row_end_7 : Html.Attribute msg
+lg_tw_row_end_7 =
+    A.class "lg:tw-row-end-7"
+
+
+lg_tw_row_end_auto : Html.Attribute msg
+lg_tw_row_end_auto =
+    A.class "lg:tw-row-end-auto"
+
+
+lg_tw_transform : Html.Attribute msg
+lg_tw_transform =
+    A.class "lg:tw-transform"
+
+
+lg_tw_transform_none : Html.Attribute msg
+lg_tw_transform_none =
+    A.class "lg:tw-transform-none"
+
+
+lg_tw_origin_center : Html.Attribute msg
+lg_tw_origin_center =
+    A.class "lg:tw-origin-center"
+
+
+lg_tw_origin_top : Html.Attribute msg
+lg_tw_origin_top =
+    A.class "lg:tw-origin-top"
+
+
+lg_tw_origin_top_right : Html.Attribute msg
+lg_tw_origin_top_right =
+    A.class "lg:tw-origin-top-right"
+
+
+lg_tw_origin_right : Html.Attribute msg
+lg_tw_origin_right =
+    A.class "lg:tw-origin-right"
+
+
+lg_tw_origin_bottom_right : Html.Attribute msg
+lg_tw_origin_bottom_right =
+    A.class "lg:tw-origin-bottom-right"
+
+
+lg_tw_origin_bottom : Html.Attribute msg
+lg_tw_origin_bottom =
+    A.class "lg:tw-origin-bottom"
+
+
+lg_tw_origin_bottom_left : Html.Attribute msg
+lg_tw_origin_bottom_left =
+    A.class "lg:tw-origin-bottom-left"
+
+
+lg_tw_origin_left : Html.Attribute msg
+lg_tw_origin_left =
+    A.class "lg:tw-origin-left"
+
+
+lg_tw_origin_top_left : Html.Attribute msg
+lg_tw_origin_top_left =
+    A.class "lg:tw-origin-top-left"
+
+
+lg_tw_scale_0 : Html.Attribute msg
+lg_tw_scale_0 =
+    A.class "lg:tw-scale-0"
+
+
+lg_tw_scale_50 : Html.Attribute msg
+lg_tw_scale_50 =
+    A.class "lg:tw-scale-50"
+
+
+lg_tw_scale_75 : Html.Attribute msg
+lg_tw_scale_75 =
+    A.class "lg:tw-scale-75"
+
+
+lg_tw_scale_90 : Html.Attribute msg
+lg_tw_scale_90 =
+    A.class "lg:tw-scale-90"
+
+
+lg_tw_scale_95 : Html.Attribute msg
+lg_tw_scale_95 =
+    A.class "lg:tw-scale-95"
+
+
+lg_tw_scale_100 : Html.Attribute msg
+lg_tw_scale_100 =
+    A.class "lg:tw-scale-100"
+
+
+lg_tw_scale_105 : Html.Attribute msg
+lg_tw_scale_105 =
+    A.class "lg:tw-scale-105"
+
+
+lg_tw_scale_110 : Html.Attribute msg
+lg_tw_scale_110 =
+    A.class "lg:tw-scale-110"
+
+
+lg_tw_scale_125 : Html.Attribute msg
+lg_tw_scale_125 =
+    A.class "lg:tw-scale-125"
+
+
+lg_tw_scale_150 : Html.Attribute msg
+lg_tw_scale_150 =
+    A.class "lg:tw-scale-150"
+
+
+lg_tw_scale_x_0 : Html.Attribute msg
+lg_tw_scale_x_0 =
+    A.class "lg:tw-scale-x-0"
+
+
+lg_tw_scale_x_50 : Html.Attribute msg
+lg_tw_scale_x_50 =
+    A.class "lg:tw-scale-x-50"
+
+
+lg_tw_scale_x_75 : Html.Attribute msg
+lg_tw_scale_x_75 =
+    A.class "lg:tw-scale-x-75"
+
+
+lg_tw_scale_x_90 : Html.Attribute msg
+lg_tw_scale_x_90 =
+    A.class "lg:tw-scale-x-90"
+
+
+lg_tw_scale_x_95 : Html.Attribute msg
+lg_tw_scale_x_95 =
+    A.class "lg:tw-scale-x-95"
+
+
+lg_tw_scale_x_100 : Html.Attribute msg
+lg_tw_scale_x_100 =
+    A.class "lg:tw-scale-x-100"
+
+
+lg_tw_scale_x_105 : Html.Attribute msg
+lg_tw_scale_x_105 =
+    A.class "lg:tw-scale-x-105"
+
+
+lg_tw_scale_x_110 : Html.Attribute msg
+lg_tw_scale_x_110 =
+    A.class "lg:tw-scale-x-110"
+
+
+lg_tw_scale_x_125 : Html.Attribute msg
+lg_tw_scale_x_125 =
+    A.class "lg:tw-scale-x-125"
+
+
+lg_tw_scale_x_150 : Html.Attribute msg
+lg_tw_scale_x_150 =
+    A.class "lg:tw-scale-x-150"
+
+
+lg_tw_scale_y_0 : Html.Attribute msg
+lg_tw_scale_y_0 =
+    A.class "lg:tw-scale-y-0"
+
+
+lg_tw_scale_y_50 : Html.Attribute msg
+lg_tw_scale_y_50 =
+    A.class "lg:tw-scale-y-50"
+
+
+lg_tw_scale_y_75 : Html.Attribute msg
+lg_tw_scale_y_75 =
+    A.class "lg:tw-scale-y-75"
+
+
+lg_tw_scale_y_90 : Html.Attribute msg
+lg_tw_scale_y_90 =
+    A.class "lg:tw-scale-y-90"
+
+
+lg_tw_scale_y_95 : Html.Attribute msg
+lg_tw_scale_y_95 =
+    A.class "lg:tw-scale-y-95"
+
+
+lg_tw_scale_y_100 : Html.Attribute msg
+lg_tw_scale_y_100 =
+    A.class "lg:tw-scale-y-100"
+
+
+lg_tw_scale_y_105 : Html.Attribute msg
+lg_tw_scale_y_105 =
+    A.class "lg:tw-scale-y-105"
+
+
+lg_tw_scale_y_110 : Html.Attribute msg
+lg_tw_scale_y_110 =
+    A.class "lg:tw-scale-y-110"
+
+
+lg_tw_scale_y_125 : Html.Attribute msg
+lg_tw_scale_y_125 =
+    A.class "lg:tw-scale-y-125"
+
+
+lg_tw_scale_y_150 : Html.Attribute msg
+lg_tw_scale_y_150 =
+    A.class "lg:tw-scale-y-150"
+
+
+lg_hover_tw_scale_0 : Html.Attribute msg
+lg_hover_tw_scale_0 =
+    A.class "lg:hover:tw-scale-0"
+
+
+lg_hover_tw_scale_50 : Html.Attribute msg
+lg_hover_tw_scale_50 =
+    A.class "lg:hover:tw-scale-50"
+
+
+lg_hover_tw_scale_75 : Html.Attribute msg
+lg_hover_tw_scale_75 =
+    A.class "lg:hover:tw-scale-75"
+
+
+lg_hover_tw_scale_90 : Html.Attribute msg
+lg_hover_tw_scale_90 =
+    A.class "lg:hover:tw-scale-90"
+
+
+lg_hover_tw_scale_95 : Html.Attribute msg
+lg_hover_tw_scale_95 =
+    A.class "lg:hover:tw-scale-95"
+
+
+lg_hover_tw_scale_100 : Html.Attribute msg
+lg_hover_tw_scale_100 =
+    A.class "lg:hover:tw-scale-100"
+
+
+lg_hover_tw_scale_105 : Html.Attribute msg
+lg_hover_tw_scale_105 =
+    A.class "lg:hover:tw-scale-105"
+
+
+lg_hover_tw_scale_110 : Html.Attribute msg
+lg_hover_tw_scale_110 =
+    A.class "lg:hover:tw-scale-110"
+
+
+lg_hover_tw_scale_125 : Html.Attribute msg
+lg_hover_tw_scale_125 =
+    A.class "lg:hover:tw-scale-125"
+
+
+lg_hover_tw_scale_150 : Html.Attribute msg
+lg_hover_tw_scale_150 =
+    A.class "lg:hover:tw-scale-150"
+
+
+lg_hover_tw_scale_x_0 : Html.Attribute msg
+lg_hover_tw_scale_x_0 =
+    A.class "lg:hover:tw-scale-x-0"
+
+
+lg_hover_tw_scale_x_50 : Html.Attribute msg
+lg_hover_tw_scale_x_50 =
+    A.class "lg:hover:tw-scale-x-50"
+
+
+lg_hover_tw_scale_x_75 : Html.Attribute msg
+lg_hover_tw_scale_x_75 =
+    A.class "lg:hover:tw-scale-x-75"
+
+
+lg_hover_tw_scale_x_90 : Html.Attribute msg
+lg_hover_tw_scale_x_90 =
+    A.class "lg:hover:tw-scale-x-90"
+
+
+lg_hover_tw_scale_x_95 : Html.Attribute msg
+lg_hover_tw_scale_x_95 =
+    A.class "lg:hover:tw-scale-x-95"
+
+
+lg_hover_tw_scale_x_100 : Html.Attribute msg
+lg_hover_tw_scale_x_100 =
+    A.class "lg:hover:tw-scale-x-100"
+
+
+lg_hover_tw_scale_x_105 : Html.Attribute msg
+lg_hover_tw_scale_x_105 =
+    A.class "lg:hover:tw-scale-x-105"
+
+
+lg_hover_tw_scale_x_110 : Html.Attribute msg
+lg_hover_tw_scale_x_110 =
+    A.class "lg:hover:tw-scale-x-110"
+
+
+lg_hover_tw_scale_x_125 : Html.Attribute msg
+lg_hover_tw_scale_x_125 =
+    A.class "lg:hover:tw-scale-x-125"
+
+
+lg_hover_tw_scale_x_150 : Html.Attribute msg
+lg_hover_tw_scale_x_150 =
+    A.class "lg:hover:tw-scale-x-150"
+
+
+lg_hover_tw_scale_y_0 : Html.Attribute msg
+lg_hover_tw_scale_y_0 =
+    A.class "lg:hover:tw-scale-y-0"
+
+
+lg_hover_tw_scale_y_50 : Html.Attribute msg
+lg_hover_tw_scale_y_50 =
+    A.class "lg:hover:tw-scale-y-50"
+
+
+lg_hover_tw_scale_y_75 : Html.Attribute msg
+lg_hover_tw_scale_y_75 =
+    A.class "lg:hover:tw-scale-y-75"
+
+
+lg_hover_tw_scale_y_90 : Html.Attribute msg
+lg_hover_tw_scale_y_90 =
+    A.class "lg:hover:tw-scale-y-90"
+
+
+lg_hover_tw_scale_y_95 : Html.Attribute msg
+lg_hover_tw_scale_y_95 =
+    A.class "lg:hover:tw-scale-y-95"
+
+
+lg_hover_tw_scale_y_100 : Html.Attribute msg
+lg_hover_tw_scale_y_100 =
+    A.class "lg:hover:tw-scale-y-100"
+
+
+lg_hover_tw_scale_y_105 : Html.Attribute msg
+lg_hover_tw_scale_y_105 =
+    A.class "lg:hover:tw-scale-y-105"
+
+
+lg_hover_tw_scale_y_110 : Html.Attribute msg
+lg_hover_tw_scale_y_110 =
+    A.class "lg:hover:tw-scale-y-110"
+
+
+lg_hover_tw_scale_y_125 : Html.Attribute msg
+lg_hover_tw_scale_y_125 =
+    A.class "lg:hover:tw-scale-y-125"
+
+
+lg_hover_tw_scale_y_150 : Html.Attribute msg
+lg_hover_tw_scale_y_150 =
+    A.class "lg:hover:tw-scale-y-150"
+
+
+lg_focus_tw_scale_0 : Html.Attribute msg
+lg_focus_tw_scale_0 =
+    A.class "lg:focus:tw-scale-0"
+
+
+lg_focus_tw_scale_50 : Html.Attribute msg
+lg_focus_tw_scale_50 =
+    A.class "lg:focus:tw-scale-50"
+
+
+lg_focus_tw_scale_75 : Html.Attribute msg
+lg_focus_tw_scale_75 =
+    A.class "lg:focus:tw-scale-75"
+
+
+lg_focus_tw_scale_90 : Html.Attribute msg
+lg_focus_tw_scale_90 =
+    A.class "lg:focus:tw-scale-90"
+
+
+lg_focus_tw_scale_95 : Html.Attribute msg
+lg_focus_tw_scale_95 =
+    A.class "lg:focus:tw-scale-95"
+
+
+lg_focus_tw_scale_100 : Html.Attribute msg
+lg_focus_tw_scale_100 =
+    A.class "lg:focus:tw-scale-100"
+
+
+lg_focus_tw_scale_105 : Html.Attribute msg
+lg_focus_tw_scale_105 =
+    A.class "lg:focus:tw-scale-105"
+
+
+lg_focus_tw_scale_110 : Html.Attribute msg
+lg_focus_tw_scale_110 =
+    A.class "lg:focus:tw-scale-110"
+
+
+lg_focus_tw_scale_125 : Html.Attribute msg
+lg_focus_tw_scale_125 =
+    A.class "lg:focus:tw-scale-125"
+
+
+lg_focus_tw_scale_150 : Html.Attribute msg
+lg_focus_tw_scale_150 =
+    A.class "lg:focus:tw-scale-150"
+
+
+lg_focus_tw_scale_x_0 : Html.Attribute msg
+lg_focus_tw_scale_x_0 =
+    A.class "lg:focus:tw-scale-x-0"
+
+
+lg_focus_tw_scale_x_50 : Html.Attribute msg
+lg_focus_tw_scale_x_50 =
+    A.class "lg:focus:tw-scale-x-50"
+
+
+lg_focus_tw_scale_x_75 : Html.Attribute msg
+lg_focus_tw_scale_x_75 =
+    A.class "lg:focus:tw-scale-x-75"
+
+
+lg_focus_tw_scale_x_90 : Html.Attribute msg
+lg_focus_tw_scale_x_90 =
+    A.class "lg:focus:tw-scale-x-90"
+
+
+lg_focus_tw_scale_x_95 : Html.Attribute msg
+lg_focus_tw_scale_x_95 =
+    A.class "lg:focus:tw-scale-x-95"
+
+
+lg_focus_tw_scale_x_100 : Html.Attribute msg
+lg_focus_tw_scale_x_100 =
+    A.class "lg:focus:tw-scale-x-100"
+
+
+lg_focus_tw_scale_x_105 : Html.Attribute msg
+lg_focus_tw_scale_x_105 =
+    A.class "lg:focus:tw-scale-x-105"
+
+
+lg_focus_tw_scale_x_110 : Html.Attribute msg
+lg_focus_tw_scale_x_110 =
+    A.class "lg:focus:tw-scale-x-110"
+
+
+lg_focus_tw_scale_x_125 : Html.Attribute msg
+lg_focus_tw_scale_x_125 =
+    A.class "lg:focus:tw-scale-x-125"
+
+
+lg_focus_tw_scale_x_150 : Html.Attribute msg
+lg_focus_tw_scale_x_150 =
+    A.class "lg:focus:tw-scale-x-150"
+
+
+lg_focus_tw_scale_y_0 : Html.Attribute msg
+lg_focus_tw_scale_y_0 =
+    A.class "lg:focus:tw-scale-y-0"
+
+
+lg_focus_tw_scale_y_50 : Html.Attribute msg
+lg_focus_tw_scale_y_50 =
+    A.class "lg:focus:tw-scale-y-50"
+
+
+lg_focus_tw_scale_y_75 : Html.Attribute msg
+lg_focus_tw_scale_y_75 =
+    A.class "lg:focus:tw-scale-y-75"
+
+
+lg_focus_tw_scale_y_90 : Html.Attribute msg
+lg_focus_tw_scale_y_90 =
+    A.class "lg:focus:tw-scale-y-90"
+
+
+lg_focus_tw_scale_y_95 : Html.Attribute msg
+lg_focus_tw_scale_y_95 =
+    A.class "lg:focus:tw-scale-y-95"
+
+
+lg_focus_tw_scale_y_100 : Html.Attribute msg
+lg_focus_tw_scale_y_100 =
+    A.class "lg:focus:tw-scale-y-100"
+
+
+lg_focus_tw_scale_y_105 : Html.Attribute msg
+lg_focus_tw_scale_y_105 =
+    A.class "lg:focus:tw-scale-y-105"
+
+
+lg_focus_tw_scale_y_110 : Html.Attribute msg
+lg_focus_tw_scale_y_110 =
+    A.class "lg:focus:tw-scale-y-110"
+
+
+lg_focus_tw_scale_y_125 : Html.Attribute msg
+lg_focus_tw_scale_y_125 =
+    A.class "lg:focus:tw-scale-y-125"
+
+
+lg_focus_tw_scale_y_150 : Html.Attribute msg
+lg_focus_tw_scale_y_150 =
+    A.class "lg:focus:tw-scale-y-150"
+
+
+lg_tw_rotate_0 : Html.Attribute msg
+lg_tw_rotate_0 =
+    A.class "lg:tw-rotate-0"
+
+
+lg_tw_rotate_45 : Html.Attribute msg
+lg_tw_rotate_45 =
+    A.class "lg:tw-rotate-45"
+
+
+lg_tw_rotate_90 : Html.Attribute msg
+lg_tw_rotate_90 =
+    A.class "lg:tw-rotate-90"
+
+
+lg_tw_rotate_180 : Html.Attribute msg
+lg_tw_rotate_180 =
+    A.class "lg:tw-rotate-180"
+
+
+lg_tw_neg_rotate_180 : Html.Attribute msg
+lg_tw_neg_rotate_180 =
+    A.class "lg:tw--rotate-180"
+
+
+lg_tw_neg_rotate_90 : Html.Attribute msg
+lg_tw_neg_rotate_90 =
+    A.class "lg:tw--rotate-90"
+
+
+lg_tw_neg_rotate_45 : Html.Attribute msg
+lg_tw_neg_rotate_45 =
+    A.class "lg:tw--rotate-45"
+
+
+lg_hover_tw_rotate_0 : Html.Attribute msg
+lg_hover_tw_rotate_0 =
+    A.class "lg:hover:tw-rotate-0"
+
+
+lg_hover_tw_rotate_45 : Html.Attribute msg
+lg_hover_tw_rotate_45 =
+    A.class "lg:hover:tw-rotate-45"
+
+
+lg_hover_tw_rotate_90 : Html.Attribute msg
+lg_hover_tw_rotate_90 =
+    A.class "lg:hover:tw-rotate-90"
+
+
+lg_hover_tw_rotate_180 : Html.Attribute msg
+lg_hover_tw_rotate_180 =
+    A.class "lg:hover:tw-rotate-180"
+
+
+lg_hover_tw_neg_rotate_180 : Html.Attribute msg
+lg_hover_tw_neg_rotate_180 =
+    A.class "lg:hover:tw--rotate-180"
+
+
+lg_hover_tw_neg_rotate_90 : Html.Attribute msg
+lg_hover_tw_neg_rotate_90 =
+    A.class "lg:hover:tw--rotate-90"
+
+
+lg_hover_tw_neg_rotate_45 : Html.Attribute msg
+lg_hover_tw_neg_rotate_45 =
+    A.class "lg:hover:tw--rotate-45"
+
+
+lg_focus_tw_rotate_0 : Html.Attribute msg
+lg_focus_tw_rotate_0 =
+    A.class "lg:focus:tw-rotate-0"
+
+
+lg_focus_tw_rotate_45 : Html.Attribute msg
+lg_focus_tw_rotate_45 =
+    A.class "lg:focus:tw-rotate-45"
+
+
+lg_focus_tw_rotate_90 : Html.Attribute msg
+lg_focus_tw_rotate_90 =
+    A.class "lg:focus:tw-rotate-90"
+
+
+lg_focus_tw_rotate_180 : Html.Attribute msg
+lg_focus_tw_rotate_180 =
+    A.class "lg:focus:tw-rotate-180"
+
+
+lg_focus_tw_neg_rotate_180 : Html.Attribute msg
+lg_focus_tw_neg_rotate_180 =
+    A.class "lg:focus:tw--rotate-180"
+
+
+lg_focus_tw_neg_rotate_90 : Html.Attribute msg
+lg_focus_tw_neg_rotate_90 =
+    A.class "lg:focus:tw--rotate-90"
+
+
+lg_focus_tw_neg_rotate_45 : Html.Attribute msg
+lg_focus_tw_neg_rotate_45 =
+    A.class "lg:focus:tw--rotate-45"
+
+
+lg_tw_translate_x_0 : Html.Attribute msg
+lg_tw_translate_x_0 =
+    A.class "lg:tw-translate-x-0"
+
+
+lg_tw_translate_x_1 : Html.Attribute msg
+lg_tw_translate_x_1 =
+    A.class "lg:tw-translate-x-1"
+
+
+lg_tw_translate_x_2 : Html.Attribute msg
+lg_tw_translate_x_2 =
+    A.class "lg:tw-translate-x-2"
+
+
+lg_tw_translate_x_3 : Html.Attribute msg
+lg_tw_translate_x_3 =
+    A.class "lg:tw-translate-x-3"
+
+
+lg_tw_translate_x_4 : Html.Attribute msg
+lg_tw_translate_x_4 =
+    A.class "lg:tw-translate-x-4"
+
+
+lg_tw_translate_x_5 : Html.Attribute msg
+lg_tw_translate_x_5 =
+    A.class "lg:tw-translate-x-5"
+
+
+lg_tw_translate_x_6 : Html.Attribute msg
+lg_tw_translate_x_6 =
+    A.class "lg:tw-translate-x-6"
+
+
+lg_tw_translate_x_8 : Html.Attribute msg
+lg_tw_translate_x_8 =
+    A.class "lg:tw-translate-x-8"
+
+
+lg_tw_translate_x_10 : Html.Attribute msg
+lg_tw_translate_x_10 =
+    A.class "lg:tw-translate-x-10"
+
+
+lg_tw_translate_x_12 : Html.Attribute msg
+lg_tw_translate_x_12 =
+    A.class "lg:tw-translate-x-12"
+
+
+lg_tw_translate_x_16 : Html.Attribute msg
+lg_tw_translate_x_16 =
+    A.class "lg:tw-translate-x-16"
+
+
+lg_tw_translate_x_20 : Html.Attribute msg
+lg_tw_translate_x_20 =
+    A.class "lg:tw-translate-x-20"
+
+
+lg_tw_translate_x_24 : Html.Attribute msg
+lg_tw_translate_x_24 =
+    A.class "lg:tw-translate-x-24"
+
+
+lg_tw_translate_x_32 : Html.Attribute msg
+lg_tw_translate_x_32 =
+    A.class "lg:tw-translate-x-32"
+
+
+lg_tw_translate_x_40 : Html.Attribute msg
+lg_tw_translate_x_40 =
+    A.class "lg:tw-translate-x-40"
+
+
+lg_tw_translate_x_48 : Html.Attribute msg
+lg_tw_translate_x_48 =
+    A.class "lg:tw-translate-x-48"
+
+
+lg_tw_translate_x_56 : Html.Attribute msg
+lg_tw_translate_x_56 =
+    A.class "lg:tw-translate-x-56"
+
+
+lg_tw_translate_x_64 : Html.Attribute msg
+lg_tw_translate_x_64 =
+    A.class "lg:tw-translate-x-64"
+
+
+lg_tw_translate_x_px : Html.Attribute msg
+lg_tw_translate_x_px =
+    A.class "lg:tw-translate-x-px"
+
+
+lg_tw_neg_translate_x_1 : Html.Attribute msg
+lg_tw_neg_translate_x_1 =
+    A.class "lg:tw--translate-x-1"
+
+
+lg_tw_neg_translate_x_2 : Html.Attribute msg
+lg_tw_neg_translate_x_2 =
+    A.class "lg:tw--translate-x-2"
+
+
+lg_tw_neg_translate_x_3 : Html.Attribute msg
+lg_tw_neg_translate_x_3 =
+    A.class "lg:tw--translate-x-3"
+
+
+lg_tw_neg_translate_x_4 : Html.Attribute msg
+lg_tw_neg_translate_x_4 =
+    A.class "lg:tw--translate-x-4"
+
+
+lg_tw_neg_translate_x_5 : Html.Attribute msg
+lg_tw_neg_translate_x_5 =
+    A.class "lg:tw--translate-x-5"
+
+
+lg_tw_neg_translate_x_6 : Html.Attribute msg
+lg_tw_neg_translate_x_6 =
+    A.class "lg:tw--translate-x-6"
+
+
+lg_tw_neg_translate_x_8 : Html.Attribute msg
+lg_tw_neg_translate_x_8 =
+    A.class "lg:tw--translate-x-8"
+
+
+lg_tw_neg_translate_x_10 : Html.Attribute msg
+lg_tw_neg_translate_x_10 =
+    A.class "lg:tw--translate-x-10"
+
+
+lg_tw_neg_translate_x_12 : Html.Attribute msg
+lg_tw_neg_translate_x_12 =
+    A.class "lg:tw--translate-x-12"
+
+
+lg_tw_neg_translate_x_16 : Html.Attribute msg
+lg_tw_neg_translate_x_16 =
+    A.class "lg:tw--translate-x-16"
+
+
+lg_tw_neg_translate_x_20 : Html.Attribute msg
+lg_tw_neg_translate_x_20 =
+    A.class "lg:tw--translate-x-20"
+
+
+lg_tw_neg_translate_x_24 : Html.Attribute msg
+lg_tw_neg_translate_x_24 =
+    A.class "lg:tw--translate-x-24"
+
+
+lg_tw_neg_translate_x_32 : Html.Attribute msg
+lg_tw_neg_translate_x_32 =
+    A.class "lg:tw--translate-x-32"
+
+
+lg_tw_neg_translate_x_40 : Html.Attribute msg
+lg_tw_neg_translate_x_40 =
+    A.class "lg:tw--translate-x-40"
+
+
+lg_tw_neg_translate_x_48 : Html.Attribute msg
+lg_tw_neg_translate_x_48 =
+    A.class "lg:tw--translate-x-48"
+
+
+lg_tw_neg_translate_x_56 : Html.Attribute msg
+lg_tw_neg_translate_x_56 =
+    A.class "lg:tw--translate-x-56"
+
+
+lg_tw_neg_translate_x_64 : Html.Attribute msg
+lg_tw_neg_translate_x_64 =
+    A.class "lg:tw--translate-x-64"
+
+
+lg_tw_neg_translate_x_px : Html.Attribute msg
+lg_tw_neg_translate_x_px =
+    A.class "lg:tw--translate-x-px"
+
+
+lg_tw_neg_translate_x_full : Html.Attribute msg
+lg_tw_neg_translate_x_full =
+    A.class "lg:tw--translate-x-full"
+
+
+lg_tw_neg_translate_x_1over2 : Html.Attribute msg
+lg_tw_neg_translate_x_1over2 =
+    A.class "lg:tw--translate-x-1/2"
+
+
+lg_tw_translate_x_1over2 : Html.Attribute msg
+lg_tw_translate_x_1over2 =
+    A.class "lg:tw-translate-x-1/2"
+
+
+lg_tw_translate_x_full : Html.Attribute msg
+lg_tw_translate_x_full =
+    A.class "lg:tw-translate-x-full"
+
+
+lg_tw_translate_y_0 : Html.Attribute msg
+lg_tw_translate_y_0 =
+    A.class "lg:tw-translate-y-0"
+
+
+lg_tw_translate_y_1 : Html.Attribute msg
+lg_tw_translate_y_1 =
+    A.class "lg:tw-translate-y-1"
+
+
+lg_tw_translate_y_2 : Html.Attribute msg
+lg_tw_translate_y_2 =
+    A.class "lg:tw-translate-y-2"
+
+
+lg_tw_translate_y_3 : Html.Attribute msg
+lg_tw_translate_y_3 =
+    A.class "lg:tw-translate-y-3"
+
+
+lg_tw_translate_y_4 : Html.Attribute msg
+lg_tw_translate_y_4 =
+    A.class "lg:tw-translate-y-4"
+
+
+lg_tw_translate_y_5 : Html.Attribute msg
+lg_tw_translate_y_5 =
+    A.class "lg:tw-translate-y-5"
+
+
+lg_tw_translate_y_6 : Html.Attribute msg
+lg_tw_translate_y_6 =
+    A.class "lg:tw-translate-y-6"
+
+
+lg_tw_translate_y_8 : Html.Attribute msg
+lg_tw_translate_y_8 =
+    A.class "lg:tw-translate-y-8"
+
+
+lg_tw_translate_y_10 : Html.Attribute msg
+lg_tw_translate_y_10 =
+    A.class "lg:tw-translate-y-10"
+
+
+lg_tw_translate_y_12 : Html.Attribute msg
+lg_tw_translate_y_12 =
+    A.class "lg:tw-translate-y-12"
+
+
+lg_tw_translate_y_16 : Html.Attribute msg
+lg_tw_translate_y_16 =
+    A.class "lg:tw-translate-y-16"
+
+
+lg_tw_translate_y_20 : Html.Attribute msg
+lg_tw_translate_y_20 =
+    A.class "lg:tw-translate-y-20"
+
+
+lg_tw_translate_y_24 : Html.Attribute msg
+lg_tw_translate_y_24 =
+    A.class "lg:tw-translate-y-24"
+
+
+lg_tw_translate_y_32 : Html.Attribute msg
+lg_tw_translate_y_32 =
+    A.class "lg:tw-translate-y-32"
+
+
+lg_tw_translate_y_40 : Html.Attribute msg
+lg_tw_translate_y_40 =
+    A.class "lg:tw-translate-y-40"
+
+
+lg_tw_translate_y_48 : Html.Attribute msg
+lg_tw_translate_y_48 =
+    A.class "lg:tw-translate-y-48"
+
+
+lg_tw_translate_y_56 : Html.Attribute msg
+lg_tw_translate_y_56 =
+    A.class "lg:tw-translate-y-56"
+
+
+lg_tw_translate_y_64 : Html.Attribute msg
+lg_tw_translate_y_64 =
+    A.class "lg:tw-translate-y-64"
+
+
+lg_tw_translate_y_px : Html.Attribute msg
+lg_tw_translate_y_px =
+    A.class "lg:tw-translate-y-px"
+
+
+lg_tw_neg_translate_y_1 : Html.Attribute msg
+lg_tw_neg_translate_y_1 =
+    A.class "lg:tw--translate-y-1"
+
+
+lg_tw_neg_translate_y_2 : Html.Attribute msg
+lg_tw_neg_translate_y_2 =
+    A.class "lg:tw--translate-y-2"
+
+
+lg_tw_neg_translate_y_3 : Html.Attribute msg
+lg_tw_neg_translate_y_3 =
+    A.class "lg:tw--translate-y-3"
+
+
+lg_tw_neg_translate_y_4 : Html.Attribute msg
+lg_tw_neg_translate_y_4 =
+    A.class "lg:tw--translate-y-4"
+
+
+lg_tw_neg_translate_y_5 : Html.Attribute msg
+lg_tw_neg_translate_y_5 =
+    A.class "lg:tw--translate-y-5"
+
+
+lg_tw_neg_translate_y_6 : Html.Attribute msg
+lg_tw_neg_translate_y_6 =
+    A.class "lg:tw--translate-y-6"
+
+
+lg_tw_neg_translate_y_8 : Html.Attribute msg
+lg_tw_neg_translate_y_8 =
+    A.class "lg:tw--translate-y-8"
+
+
+lg_tw_neg_translate_y_10 : Html.Attribute msg
+lg_tw_neg_translate_y_10 =
+    A.class "lg:tw--translate-y-10"
+
+
+lg_tw_neg_translate_y_12 : Html.Attribute msg
+lg_tw_neg_translate_y_12 =
+    A.class "lg:tw--translate-y-12"
+
+
+lg_tw_neg_translate_y_16 : Html.Attribute msg
+lg_tw_neg_translate_y_16 =
+    A.class "lg:tw--translate-y-16"
+
+
+lg_tw_neg_translate_y_20 : Html.Attribute msg
+lg_tw_neg_translate_y_20 =
+    A.class "lg:tw--translate-y-20"
+
+
+lg_tw_neg_translate_y_24 : Html.Attribute msg
+lg_tw_neg_translate_y_24 =
+    A.class "lg:tw--translate-y-24"
+
+
+lg_tw_neg_translate_y_32 : Html.Attribute msg
+lg_tw_neg_translate_y_32 =
+    A.class "lg:tw--translate-y-32"
+
+
+lg_tw_neg_translate_y_40 : Html.Attribute msg
+lg_tw_neg_translate_y_40 =
+    A.class "lg:tw--translate-y-40"
+
+
+lg_tw_neg_translate_y_48 : Html.Attribute msg
+lg_tw_neg_translate_y_48 =
+    A.class "lg:tw--translate-y-48"
+
+
+lg_tw_neg_translate_y_56 : Html.Attribute msg
+lg_tw_neg_translate_y_56 =
+    A.class "lg:tw--translate-y-56"
+
+
+lg_tw_neg_translate_y_64 : Html.Attribute msg
+lg_tw_neg_translate_y_64 =
+    A.class "lg:tw--translate-y-64"
+
+
+lg_tw_neg_translate_y_px : Html.Attribute msg
+lg_tw_neg_translate_y_px =
+    A.class "lg:tw--translate-y-px"
+
+
+lg_tw_neg_translate_y_full : Html.Attribute msg
+lg_tw_neg_translate_y_full =
+    A.class "lg:tw--translate-y-full"
+
+
+lg_tw_neg_translate_y_1over2 : Html.Attribute msg
+lg_tw_neg_translate_y_1over2 =
+    A.class "lg:tw--translate-y-1/2"
+
+
+lg_tw_translate_y_1over2 : Html.Attribute msg
+lg_tw_translate_y_1over2 =
+    A.class "lg:tw-translate-y-1/2"
+
+
+lg_tw_translate_y_full : Html.Attribute msg
+lg_tw_translate_y_full =
+    A.class "lg:tw-translate-y-full"
+
+
+lg_hover_tw_translate_x_0 : Html.Attribute msg
+lg_hover_tw_translate_x_0 =
+    A.class "lg:hover:tw-translate-x-0"
+
+
+lg_hover_tw_translate_x_1 : Html.Attribute msg
+lg_hover_tw_translate_x_1 =
+    A.class "lg:hover:tw-translate-x-1"
+
+
+lg_hover_tw_translate_x_2 : Html.Attribute msg
+lg_hover_tw_translate_x_2 =
+    A.class "lg:hover:tw-translate-x-2"
+
+
+lg_hover_tw_translate_x_3 : Html.Attribute msg
+lg_hover_tw_translate_x_3 =
+    A.class "lg:hover:tw-translate-x-3"
+
+
+lg_hover_tw_translate_x_4 : Html.Attribute msg
+lg_hover_tw_translate_x_4 =
+    A.class "lg:hover:tw-translate-x-4"
+
+
+lg_hover_tw_translate_x_5 : Html.Attribute msg
+lg_hover_tw_translate_x_5 =
+    A.class "lg:hover:tw-translate-x-5"
+
+
+lg_hover_tw_translate_x_6 : Html.Attribute msg
+lg_hover_tw_translate_x_6 =
+    A.class "lg:hover:tw-translate-x-6"
+
+
+lg_hover_tw_translate_x_8 : Html.Attribute msg
+lg_hover_tw_translate_x_8 =
+    A.class "lg:hover:tw-translate-x-8"
+
+
+lg_hover_tw_translate_x_10 : Html.Attribute msg
+lg_hover_tw_translate_x_10 =
+    A.class "lg:hover:tw-translate-x-10"
+
+
+lg_hover_tw_translate_x_12 : Html.Attribute msg
+lg_hover_tw_translate_x_12 =
+    A.class "lg:hover:tw-translate-x-12"
+
+
+lg_hover_tw_translate_x_16 : Html.Attribute msg
+lg_hover_tw_translate_x_16 =
+    A.class "lg:hover:tw-translate-x-16"
+
+
+lg_hover_tw_translate_x_20 : Html.Attribute msg
+lg_hover_tw_translate_x_20 =
+    A.class "lg:hover:tw-translate-x-20"
+
+
+lg_hover_tw_translate_x_24 : Html.Attribute msg
+lg_hover_tw_translate_x_24 =
+    A.class "lg:hover:tw-translate-x-24"
+
+
+lg_hover_tw_translate_x_32 : Html.Attribute msg
+lg_hover_tw_translate_x_32 =
+    A.class "lg:hover:tw-translate-x-32"
+
+
+lg_hover_tw_translate_x_40 : Html.Attribute msg
+lg_hover_tw_translate_x_40 =
+    A.class "lg:hover:tw-translate-x-40"
+
+
+lg_hover_tw_translate_x_48 : Html.Attribute msg
+lg_hover_tw_translate_x_48 =
+    A.class "lg:hover:tw-translate-x-48"
+
+
+lg_hover_tw_translate_x_56 : Html.Attribute msg
+lg_hover_tw_translate_x_56 =
+    A.class "lg:hover:tw-translate-x-56"
+
+
+lg_hover_tw_translate_x_64 : Html.Attribute msg
+lg_hover_tw_translate_x_64 =
+    A.class "lg:hover:tw-translate-x-64"
+
+
+lg_hover_tw_translate_x_px : Html.Attribute msg
+lg_hover_tw_translate_x_px =
+    A.class "lg:hover:tw-translate-x-px"
+
+
+lg_hover_tw_neg_translate_x_1 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_1 =
+    A.class "lg:hover:tw--translate-x-1"
+
+
+lg_hover_tw_neg_translate_x_2 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_2 =
+    A.class "lg:hover:tw--translate-x-2"
+
+
+lg_hover_tw_neg_translate_x_3 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_3 =
+    A.class "lg:hover:tw--translate-x-3"
+
+
+lg_hover_tw_neg_translate_x_4 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_4 =
+    A.class "lg:hover:tw--translate-x-4"
+
+
+lg_hover_tw_neg_translate_x_5 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_5 =
+    A.class "lg:hover:tw--translate-x-5"
+
+
+lg_hover_tw_neg_translate_x_6 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_6 =
+    A.class "lg:hover:tw--translate-x-6"
+
+
+lg_hover_tw_neg_translate_x_8 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_8 =
+    A.class "lg:hover:tw--translate-x-8"
+
+
+lg_hover_tw_neg_translate_x_10 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_10 =
+    A.class "lg:hover:tw--translate-x-10"
+
+
+lg_hover_tw_neg_translate_x_12 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_12 =
+    A.class "lg:hover:tw--translate-x-12"
+
+
+lg_hover_tw_neg_translate_x_16 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_16 =
+    A.class "lg:hover:tw--translate-x-16"
+
+
+lg_hover_tw_neg_translate_x_20 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_20 =
+    A.class "lg:hover:tw--translate-x-20"
+
+
+lg_hover_tw_neg_translate_x_24 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_24 =
+    A.class "lg:hover:tw--translate-x-24"
+
+
+lg_hover_tw_neg_translate_x_32 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_32 =
+    A.class "lg:hover:tw--translate-x-32"
+
+
+lg_hover_tw_neg_translate_x_40 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_40 =
+    A.class "lg:hover:tw--translate-x-40"
+
+
+lg_hover_tw_neg_translate_x_48 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_48 =
+    A.class "lg:hover:tw--translate-x-48"
+
+
+lg_hover_tw_neg_translate_x_56 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_56 =
+    A.class "lg:hover:tw--translate-x-56"
+
+
+lg_hover_tw_neg_translate_x_64 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_64 =
+    A.class "lg:hover:tw--translate-x-64"
+
+
+lg_hover_tw_neg_translate_x_px : Html.Attribute msg
+lg_hover_tw_neg_translate_x_px =
+    A.class "lg:hover:tw--translate-x-px"
+
+
+lg_hover_tw_neg_translate_x_full : Html.Attribute msg
+lg_hover_tw_neg_translate_x_full =
+    A.class "lg:hover:tw--translate-x-full"
+
+
+lg_hover_tw_neg_translate_x_1over2 : Html.Attribute msg
+lg_hover_tw_neg_translate_x_1over2 =
+    A.class "lg:hover:tw--translate-x-1/2"
+
+
+lg_hover_tw_translate_x_1over2 : Html.Attribute msg
+lg_hover_tw_translate_x_1over2 =
+    A.class "lg:hover:tw-translate-x-1/2"
+
+
+lg_hover_tw_translate_x_full : Html.Attribute msg
+lg_hover_tw_translate_x_full =
+    A.class "lg:hover:tw-translate-x-full"
+
+
+lg_hover_tw_translate_y_0 : Html.Attribute msg
+lg_hover_tw_translate_y_0 =
+    A.class "lg:hover:tw-translate-y-0"
+
+
+lg_hover_tw_translate_y_1 : Html.Attribute msg
+lg_hover_tw_translate_y_1 =
+    A.class "lg:hover:tw-translate-y-1"
+
+
+lg_hover_tw_translate_y_2 : Html.Attribute msg
+lg_hover_tw_translate_y_2 =
+    A.class "lg:hover:tw-translate-y-2"
+
+
+lg_hover_tw_translate_y_3 : Html.Attribute msg
+lg_hover_tw_translate_y_3 =
+    A.class "lg:hover:tw-translate-y-3"
+
+
+lg_hover_tw_translate_y_4 : Html.Attribute msg
+lg_hover_tw_translate_y_4 =
+    A.class "lg:hover:tw-translate-y-4"
+
+
+lg_hover_tw_translate_y_5 : Html.Attribute msg
+lg_hover_tw_translate_y_5 =
+    A.class "lg:hover:tw-translate-y-5"
+
+
+lg_hover_tw_translate_y_6 : Html.Attribute msg
+lg_hover_tw_translate_y_6 =
+    A.class "lg:hover:tw-translate-y-6"
+
+
+lg_hover_tw_translate_y_8 : Html.Attribute msg
+lg_hover_tw_translate_y_8 =
+    A.class "lg:hover:tw-translate-y-8"
+
+
+lg_hover_tw_translate_y_10 : Html.Attribute msg
+lg_hover_tw_translate_y_10 =
+    A.class "lg:hover:tw-translate-y-10"
+
+
+lg_hover_tw_translate_y_12 : Html.Attribute msg
+lg_hover_tw_translate_y_12 =
+    A.class "lg:hover:tw-translate-y-12"
+
+
+lg_hover_tw_translate_y_16 : Html.Attribute msg
+lg_hover_tw_translate_y_16 =
+    A.class "lg:hover:tw-translate-y-16"
+
+
+lg_hover_tw_translate_y_20 : Html.Attribute msg
+lg_hover_tw_translate_y_20 =
+    A.class "lg:hover:tw-translate-y-20"
+
+
+lg_hover_tw_translate_y_24 : Html.Attribute msg
+lg_hover_tw_translate_y_24 =
+    A.class "lg:hover:tw-translate-y-24"
+
+
+lg_hover_tw_translate_y_32 : Html.Attribute msg
+lg_hover_tw_translate_y_32 =
+    A.class "lg:hover:tw-translate-y-32"
+
+
+lg_hover_tw_translate_y_40 : Html.Attribute msg
+lg_hover_tw_translate_y_40 =
+    A.class "lg:hover:tw-translate-y-40"
+
+
+lg_hover_tw_translate_y_48 : Html.Attribute msg
+lg_hover_tw_translate_y_48 =
+    A.class "lg:hover:tw-translate-y-48"
+
+
+lg_hover_tw_translate_y_56 : Html.Attribute msg
+lg_hover_tw_translate_y_56 =
+    A.class "lg:hover:tw-translate-y-56"
+
+
+lg_hover_tw_translate_y_64 : Html.Attribute msg
+lg_hover_tw_translate_y_64 =
+    A.class "lg:hover:tw-translate-y-64"
+
+
+lg_hover_tw_translate_y_px : Html.Attribute msg
+lg_hover_tw_translate_y_px =
+    A.class "lg:hover:tw-translate-y-px"
+
+
+lg_hover_tw_neg_translate_y_1 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_1 =
+    A.class "lg:hover:tw--translate-y-1"
+
+
+lg_hover_tw_neg_translate_y_2 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_2 =
+    A.class "lg:hover:tw--translate-y-2"
+
+
+lg_hover_tw_neg_translate_y_3 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_3 =
+    A.class "lg:hover:tw--translate-y-3"
+
+
+lg_hover_tw_neg_translate_y_4 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_4 =
+    A.class "lg:hover:tw--translate-y-4"
+
+
+lg_hover_tw_neg_translate_y_5 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_5 =
+    A.class "lg:hover:tw--translate-y-5"
+
+
+lg_hover_tw_neg_translate_y_6 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_6 =
+    A.class "lg:hover:tw--translate-y-6"
+
+
+lg_hover_tw_neg_translate_y_8 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_8 =
+    A.class "lg:hover:tw--translate-y-8"
+
+
+lg_hover_tw_neg_translate_y_10 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_10 =
+    A.class "lg:hover:tw--translate-y-10"
+
+
+lg_hover_tw_neg_translate_y_12 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_12 =
+    A.class "lg:hover:tw--translate-y-12"
+
+
+lg_hover_tw_neg_translate_y_16 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_16 =
+    A.class "lg:hover:tw--translate-y-16"
+
+
+lg_hover_tw_neg_translate_y_20 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_20 =
+    A.class "lg:hover:tw--translate-y-20"
+
+
+lg_hover_tw_neg_translate_y_24 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_24 =
+    A.class "lg:hover:tw--translate-y-24"
+
+
+lg_hover_tw_neg_translate_y_32 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_32 =
+    A.class "lg:hover:tw--translate-y-32"
+
+
+lg_hover_tw_neg_translate_y_40 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_40 =
+    A.class "lg:hover:tw--translate-y-40"
+
+
+lg_hover_tw_neg_translate_y_48 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_48 =
+    A.class "lg:hover:tw--translate-y-48"
+
+
+lg_hover_tw_neg_translate_y_56 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_56 =
+    A.class "lg:hover:tw--translate-y-56"
+
+
+lg_hover_tw_neg_translate_y_64 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_64 =
+    A.class "lg:hover:tw--translate-y-64"
+
+
+lg_hover_tw_neg_translate_y_px : Html.Attribute msg
+lg_hover_tw_neg_translate_y_px =
+    A.class "lg:hover:tw--translate-y-px"
+
+
+lg_hover_tw_neg_translate_y_full : Html.Attribute msg
+lg_hover_tw_neg_translate_y_full =
+    A.class "lg:hover:tw--translate-y-full"
+
+
+lg_hover_tw_neg_translate_y_1over2 : Html.Attribute msg
+lg_hover_tw_neg_translate_y_1over2 =
+    A.class "lg:hover:tw--translate-y-1/2"
+
+
+lg_hover_tw_translate_y_1over2 : Html.Attribute msg
+lg_hover_tw_translate_y_1over2 =
+    A.class "lg:hover:tw-translate-y-1/2"
+
+
+lg_hover_tw_translate_y_full : Html.Attribute msg
+lg_hover_tw_translate_y_full =
+    A.class "lg:hover:tw-translate-y-full"
+
+
+lg_focus_tw_translate_x_0 : Html.Attribute msg
+lg_focus_tw_translate_x_0 =
+    A.class "lg:focus:tw-translate-x-0"
+
+
+lg_focus_tw_translate_x_1 : Html.Attribute msg
+lg_focus_tw_translate_x_1 =
+    A.class "lg:focus:tw-translate-x-1"
+
+
+lg_focus_tw_translate_x_2 : Html.Attribute msg
+lg_focus_tw_translate_x_2 =
+    A.class "lg:focus:tw-translate-x-2"
+
+
+lg_focus_tw_translate_x_3 : Html.Attribute msg
+lg_focus_tw_translate_x_3 =
+    A.class "lg:focus:tw-translate-x-3"
+
+
+lg_focus_tw_translate_x_4 : Html.Attribute msg
+lg_focus_tw_translate_x_4 =
+    A.class "lg:focus:tw-translate-x-4"
+
+
+lg_focus_tw_translate_x_5 : Html.Attribute msg
+lg_focus_tw_translate_x_5 =
+    A.class "lg:focus:tw-translate-x-5"
+
+
+lg_focus_tw_translate_x_6 : Html.Attribute msg
+lg_focus_tw_translate_x_6 =
+    A.class "lg:focus:tw-translate-x-6"
+
+
+lg_focus_tw_translate_x_8 : Html.Attribute msg
+lg_focus_tw_translate_x_8 =
+    A.class "lg:focus:tw-translate-x-8"
+
+
+lg_focus_tw_translate_x_10 : Html.Attribute msg
+lg_focus_tw_translate_x_10 =
+    A.class "lg:focus:tw-translate-x-10"
+
+
+lg_focus_tw_translate_x_12 : Html.Attribute msg
+lg_focus_tw_translate_x_12 =
+    A.class "lg:focus:tw-translate-x-12"
+
+
+lg_focus_tw_translate_x_16 : Html.Attribute msg
+lg_focus_tw_translate_x_16 =
+    A.class "lg:focus:tw-translate-x-16"
+
+
+lg_focus_tw_translate_x_20 : Html.Attribute msg
+lg_focus_tw_translate_x_20 =
+    A.class "lg:focus:tw-translate-x-20"
+
+
+lg_focus_tw_translate_x_24 : Html.Attribute msg
+lg_focus_tw_translate_x_24 =
+    A.class "lg:focus:tw-translate-x-24"
+
+
+lg_focus_tw_translate_x_32 : Html.Attribute msg
+lg_focus_tw_translate_x_32 =
+    A.class "lg:focus:tw-translate-x-32"
+
+
+lg_focus_tw_translate_x_40 : Html.Attribute msg
+lg_focus_tw_translate_x_40 =
+    A.class "lg:focus:tw-translate-x-40"
+
+
+lg_focus_tw_translate_x_48 : Html.Attribute msg
+lg_focus_tw_translate_x_48 =
+    A.class "lg:focus:tw-translate-x-48"
+
+
+lg_focus_tw_translate_x_56 : Html.Attribute msg
+lg_focus_tw_translate_x_56 =
+    A.class "lg:focus:tw-translate-x-56"
+
+
+lg_focus_tw_translate_x_64 : Html.Attribute msg
+lg_focus_tw_translate_x_64 =
+    A.class "lg:focus:tw-translate-x-64"
+
+
+lg_focus_tw_translate_x_px : Html.Attribute msg
+lg_focus_tw_translate_x_px =
+    A.class "lg:focus:tw-translate-x-px"
+
+
+lg_focus_tw_neg_translate_x_1 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_1 =
+    A.class "lg:focus:tw--translate-x-1"
+
+
+lg_focus_tw_neg_translate_x_2 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_2 =
+    A.class "lg:focus:tw--translate-x-2"
+
+
+lg_focus_tw_neg_translate_x_3 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_3 =
+    A.class "lg:focus:tw--translate-x-3"
+
+
+lg_focus_tw_neg_translate_x_4 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_4 =
+    A.class "lg:focus:tw--translate-x-4"
+
+
+lg_focus_tw_neg_translate_x_5 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_5 =
+    A.class "lg:focus:tw--translate-x-5"
+
+
+lg_focus_tw_neg_translate_x_6 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_6 =
+    A.class "lg:focus:tw--translate-x-6"
+
+
+lg_focus_tw_neg_translate_x_8 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_8 =
+    A.class "lg:focus:tw--translate-x-8"
+
+
+lg_focus_tw_neg_translate_x_10 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_10 =
+    A.class "lg:focus:tw--translate-x-10"
+
+
+lg_focus_tw_neg_translate_x_12 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_12 =
+    A.class "lg:focus:tw--translate-x-12"
+
+
+lg_focus_tw_neg_translate_x_16 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_16 =
+    A.class "lg:focus:tw--translate-x-16"
+
+
+lg_focus_tw_neg_translate_x_20 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_20 =
+    A.class "lg:focus:tw--translate-x-20"
+
+
+lg_focus_tw_neg_translate_x_24 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_24 =
+    A.class "lg:focus:tw--translate-x-24"
+
+
+lg_focus_tw_neg_translate_x_32 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_32 =
+    A.class "lg:focus:tw--translate-x-32"
+
+
+lg_focus_tw_neg_translate_x_40 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_40 =
+    A.class "lg:focus:tw--translate-x-40"
+
+
+lg_focus_tw_neg_translate_x_48 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_48 =
+    A.class "lg:focus:tw--translate-x-48"
+
+
+lg_focus_tw_neg_translate_x_56 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_56 =
+    A.class "lg:focus:tw--translate-x-56"
+
+
+lg_focus_tw_neg_translate_x_64 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_64 =
+    A.class "lg:focus:tw--translate-x-64"
+
+
+lg_focus_tw_neg_translate_x_px : Html.Attribute msg
+lg_focus_tw_neg_translate_x_px =
+    A.class "lg:focus:tw--translate-x-px"
+
+
+lg_focus_tw_neg_translate_x_full : Html.Attribute msg
+lg_focus_tw_neg_translate_x_full =
+    A.class "lg:focus:tw--translate-x-full"
+
+
+lg_focus_tw_neg_translate_x_1over2 : Html.Attribute msg
+lg_focus_tw_neg_translate_x_1over2 =
+    A.class "lg:focus:tw--translate-x-1/2"
+
+
+lg_focus_tw_translate_x_1over2 : Html.Attribute msg
+lg_focus_tw_translate_x_1over2 =
+    A.class "lg:focus:tw-translate-x-1/2"
+
+
+lg_focus_tw_translate_x_full : Html.Attribute msg
+lg_focus_tw_translate_x_full =
+    A.class "lg:focus:tw-translate-x-full"
+
+
+lg_focus_tw_translate_y_0 : Html.Attribute msg
+lg_focus_tw_translate_y_0 =
+    A.class "lg:focus:tw-translate-y-0"
+
+
+lg_focus_tw_translate_y_1 : Html.Attribute msg
+lg_focus_tw_translate_y_1 =
+    A.class "lg:focus:tw-translate-y-1"
+
+
+lg_focus_tw_translate_y_2 : Html.Attribute msg
+lg_focus_tw_translate_y_2 =
+    A.class "lg:focus:tw-translate-y-2"
+
+
+lg_focus_tw_translate_y_3 : Html.Attribute msg
+lg_focus_tw_translate_y_3 =
+    A.class "lg:focus:tw-translate-y-3"
+
+
+lg_focus_tw_translate_y_4 : Html.Attribute msg
+lg_focus_tw_translate_y_4 =
+    A.class "lg:focus:tw-translate-y-4"
+
+
+lg_focus_tw_translate_y_5 : Html.Attribute msg
+lg_focus_tw_translate_y_5 =
+    A.class "lg:focus:tw-translate-y-5"
+
+
+lg_focus_tw_translate_y_6 : Html.Attribute msg
+lg_focus_tw_translate_y_6 =
+    A.class "lg:focus:tw-translate-y-6"
+
+
+lg_focus_tw_translate_y_8 : Html.Attribute msg
+lg_focus_tw_translate_y_8 =
+    A.class "lg:focus:tw-translate-y-8"
+
+
+lg_focus_tw_translate_y_10 : Html.Attribute msg
+lg_focus_tw_translate_y_10 =
+    A.class "lg:focus:tw-translate-y-10"
+
+
+lg_focus_tw_translate_y_12 : Html.Attribute msg
+lg_focus_tw_translate_y_12 =
+    A.class "lg:focus:tw-translate-y-12"
+
+
+lg_focus_tw_translate_y_16 : Html.Attribute msg
+lg_focus_tw_translate_y_16 =
+    A.class "lg:focus:tw-translate-y-16"
+
+
+lg_focus_tw_translate_y_20 : Html.Attribute msg
+lg_focus_tw_translate_y_20 =
+    A.class "lg:focus:tw-translate-y-20"
+
+
+lg_focus_tw_translate_y_24 : Html.Attribute msg
+lg_focus_tw_translate_y_24 =
+    A.class "lg:focus:tw-translate-y-24"
+
+
+lg_focus_tw_translate_y_32 : Html.Attribute msg
+lg_focus_tw_translate_y_32 =
+    A.class "lg:focus:tw-translate-y-32"
+
+
+lg_focus_tw_translate_y_40 : Html.Attribute msg
+lg_focus_tw_translate_y_40 =
+    A.class "lg:focus:tw-translate-y-40"
+
+
+lg_focus_tw_translate_y_48 : Html.Attribute msg
+lg_focus_tw_translate_y_48 =
+    A.class "lg:focus:tw-translate-y-48"
+
+
+lg_focus_tw_translate_y_56 : Html.Attribute msg
+lg_focus_tw_translate_y_56 =
+    A.class "lg:focus:tw-translate-y-56"
+
+
+lg_focus_tw_translate_y_64 : Html.Attribute msg
+lg_focus_tw_translate_y_64 =
+    A.class "lg:focus:tw-translate-y-64"
+
+
+lg_focus_tw_translate_y_px : Html.Attribute msg
+lg_focus_tw_translate_y_px =
+    A.class "lg:focus:tw-translate-y-px"
+
+
+lg_focus_tw_neg_translate_y_1 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_1 =
+    A.class "lg:focus:tw--translate-y-1"
+
+
+lg_focus_tw_neg_translate_y_2 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_2 =
+    A.class "lg:focus:tw--translate-y-2"
+
+
+lg_focus_tw_neg_translate_y_3 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_3 =
+    A.class "lg:focus:tw--translate-y-3"
+
+
+lg_focus_tw_neg_translate_y_4 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_4 =
+    A.class "lg:focus:tw--translate-y-4"
+
+
+lg_focus_tw_neg_translate_y_5 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_5 =
+    A.class "lg:focus:tw--translate-y-5"
+
+
+lg_focus_tw_neg_translate_y_6 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_6 =
+    A.class "lg:focus:tw--translate-y-6"
+
+
+lg_focus_tw_neg_translate_y_8 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_8 =
+    A.class "lg:focus:tw--translate-y-8"
+
+
+lg_focus_tw_neg_translate_y_10 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_10 =
+    A.class "lg:focus:tw--translate-y-10"
+
+
+lg_focus_tw_neg_translate_y_12 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_12 =
+    A.class "lg:focus:tw--translate-y-12"
+
+
+lg_focus_tw_neg_translate_y_16 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_16 =
+    A.class "lg:focus:tw--translate-y-16"
+
+
+lg_focus_tw_neg_translate_y_20 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_20 =
+    A.class "lg:focus:tw--translate-y-20"
+
+
+lg_focus_tw_neg_translate_y_24 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_24 =
+    A.class "lg:focus:tw--translate-y-24"
+
+
+lg_focus_tw_neg_translate_y_32 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_32 =
+    A.class "lg:focus:tw--translate-y-32"
+
+
+lg_focus_tw_neg_translate_y_40 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_40 =
+    A.class "lg:focus:tw--translate-y-40"
+
+
+lg_focus_tw_neg_translate_y_48 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_48 =
+    A.class "lg:focus:tw--translate-y-48"
+
+
+lg_focus_tw_neg_translate_y_56 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_56 =
+    A.class "lg:focus:tw--translate-y-56"
+
+
+lg_focus_tw_neg_translate_y_64 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_64 =
+    A.class "lg:focus:tw--translate-y-64"
+
+
+lg_focus_tw_neg_translate_y_px : Html.Attribute msg
+lg_focus_tw_neg_translate_y_px =
+    A.class "lg:focus:tw--translate-y-px"
+
+
+lg_focus_tw_neg_translate_y_full : Html.Attribute msg
+lg_focus_tw_neg_translate_y_full =
+    A.class "lg:focus:tw--translate-y-full"
+
+
+lg_focus_tw_neg_translate_y_1over2 : Html.Attribute msg
+lg_focus_tw_neg_translate_y_1over2 =
+    A.class "lg:focus:tw--translate-y-1/2"
+
+
+lg_focus_tw_translate_y_1over2 : Html.Attribute msg
+lg_focus_tw_translate_y_1over2 =
+    A.class "lg:focus:tw-translate-y-1/2"
+
+
+lg_focus_tw_translate_y_full : Html.Attribute msg
+lg_focus_tw_translate_y_full =
+    A.class "lg:focus:tw-translate-y-full"
+
+
+lg_tw_skew_x_0 : Html.Attribute msg
+lg_tw_skew_x_0 =
+    A.class "lg:tw-skew-x-0"
+
+
+lg_tw_skew_x_3 : Html.Attribute msg
+lg_tw_skew_x_3 =
+    A.class "lg:tw-skew-x-3"
+
+
+lg_tw_skew_x_6 : Html.Attribute msg
+lg_tw_skew_x_6 =
+    A.class "lg:tw-skew-x-6"
+
+
+lg_tw_skew_x_12 : Html.Attribute msg
+lg_tw_skew_x_12 =
+    A.class "lg:tw-skew-x-12"
+
+
+lg_tw_neg_skew_x_12 : Html.Attribute msg
+lg_tw_neg_skew_x_12 =
+    A.class "lg:tw--skew-x-12"
+
+
+lg_tw_neg_skew_x_6 : Html.Attribute msg
+lg_tw_neg_skew_x_6 =
+    A.class "lg:tw--skew-x-6"
+
+
+lg_tw_neg_skew_x_3 : Html.Attribute msg
+lg_tw_neg_skew_x_3 =
+    A.class "lg:tw--skew-x-3"
+
+
+lg_tw_skew_y_0 : Html.Attribute msg
+lg_tw_skew_y_0 =
+    A.class "lg:tw-skew-y-0"
+
+
+lg_tw_skew_y_3 : Html.Attribute msg
+lg_tw_skew_y_3 =
+    A.class "lg:tw-skew-y-3"
+
+
+lg_tw_skew_y_6 : Html.Attribute msg
+lg_tw_skew_y_6 =
+    A.class "lg:tw-skew-y-6"
+
+
+lg_tw_skew_y_12 : Html.Attribute msg
+lg_tw_skew_y_12 =
+    A.class "lg:tw-skew-y-12"
+
+
+lg_tw_neg_skew_y_12 : Html.Attribute msg
+lg_tw_neg_skew_y_12 =
+    A.class "lg:tw--skew-y-12"
+
+
+lg_tw_neg_skew_y_6 : Html.Attribute msg
+lg_tw_neg_skew_y_6 =
+    A.class "lg:tw--skew-y-6"
+
+
+lg_tw_neg_skew_y_3 : Html.Attribute msg
+lg_tw_neg_skew_y_3 =
+    A.class "lg:tw--skew-y-3"
+
+
+lg_hover_tw_skew_x_0 : Html.Attribute msg
+lg_hover_tw_skew_x_0 =
+    A.class "lg:hover:tw-skew-x-0"
+
+
+lg_hover_tw_skew_x_3 : Html.Attribute msg
+lg_hover_tw_skew_x_3 =
+    A.class "lg:hover:tw-skew-x-3"
+
+
+lg_hover_tw_skew_x_6 : Html.Attribute msg
+lg_hover_tw_skew_x_6 =
+    A.class "lg:hover:tw-skew-x-6"
+
+
+lg_hover_tw_skew_x_12 : Html.Attribute msg
+lg_hover_tw_skew_x_12 =
+    A.class "lg:hover:tw-skew-x-12"
+
+
+lg_hover_tw_neg_skew_x_12 : Html.Attribute msg
+lg_hover_tw_neg_skew_x_12 =
+    A.class "lg:hover:tw--skew-x-12"
+
+
+lg_hover_tw_neg_skew_x_6 : Html.Attribute msg
+lg_hover_tw_neg_skew_x_6 =
+    A.class "lg:hover:tw--skew-x-6"
+
+
+lg_hover_tw_neg_skew_x_3 : Html.Attribute msg
+lg_hover_tw_neg_skew_x_3 =
+    A.class "lg:hover:tw--skew-x-3"
+
+
+lg_hover_tw_skew_y_0 : Html.Attribute msg
+lg_hover_tw_skew_y_0 =
+    A.class "lg:hover:tw-skew-y-0"
+
+
+lg_hover_tw_skew_y_3 : Html.Attribute msg
+lg_hover_tw_skew_y_3 =
+    A.class "lg:hover:tw-skew-y-3"
+
+
+lg_hover_tw_skew_y_6 : Html.Attribute msg
+lg_hover_tw_skew_y_6 =
+    A.class "lg:hover:tw-skew-y-6"
+
+
+lg_hover_tw_skew_y_12 : Html.Attribute msg
+lg_hover_tw_skew_y_12 =
+    A.class "lg:hover:tw-skew-y-12"
+
+
+lg_hover_tw_neg_skew_y_12 : Html.Attribute msg
+lg_hover_tw_neg_skew_y_12 =
+    A.class "lg:hover:tw--skew-y-12"
+
+
+lg_hover_tw_neg_skew_y_6 : Html.Attribute msg
+lg_hover_tw_neg_skew_y_6 =
+    A.class "lg:hover:tw--skew-y-6"
+
+
+lg_hover_tw_neg_skew_y_3 : Html.Attribute msg
+lg_hover_tw_neg_skew_y_3 =
+    A.class "lg:hover:tw--skew-y-3"
+
+
+lg_focus_tw_skew_x_0 : Html.Attribute msg
+lg_focus_tw_skew_x_0 =
+    A.class "lg:focus:tw-skew-x-0"
+
+
+lg_focus_tw_skew_x_3 : Html.Attribute msg
+lg_focus_tw_skew_x_3 =
+    A.class "lg:focus:tw-skew-x-3"
+
+
+lg_focus_tw_skew_x_6 : Html.Attribute msg
+lg_focus_tw_skew_x_6 =
+    A.class "lg:focus:tw-skew-x-6"
+
+
+lg_focus_tw_skew_x_12 : Html.Attribute msg
+lg_focus_tw_skew_x_12 =
+    A.class "lg:focus:tw-skew-x-12"
+
+
+lg_focus_tw_neg_skew_x_12 : Html.Attribute msg
+lg_focus_tw_neg_skew_x_12 =
+    A.class "lg:focus:tw--skew-x-12"
+
+
+lg_focus_tw_neg_skew_x_6 : Html.Attribute msg
+lg_focus_tw_neg_skew_x_6 =
+    A.class "lg:focus:tw--skew-x-6"
+
+
+lg_focus_tw_neg_skew_x_3 : Html.Attribute msg
+lg_focus_tw_neg_skew_x_3 =
+    A.class "lg:focus:tw--skew-x-3"
+
+
+lg_focus_tw_skew_y_0 : Html.Attribute msg
+lg_focus_tw_skew_y_0 =
+    A.class "lg:focus:tw-skew-y-0"
+
+
+lg_focus_tw_skew_y_3 : Html.Attribute msg
+lg_focus_tw_skew_y_3 =
+    A.class "lg:focus:tw-skew-y-3"
+
+
+lg_focus_tw_skew_y_6 : Html.Attribute msg
+lg_focus_tw_skew_y_6 =
+    A.class "lg:focus:tw-skew-y-6"
+
+
+lg_focus_tw_skew_y_12 : Html.Attribute msg
+lg_focus_tw_skew_y_12 =
+    A.class "lg:focus:tw-skew-y-12"
+
+
+lg_focus_tw_neg_skew_y_12 : Html.Attribute msg
+lg_focus_tw_neg_skew_y_12 =
+    A.class "lg:focus:tw--skew-y-12"
+
+
+lg_focus_tw_neg_skew_y_6 : Html.Attribute msg
+lg_focus_tw_neg_skew_y_6 =
+    A.class "lg:focus:tw--skew-y-6"
+
+
+lg_focus_tw_neg_skew_y_3 : Html.Attribute msg
+lg_focus_tw_neg_skew_y_3 =
+    A.class "lg:focus:tw--skew-y-3"
+
+
+lg_tw_transition_none : Html.Attribute msg
+lg_tw_transition_none =
+    A.class "lg:tw-transition-none"
+
+
+lg_tw_transition_all : Html.Attribute msg
+lg_tw_transition_all =
+    A.class "lg:tw-transition-all"
+
+
+lg_tw_transition : Html.Attribute msg
+lg_tw_transition =
+    A.class "lg:tw-transition"
+
+
+lg_tw_transition_colors : Html.Attribute msg
+lg_tw_transition_colors =
+    A.class "lg:tw-transition-colors"
+
+
+lg_tw_transition_opacity : Html.Attribute msg
+lg_tw_transition_opacity =
+    A.class "lg:tw-transition-opacity"
+
+
+lg_tw_transition_shadow : Html.Attribute msg
+lg_tw_transition_shadow =
+    A.class "lg:tw-transition-shadow"
+
+
+lg_tw_transition_transform : Html.Attribute msg
+lg_tw_transition_transform =
+    A.class "lg:tw-transition-transform"
+
+
+lg_tw_ease_linear : Html.Attribute msg
+lg_tw_ease_linear =
+    A.class "lg:tw-ease-linear"
+
+
+lg_tw_ease_in : Html.Attribute msg
+lg_tw_ease_in =
+    A.class "lg:tw-ease-in"
+
+
+lg_tw_ease_out : Html.Attribute msg
+lg_tw_ease_out =
+    A.class "lg:tw-ease-out"
+
+
+lg_tw_ease_in_out : Html.Attribute msg
+lg_tw_ease_in_out =
+    A.class "lg:tw-ease-in-out"
+
+
+lg_tw_duration_75 : Html.Attribute msg
+lg_tw_duration_75 =
+    A.class "lg:tw-duration-75"
+
+
+lg_tw_duration_100 : Html.Attribute msg
+lg_tw_duration_100 =
+    A.class "lg:tw-duration-100"
+
+
+lg_tw_duration_150 : Html.Attribute msg
+lg_tw_duration_150 =
+    A.class "lg:tw-duration-150"
+
+
+lg_tw_duration_200 : Html.Attribute msg
+lg_tw_duration_200 =
+    A.class "lg:tw-duration-200"
+
+
+lg_tw_duration_300 : Html.Attribute msg
+lg_tw_duration_300 =
+    A.class "lg:tw-duration-300"
+
+
+lg_tw_duration_500 : Html.Attribute msg
+lg_tw_duration_500 =
+    A.class "lg:tw-duration-500"
+
+
+lg_tw_duration_700 : Html.Attribute msg
+lg_tw_duration_700 =
+    A.class "lg:tw-duration-700"
+
+
+lg_tw_duration_1000 : Html.Attribute msg
+lg_tw_duration_1000 =
+    A.class "lg:tw-duration-1000"
 
 
 xl_tw_sr_only : Html.Attribute msg
@@ -50203,6 +65653,11 @@ xl_tw_rounded =
     A.class "xl:tw-rounded"
 
 
+xl_tw_rounded_md : Html.Attribute msg
+xl_tw_rounded_md =
+    A.class "xl:tw-rounded-md"
+
+
 xl_tw_rounded_lg : Html.Attribute msg
 xl_tw_rounded_lg =
     A.class "xl:tw-rounded-lg"
@@ -50271,6 +65726,26 @@ xl_tw_rounded_b =
 xl_tw_rounded_l : Html.Attribute msg
 xl_tw_rounded_l =
     A.class "xl:tw-rounded-l"
+
+
+xl_tw_rounded_t_md : Html.Attribute msg
+xl_tw_rounded_t_md =
+    A.class "xl:tw-rounded-t-md"
+
+
+xl_tw_rounded_r_md : Html.Attribute msg
+xl_tw_rounded_r_md =
+    A.class "xl:tw-rounded-r-md"
+
+
+xl_tw_rounded_b_md : Html.Attribute msg
+xl_tw_rounded_b_md =
+    A.class "xl:tw-rounded-b-md"
+
+
+xl_tw_rounded_l_md : Html.Attribute msg
+xl_tw_rounded_l_md =
+    A.class "xl:tw-rounded-l-md"
 
 
 xl_tw_rounded_t_lg : Html.Attribute msg
@@ -50371,6 +65846,26 @@ xl_tw_rounded_br =
 xl_tw_rounded_bl : Html.Attribute msg
 xl_tw_rounded_bl =
     A.class "xl:tw-rounded-bl"
+
+
+xl_tw_rounded_tl_md : Html.Attribute msg
+xl_tw_rounded_tl_md =
+    A.class "xl:tw-rounded-tl-md"
+
+
+xl_tw_rounded_tr_md : Html.Attribute msg
+xl_tw_rounded_tr_md =
+    A.class "xl:tw-rounded-tr-md"
+
+
+xl_tw_rounded_br_md : Html.Attribute msg
+xl_tw_rounded_br_md =
+    A.class "xl:tw-rounded-br-md"
+
+
+xl_tw_rounded_bl_md : Html.Attribute msg
+xl_tw_rounded_bl_md =
+    A.class "xl:tw-rounded-bl-md"
 
 
 xl_tw_rounded_tl_lg : Html.Attribute msg
@@ -50563,6 +66058,16 @@ xl_tw_border_l =
     A.class "xl:tw-border-l"
 
 
+xl_tw_box_border : Html.Attribute msg
+xl_tw_box_border =
+    A.class "xl:tw-box-border"
+
+
+xl_tw_box_content : Html.Attribute msg
+xl_tw_box_content =
+    A.class "xl:tw-box-content"
+
+
 xl_tw_cursor_auto : Html.Attribute msg
 xl_tw_cursor_auto =
     A.class "xl:tw-cursor-auto"
@@ -50623,19 +66128,54 @@ xl_tw_inline_flex =
     A.class "xl:tw-inline-flex"
 
 
+xl_tw_grid : Html.Attribute msg
+xl_tw_grid =
+    A.class "xl:tw-grid"
+
+
 xl_tw_table : Html.Attribute msg
 xl_tw_table =
     A.class "xl:tw-table"
 
 
-xl_tw_table_row : Html.Attribute msg
-xl_tw_table_row =
-    A.class "xl:tw-table-row"
+xl_tw_table_caption : Html.Attribute msg
+xl_tw_table_caption =
+    A.class "xl:tw-table-caption"
 
 
 xl_tw_table_cell : Html.Attribute msg
 xl_tw_table_cell =
     A.class "xl:tw-table-cell"
+
+
+xl_tw_table_column : Html.Attribute msg
+xl_tw_table_column =
+    A.class "xl:tw-table-column"
+
+
+xl_tw_table_column_group : Html.Attribute msg
+xl_tw_table_column_group =
+    A.class "xl:tw-table-column-group"
+
+
+xl_tw_table_footer_group : Html.Attribute msg
+xl_tw_table_footer_group =
+    A.class "xl:tw-table-footer-group"
+
+
+xl_tw_table_header_group : Html.Attribute msg
+xl_tw_table_header_group =
+    A.class "xl:tw-table-header-group"
+
+
+xl_tw_table_row_group : Html.Attribute msg
+xl_tw_table_row_group =
+    A.class "xl:tw-table-row-group"
+
+
+xl_tw_table_row : Html.Attribute msg
+xl_tw_table_row =
+    A.class "xl:tw-table-row"
 
 
 xl_tw_hidden : Html.Attribute msg
@@ -50751,6 +66291,11 @@ xl_tw_justify_between =
 xl_tw_justify_around : Html.Attribute msg
 xl_tw_justify_around =
     A.class "xl:tw-justify-around"
+
+
+xl_tw_justify_evenly : Html.Attribute msg
+xl_tw_justify_evenly =
+    A.class "xl:tw-justify-evenly"
 
 
 xl_tw_content_center : Html.Attribute msg
@@ -50911,6 +66456,21 @@ xl_tw_float_none =
 xl_tw_clearfix_after : Html.Attribute msg
 xl_tw_clearfix_after =
     A.class "xl:tw-clearfix:after"
+
+
+xl_tw_clear_left : Html.Attribute msg
+xl_tw_clear_left =
+    A.class "xl:tw-clear-left"
+
+
+xl_tw_clear_right : Html.Attribute msg
+xl_tw_clear_right =
+    A.class "xl:tw-clear-right"
+
+
+xl_tw_clear_both : Html.Attribute msg
+xl_tw_clear_both =
+    A.class "xl:tw-clear-both"
 
 
 xl_tw_font_sans : Html.Attribute msg
@@ -51171,6 +66731,46 @@ xl_tw_h_full =
 xl_tw_h_screen : Html.Attribute msg
 xl_tw_h_screen =
     A.class "xl:tw-h-screen"
+
+
+xl_tw_leading_3 : Html.Attribute msg
+xl_tw_leading_3 =
+    A.class "xl:tw-leading-3"
+
+
+xl_tw_leading_4 : Html.Attribute msg
+xl_tw_leading_4 =
+    A.class "xl:tw-leading-4"
+
+
+xl_tw_leading_5 : Html.Attribute msg
+xl_tw_leading_5 =
+    A.class "xl:tw-leading-5"
+
+
+xl_tw_leading_6 : Html.Attribute msg
+xl_tw_leading_6 =
+    A.class "xl:tw-leading-6"
+
+
+xl_tw_leading_7 : Html.Attribute msg
+xl_tw_leading_7 =
+    A.class "xl:tw-leading-7"
+
+
+xl_tw_leading_8 : Html.Attribute msg
+xl_tw_leading_8 =
+    A.class "xl:tw-leading-8"
+
+
+xl_tw_leading_9 : Html.Attribute msg
+xl_tw_leading_9 =
+    A.class "xl:tw-leading-9"
+
+
+xl_tw_leading_10 : Html.Attribute msg
+xl_tw_leading_10 =
+    A.class "xl:tw-leading-10"
 
 
 xl_tw_leading_none : Html.Attribute msg
@@ -52568,6 +68168,11 @@ xl_tw_max_h_screen =
     A.class "xl:tw-max-h-screen"
 
 
+xl_tw_max_w_none : Html.Attribute msg
+xl_tw_max_w_none =
+    A.class "xl:tw-max-w-none"
+
+
 xl_tw_max_w_xs : Html.Attribute msg
 xl_tw_max_w_xs =
     A.class "xl:tw-max-w-xs"
@@ -52621,6 +68226,26 @@ xl_tw_max_w_6xl =
 xl_tw_max_w_full : Html.Attribute msg
 xl_tw_max_w_full =
     A.class "xl:tw-max-w-full"
+
+
+xl_tw_max_w_screen_sm : Html.Attribute msg
+xl_tw_max_w_screen_sm =
+    A.class "xl:tw-max-w-screen-sm"
+
+
+xl_tw_max_w_screen_md : Html.Attribute msg
+xl_tw_max_w_screen_md =
+    A.class "xl:tw-max-w-screen-md"
+
+
+xl_tw_max_w_screen_lg : Html.Attribute msg
+xl_tw_max_w_screen_lg =
+    A.class "xl:tw-max-w-screen-lg"
+
+
+xl_tw_max_w_screen_xl : Html.Attribute msg
+xl_tw_max_w_screen_xl =
+    A.class "xl:tw-max-w-screen-xl"
 
 
 xl_tw_min_h_0 : Html.Attribute msg
@@ -54593,6 +70218,16 @@ xl_tw_resize =
     A.class "xl:tw-resize"
 
 
+xl_tw_shadow_xs : Html.Attribute msg
+xl_tw_shadow_xs =
+    A.class "xl:tw-shadow-xs"
+
+
+xl_tw_shadow_sm : Html.Attribute msg
+xl_tw_shadow_sm =
+    A.class "xl:tw-shadow-sm"
+
+
 xl_tw_shadow : Html.Attribute msg
 xl_tw_shadow =
     A.class "xl:tw-shadow"
@@ -54633,6 +70268,16 @@ xl_tw_shadow_none =
     A.class "xl:tw-shadow-none"
 
 
+xl_hover_tw_shadow_xs : Html.Attribute msg
+xl_hover_tw_shadow_xs =
+    A.class "xl:hover:tw-shadow-xs"
+
+
+xl_hover_tw_shadow_sm : Html.Attribute msg
+xl_hover_tw_shadow_sm =
+    A.class "xl:hover:tw-shadow-sm"
+
+
 xl_hover_tw_shadow : Html.Attribute msg
 xl_hover_tw_shadow =
     A.class "xl:hover:tw-shadow"
@@ -54671,6 +70316,16 @@ xl_hover_tw_shadow_outline =
 xl_hover_tw_shadow_none : Html.Attribute msg
 xl_hover_tw_shadow_none =
     A.class "xl:hover:tw-shadow-none"
+
+
+xl_focus_tw_shadow_xs : Html.Attribute msg
+xl_focus_tw_shadow_xs =
+    A.class "xl:focus:tw-shadow-xs"
+
+
+xl_focus_tw_shadow_sm : Html.Attribute msg
+xl_focus_tw_shadow_sm =
+    A.class "xl:focus:tw-shadow-sm"
 
 
 xl_focus_tw_shadow : Html.Attribute msg
@@ -54721,6 +70376,21 @@ xl_tw_fill_current =
 xl_tw_stroke_current : Html.Attribute msg
 xl_tw_stroke_current =
     A.class "xl:tw-stroke-current"
+
+
+xl_tw_stroke_0 : Html.Attribute msg
+xl_tw_stroke_0 =
+    A.class "xl:tw-stroke-0"
+
+
+xl_tw_stroke_1 : Html.Attribute msg
+xl_tw_stroke_1 =
+    A.class "xl:tw-stroke-1"
+
+
+xl_tw_stroke_2 : Html.Attribute msg
+xl_tw_stroke_2 =
+    A.class "xl:tw-stroke-2"
 
 
 xl_tw_table_auto : Html.Attribute msg
@@ -56691,4 +72361,2874 @@ xl_tw_z_50 =
 xl_tw_z_auto : Html.Attribute msg
 xl_tw_z_auto =
     A.class "xl:tw-z-auto"
+
+
+xl_tw_gap_0 : Html.Attribute msg
+xl_tw_gap_0 =
+    A.class "xl:tw-gap-0"
+
+
+xl_tw_gap_1 : Html.Attribute msg
+xl_tw_gap_1 =
+    A.class "xl:tw-gap-1"
+
+
+xl_tw_gap_2 : Html.Attribute msg
+xl_tw_gap_2 =
+    A.class "xl:tw-gap-2"
+
+
+xl_tw_gap_3 : Html.Attribute msg
+xl_tw_gap_3 =
+    A.class "xl:tw-gap-3"
+
+
+xl_tw_gap_4 : Html.Attribute msg
+xl_tw_gap_4 =
+    A.class "xl:tw-gap-4"
+
+
+xl_tw_gap_5 : Html.Attribute msg
+xl_tw_gap_5 =
+    A.class "xl:tw-gap-5"
+
+
+xl_tw_gap_6 : Html.Attribute msg
+xl_tw_gap_6 =
+    A.class "xl:tw-gap-6"
+
+
+xl_tw_gap_8 : Html.Attribute msg
+xl_tw_gap_8 =
+    A.class "xl:tw-gap-8"
+
+
+xl_tw_gap_10 : Html.Attribute msg
+xl_tw_gap_10 =
+    A.class "xl:tw-gap-10"
+
+
+xl_tw_gap_12 : Html.Attribute msg
+xl_tw_gap_12 =
+    A.class "xl:tw-gap-12"
+
+
+xl_tw_gap_16 : Html.Attribute msg
+xl_tw_gap_16 =
+    A.class "xl:tw-gap-16"
+
+
+xl_tw_gap_20 : Html.Attribute msg
+xl_tw_gap_20 =
+    A.class "xl:tw-gap-20"
+
+
+xl_tw_gap_24 : Html.Attribute msg
+xl_tw_gap_24 =
+    A.class "xl:tw-gap-24"
+
+
+xl_tw_gap_32 : Html.Attribute msg
+xl_tw_gap_32 =
+    A.class "xl:tw-gap-32"
+
+
+xl_tw_gap_40 : Html.Attribute msg
+xl_tw_gap_40 =
+    A.class "xl:tw-gap-40"
+
+
+xl_tw_gap_48 : Html.Attribute msg
+xl_tw_gap_48 =
+    A.class "xl:tw-gap-48"
+
+
+xl_tw_gap_56 : Html.Attribute msg
+xl_tw_gap_56 =
+    A.class "xl:tw-gap-56"
+
+
+xl_tw_gap_64 : Html.Attribute msg
+xl_tw_gap_64 =
+    A.class "xl:tw-gap-64"
+
+
+xl_tw_gap_px : Html.Attribute msg
+xl_tw_gap_px =
+    A.class "xl:tw-gap-px"
+
+
+xl_tw_col_gap_0 : Html.Attribute msg
+xl_tw_col_gap_0 =
+    A.class "xl:tw-col-gap-0"
+
+
+xl_tw_col_gap_1 : Html.Attribute msg
+xl_tw_col_gap_1 =
+    A.class "xl:tw-col-gap-1"
+
+
+xl_tw_col_gap_2 : Html.Attribute msg
+xl_tw_col_gap_2 =
+    A.class "xl:tw-col-gap-2"
+
+
+xl_tw_col_gap_3 : Html.Attribute msg
+xl_tw_col_gap_3 =
+    A.class "xl:tw-col-gap-3"
+
+
+xl_tw_col_gap_4 : Html.Attribute msg
+xl_tw_col_gap_4 =
+    A.class "xl:tw-col-gap-4"
+
+
+xl_tw_col_gap_5 : Html.Attribute msg
+xl_tw_col_gap_5 =
+    A.class "xl:tw-col-gap-5"
+
+
+xl_tw_col_gap_6 : Html.Attribute msg
+xl_tw_col_gap_6 =
+    A.class "xl:tw-col-gap-6"
+
+
+xl_tw_col_gap_8 : Html.Attribute msg
+xl_tw_col_gap_8 =
+    A.class "xl:tw-col-gap-8"
+
+
+xl_tw_col_gap_10 : Html.Attribute msg
+xl_tw_col_gap_10 =
+    A.class "xl:tw-col-gap-10"
+
+
+xl_tw_col_gap_12 : Html.Attribute msg
+xl_tw_col_gap_12 =
+    A.class "xl:tw-col-gap-12"
+
+
+xl_tw_col_gap_16 : Html.Attribute msg
+xl_tw_col_gap_16 =
+    A.class "xl:tw-col-gap-16"
+
+
+xl_tw_col_gap_20 : Html.Attribute msg
+xl_tw_col_gap_20 =
+    A.class "xl:tw-col-gap-20"
+
+
+xl_tw_col_gap_24 : Html.Attribute msg
+xl_tw_col_gap_24 =
+    A.class "xl:tw-col-gap-24"
+
+
+xl_tw_col_gap_32 : Html.Attribute msg
+xl_tw_col_gap_32 =
+    A.class "xl:tw-col-gap-32"
+
+
+xl_tw_col_gap_40 : Html.Attribute msg
+xl_tw_col_gap_40 =
+    A.class "xl:tw-col-gap-40"
+
+
+xl_tw_col_gap_48 : Html.Attribute msg
+xl_tw_col_gap_48 =
+    A.class "xl:tw-col-gap-48"
+
+
+xl_tw_col_gap_56 : Html.Attribute msg
+xl_tw_col_gap_56 =
+    A.class "xl:tw-col-gap-56"
+
+
+xl_tw_col_gap_64 : Html.Attribute msg
+xl_tw_col_gap_64 =
+    A.class "xl:tw-col-gap-64"
+
+
+xl_tw_col_gap_px : Html.Attribute msg
+xl_tw_col_gap_px =
+    A.class "xl:tw-col-gap-px"
+
+
+xl_tw_row_gap_0 : Html.Attribute msg
+xl_tw_row_gap_0 =
+    A.class "xl:tw-row-gap-0"
+
+
+xl_tw_row_gap_1 : Html.Attribute msg
+xl_tw_row_gap_1 =
+    A.class "xl:tw-row-gap-1"
+
+
+xl_tw_row_gap_2 : Html.Attribute msg
+xl_tw_row_gap_2 =
+    A.class "xl:tw-row-gap-2"
+
+
+xl_tw_row_gap_3 : Html.Attribute msg
+xl_tw_row_gap_3 =
+    A.class "xl:tw-row-gap-3"
+
+
+xl_tw_row_gap_4 : Html.Attribute msg
+xl_tw_row_gap_4 =
+    A.class "xl:tw-row-gap-4"
+
+
+xl_tw_row_gap_5 : Html.Attribute msg
+xl_tw_row_gap_5 =
+    A.class "xl:tw-row-gap-5"
+
+
+xl_tw_row_gap_6 : Html.Attribute msg
+xl_tw_row_gap_6 =
+    A.class "xl:tw-row-gap-6"
+
+
+xl_tw_row_gap_8 : Html.Attribute msg
+xl_tw_row_gap_8 =
+    A.class "xl:tw-row-gap-8"
+
+
+xl_tw_row_gap_10 : Html.Attribute msg
+xl_tw_row_gap_10 =
+    A.class "xl:tw-row-gap-10"
+
+
+xl_tw_row_gap_12 : Html.Attribute msg
+xl_tw_row_gap_12 =
+    A.class "xl:tw-row-gap-12"
+
+
+xl_tw_row_gap_16 : Html.Attribute msg
+xl_tw_row_gap_16 =
+    A.class "xl:tw-row-gap-16"
+
+
+xl_tw_row_gap_20 : Html.Attribute msg
+xl_tw_row_gap_20 =
+    A.class "xl:tw-row-gap-20"
+
+
+xl_tw_row_gap_24 : Html.Attribute msg
+xl_tw_row_gap_24 =
+    A.class "xl:tw-row-gap-24"
+
+
+xl_tw_row_gap_32 : Html.Attribute msg
+xl_tw_row_gap_32 =
+    A.class "xl:tw-row-gap-32"
+
+
+xl_tw_row_gap_40 : Html.Attribute msg
+xl_tw_row_gap_40 =
+    A.class "xl:tw-row-gap-40"
+
+
+xl_tw_row_gap_48 : Html.Attribute msg
+xl_tw_row_gap_48 =
+    A.class "xl:tw-row-gap-48"
+
+
+xl_tw_row_gap_56 : Html.Attribute msg
+xl_tw_row_gap_56 =
+    A.class "xl:tw-row-gap-56"
+
+
+xl_tw_row_gap_64 : Html.Attribute msg
+xl_tw_row_gap_64 =
+    A.class "xl:tw-row-gap-64"
+
+
+xl_tw_row_gap_px : Html.Attribute msg
+xl_tw_row_gap_px =
+    A.class "xl:tw-row-gap-px"
+
+
+xl_tw_grid_flow_row : Html.Attribute msg
+xl_tw_grid_flow_row =
+    A.class "xl:tw-grid-flow-row"
+
+
+xl_tw_grid_flow_col : Html.Attribute msg
+xl_tw_grid_flow_col =
+    A.class "xl:tw-grid-flow-col"
+
+
+xl_tw_grid_flow_row_dense : Html.Attribute msg
+xl_tw_grid_flow_row_dense =
+    A.class "xl:tw-grid-flow-row-dense"
+
+
+xl_tw_grid_flow_col_dense : Html.Attribute msg
+xl_tw_grid_flow_col_dense =
+    A.class "xl:tw-grid-flow-col-dense"
+
+
+xl_tw_grid_cols_1 : Html.Attribute msg
+xl_tw_grid_cols_1 =
+    A.class "xl:tw-grid-cols-1"
+
+
+xl_tw_grid_cols_2 : Html.Attribute msg
+xl_tw_grid_cols_2 =
+    A.class "xl:tw-grid-cols-2"
+
+
+xl_tw_grid_cols_3 : Html.Attribute msg
+xl_tw_grid_cols_3 =
+    A.class "xl:tw-grid-cols-3"
+
+
+xl_tw_grid_cols_4 : Html.Attribute msg
+xl_tw_grid_cols_4 =
+    A.class "xl:tw-grid-cols-4"
+
+
+xl_tw_grid_cols_5 : Html.Attribute msg
+xl_tw_grid_cols_5 =
+    A.class "xl:tw-grid-cols-5"
+
+
+xl_tw_grid_cols_6 : Html.Attribute msg
+xl_tw_grid_cols_6 =
+    A.class "xl:tw-grid-cols-6"
+
+
+xl_tw_grid_cols_7 : Html.Attribute msg
+xl_tw_grid_cols_7 =
+    A.class "xl:tw-grid-cols-7"
+
+
+xl_tw_grid_cols_8 : Html.Attribute msg
+xl_tw_grid_cols_8 =
+    A.class "xl:tw-grid-cols-8"
+
+
+xl_tw_grid_cols_9 : Html.Attribute msg
+xl_tw_grid_cols_9 =
+    A.class "xl:tw-grid-cols-9"
+
+
+xl_tw_grid_cols_10 : Html.Attribute msg
+xl_tw_grid_cols_10 =
+    A.class "xl:tw-grid-cols-10"
+
+
+xl_tw_grid_cols_11 : Html.Attribute msg
+xl_tw_grid_cols_11 =
+    A.class "xl:tw-grid-cols-11"
+
+
+xl_tw_grid_cols_12 : Html.Attribute msg
+xl_tw_grid_cols_12 =
+    A.class "xl:tw-grid-cols-12"
+
+
+xl_tw_grid_cols_none : Html.Attribute msg
+xl_tw_grid_cols_none =
+    A.class "xl:tw-grid-cols-none"
+
+
+xl_tw_col_auto : Html.Attribute msg
+xl_tw_col_auto =
+    A.class "xl:tw-col-auto"
+
+
+xl_tw_col_span_1 : Html.Attribute msg
+xl_tw_col_span_1 =
+    A.class "xl:tw-col-span-1"
+
+
+xl_tw_col_span_2 : Html.Attribute msg
+xl_tw_col_span_2 =
+    A.class "xl:tw-col-span-2"
+
+
+xl_tw_col_span_3 : Html.Attribute msg
+xl_tw_col_span_3 =
+    A.class "xl:tw-col-span-3"
+
+
+xl_tw_col_span_4 : Html.Attribute msg
+xl_tw_col_span_4 =
+    A.class "xl:tw-col-span-4"
+
+
+xl_tw_col_span_5 : Html.Attribute msg
+xl_tw_col_span_5 =
+    A.class "xl:tw-col-span-5"
+
+
+xl_tw_col_span_6 : Html.Attribute msg
+xl_tw_col_span_6 =
+    A.class "xl:tw-col-span-6"
+
+
+xl_tw_col_span_7 : Html.Attribute msg
+xl_tw_col_span_7 =
+    A.class "xl:tw-col-span-7"
+
+
+xl_tw_col_span_8 : Html.Attribute msg
+xl_tw_col_span_8 =
+    A.class "xl:tw-col-span-8"
+
+
+xl_tw_col_span_9 : Html.Attribute msg
+xl_tw_col_span_9 =
+    A.class "xl:tw-col-span-9"
+
+
+xl_tw_col_span_10 : Html.Attribute msg
+xl_tw_col_span_10 =
+    A.class "xl:tw-col-span-10"
+
+
+xl_tw_col_span_11 : Html.Attribute msg
+xl_tw_col_span_11 =
+    A.class "xl:tw-col-span-11"
+
+
+xl_tw_col_span_12 : Html.Attribute msg
+xl_tw_col_span_12 =
+    A.class "xl:tw-col-span-12"
+
+
+xl_tw_col_start_1 : Html.Attribute msg
+xl_tw_col_start_1 =
+    A.class "xl:tw-col-start-1"
+
+
+xl_tw_col_start_2 : Html.Attribute msg
+xl_tw_col_start_2 =
+    A.class "xl:tw-col-start-2"
+
+
+xl_tw_col_start_3 : Html.Attribute msg
+xl_tw_col_start_3 =
+    A.class "xl:tw-col-start-3"
+
+
+xl_tw_col_start_4 : Html.Attribute msg
+xl_tw_col_start_4 =
+    A.class "xl:tw-col-start-4"
+
+
+xl_tw_col_start_5 : Html.Attribute msg
+xl_tw_col_start_5 =
+    A.class "xl:tw-col-start-5"
+
+
+xl_tw_col_start_6 : Html.Attribute msg
+xl_tw_col_start_6 =
+    A.class "xl:tw-col-start-6"
+
+
+xl_tw_col_start_7 : Html.Attribute msg
+xl_tw_col_start_7 =
+    A.class "xl:tw-col-start-7"
+
+
+xl_tw_col_start_8 : Html.Attribute msg
+xl_tw_col_start_8 =
+    A.class "xl:tw-col-start-8"
+
+
+xl_tw_col_start_9 : Html.Attribute msg
+xl_tw_col_start_9 =
+    A.class "xl:tw-col-start-9"
+
+
+xl_tw_col_start_10 : Html.Attribute msg
+xl_tw_col_start_10 =
+    A.class "xl:tw-col-start-10"
+
+
+xl_tw_col_start_11 : Html.Attribute msg
+xl_tw_col_start_11 =
+    A.class "xl:tw-col-start-11"
+
+
+xl_tw_col_start_12 : Html.Attribute msg
+xl_tw_col_start_12 =
+    A.class "xl:tw-col-start-12"
+
+
+xl_tw_col_start_13 : Html.Attribute msg
+xl_tw_col_start_13 =
+    A.class "xl:tw-col-start-13"
+
+
+xl_tw_col_start_auto : Html.Attribute msg
+xl_tw_col_start_auto =
+    A.class "xl:tw-col-start-auto"
+
+
+xl_tw_col_end_1 : Html.Attribute msg
+xl_tw_col_end_1 =
+    A.class "xl:tw-col-end-1"
+
+
+xl_tw_col_end_2 : Html.Attribute msg
+xl_tw_col_end_2 =
+    A.class "xl:tw-col-end-2"
+
+
+xl_tw_col_end_3 : Html.Attribute msg
+xl_tw_col_end_3 =
+    A.class "xl:tw-col-end-3"
+
+
+xl_tw_col_end_4 : Html.Attribute msg
+xl_tw_col_end_4 =
+    A.class "xl:tw-col-end-4"
+
+
+xl_tw_col_end_5 : Html.Attribute msg
+xl_tw_col_end_5 =
+    A.class "xl:tw-col-end-5"
+
+
+xl_tw_col_end_6 : Html.Attribute msg
+xl_tw_col_end_6 =
+    A.class "xl:tw-col-end-6"
+
+
+xl_tw_col_end_7 : Html.Attribute msg
+xl_tw_col_end_7 =
+    A.class "xl:tw-col-end-7"
+
+
+xl_tw_col_end_8 : Html.Attribute msg
+xl_tw_col_end_8 =
+    A.class "xl:tw-col-end-8"
+
+
+xl_tw_col_end_9 : Html.Attribute msg
+xl_tw_col_end_9 =
+    A.class "xl:tw-col-end-9"
+
+
+xl_tw_col_end_10 : Html.Attribute msg
+xl_tw_col_end_10 =
+    A.class "xl:tw-col-end-10"
+
+
+xl_tw_col_end_11 : Html.Attribute msg
+xl_tw_col_end_11 =
+    A.class "xl:tw-col-end-11"
+
+
+xl_tw_col_end_12 : Html.Attribute msg
+xl_tw_col_end_12 =
+    A.class "xl:tw-col-end-12"
+
+
+xl_tw_col_end_13 : Html.Attribute msg
+xl_tw_col_end_13 =
+    A.class "xl:tw-col-end-13"
+
+
+xl_tw_col_end_auto : Html.Attribute msg
+xl_tw_col_end_auto =
+    A.class "xl:tw-col-end-auto"
+
+
+xl_tw_grid_rows_1 : Html.Attribute msg
+xl_tw_grid_rows_1 =
+    A.class "xl:tw-grid-rows-1"
+
+
+xl_tw_grid_rows_2 : Html.Attribute msg
+xl_tw_grid_rows_2 =
+    A.class "xl:tw-grid-rows-2"
+
+
+xl_tw_grid_rows_3 : Html.Attribute msg
+xl_tw_grid_rows_3 =
+    A.class "xl:tw-grid-rows-3"
+
+
+xl_tw_grid_rows_4 : Html.Attribute msg
+xl_tw_grid_rows_4 =
+    A.class "xl:tw-grid-rows-4"
+
+
+xl_tw_grid_rows_5 : Html.Attribute msg
+xl_tw_grid_rows_5 =
+    A.class "xl:tw-grid-rows-5"
+
+
+xl_tw_grid_rows_6 : Html.Attribute msg
+xl_tw_grid_rows_6 =
+    A.class "xl:tw-grid-rows-6"
+
+
+xl_tw_grid_rows_none : Html.Attribute msg
+xl_tw_grid_rows_none =
+    A.class "xl:tw-grid-rows-none"
+
+
+xl_tw_row_auto : Html.Attribute msg
+xl_tw_row_auto =
+    A.class "xl:tw-row-auto"
+
+
+xl_tw_row_span_1 : Html.Attribute msg
+xl_tw_row_span_1 =
+    A.class "xl:tw-row-span-1"
+
+
+xl_tw_row_span_2 : Html.Attribute msg
+xl_tw_row_span_2 =
+    A.class "xl:tw-row-span-2"
+
+
+xl_tw_row_span_3 : Html.Attribute msg
+xl_tw_row_span_3 =
+    A.class "xl:tw-row-span-3"
+
+
+xl_tw_row_span_4 : Html.Attribute msg
+xl_tw_row_span_4 =
+    A.class "xl:tw-row-span-4"
+
+
+xl_tw_row_span_5 : Html.Attribute msg
+xl_tw_row_span_5 =
+    A.class "xl:tw-row-span-5"
+
+
+xl_tw_row_span_6 : Html.Attribute msg
+xl_tw_row_span_6 =
+    A.class "xl:tw-row-span-6"
+
+
+xl_tw_row_start_1 : Html.Attribute msg
+xl_tw_row_start_1 =
+    A.class "xl:tw-row-start-1"
+
+
+xl_tw_row_start_2 : Html.Attribute msg
+xl_tw_row_start_2 =
+    A.class "xl:tw-row-start-2"
+
+
+xl_tw_row_start_3 : Html.Attribute msg
+xl_tw_row_start_3 =
+    A.class "xl:tw-row-start-3"
+
+
+xl_tw_row_start_4 : Html.Attribute msg
+xl_tw_row_start_4 =
+    A.class "xl:tw-row-start-4"
+
+
+xl_tw_row_start_5 : Html.Attribute msg
+xl_tw_row_start_5 =
+    A.class "xl:tw-row-start-5"
+
+
+xl_tw_row_start_6 : Html.Attribute msg
+xl_tw_row_start_6 =
+    A.class "xl:tw-row-start-6"
+
+
+xl_tw_row_start_7 : Html.Attribute msg
+xl_tw_row_start_7 =
+    A.class "xl:tw-row-start-7"
+
+
+xl_tw_row_start_auto : Html.Attribute msg
+xl_tw_row_start_auto =
+    A.class "xl:tw-row-start-auto"
+
+
+xl_tw_row_end_1 : Html.Attribute msg
+xl_tw_row_end_1 =
+    A.class "xl:tw-row-end-1"
+
+
+xl_tw_row_end_2 : Html.Attribute msg
+xl_tw_row_end_2 =
+    A.class "xl:tw-row-end-2"
+
+
+xl_tw_row_end_3 : Html.Attribute msg
+xl_tw_row_end_3 =
+    A.class "xl:tw-row-end-3"
+
+
+xl_tw_row_end_4 : Html.Attribute msg
+xl_tw_row_end_4 =
+    A.class "xl:tw-row-end-4"
+
+
+xl_tw_row_end_5 : Html.Attribute msg
+xl_tw_row_end_5 =
+    A.class "xl:tw-row-end-5"
+
+
+xl_tw_row_end_6 : Html.Attribute msg
+xl_tw_row_end_6 =
+    A.class "xl:tw-row-end-6"
+
+
+xl_tw_row_end_7 : Html.Attribute msg
+xl_tw_row_end_7 =
+    A.class "xl:tw-row-end-7"
+
+
+xl_tw_row_end_auto : Html.Attribute msg
+xl_tw_row_end_auto =
+    A.class "xl:tw-row-end-auto"
+
+
+xl_tw_transform : Html.Attribute msg
+xl_tw_transform =
+    A.class "xl:tw-transform"
+
+
+xl_tw_transform_none : Html.Attribute msg
+xl_tw_transform_none =
+    A.class "xl:tw-transform-none"
+
+
+xl_tw_origin_center : Html.Attribute msg
+xl_tw_origin_center =
+    A.class "xl:tw-origin-center"
+
+
+xl_tw_origin_top : Html.Attribute msg
+xl_tw_origin_top =
+    A.class "xl:tw-origin-top"
+
+
+xl_tw_origin_top_right : Html.Attribute msg
+xl_tw_origin_top_right =
+    A.class "xl:tw-origin-top-right"
+
+
+xl_tw_origin_right : Html.Attribute msg
+xl_tw_origin_right =
+    A.class "xl:tw-origin-right"
+
+
+xl_tw_origin_bottom_right : Html.Attribute msg
+xl_tw_origin_bottom_right =
+    A.class "xl:tw-origin-bottom-right"
+
+
+xl_tw_origin_bottom : Html.Attribute msg
+xl_tw_origin_bottom =
+    A.class "xl:tw-origin-bottom"
+
+
+xl_tw_origin_bottom_left : Html.Attribute msg
+xl_tw_origin_bottom_left =
+    A.class "xl:tw-origin-bottom-left"
+
+
+xl_tw_origin_left : Html.Attribute msg
+xl_tw_origin_left =
+    A.class "xl:tw-origin-left"
+
+
+xl_tw_origin_top_left : Html.Attribute msg
+xl_tw_origin_top_left =
+    A.class "xl:tw-origin-top-left"
+
+
+xl_tw_scale_0 : Html.Attribute msg
+xl_tw_scale_0 =
+    A.class "xl:tw-scale-0"
+
+
+xl_tw_scale_50 : Html.Attribute msg
+xl_tw_scale_50 =
+    A.class "xl:tw-scale-50"
+
+
+xl_tw_scale_75 : Html.Attribute msg
+xl_tw_scale_75 =
+    A.class "xl:tw-scale-75"
+
+
+xl_tw_scale_90 : Html.Attribute msg
+xl_tw_scale_90 =
+    A.class "xl:tw-scale-90"
+
+
+xl_tw_scale_95 : Html.Attribute msg
+xl_tw_scale_95 =
+    A.class "xl:tw-scale-95"
+
+
+xl_tw_scale_100 : Html.Attribute msg
+xl_tw_scale_100 =
+    A.class "xl:tw-scale-100"
+
+
+xl_tw_scale_105 : Html.Attribute msg
+xl_tw_scale_105 =
+    A.class "xl:tw-scale-105"
+
+
+xl_tw_scale_110 : Html.Attribute msg
+xl_tw_scale_110 =
+    A.class "xl:tw-scale-110"
+
+
+xl_tw_scale_125 : Html.Attribute msg
+xl_tw_scale_125 =
+    A.class "xl:tw-scale-125"
+
+
+xl_tw_scale_150 : Html.Attribute msg
+xl_tw_scale_150 =
+    A.class "xl:tw-scale-150"
+
+
+xl_tw_scale_x_0 : Html.Attribute msg
+xl_tw_scale_x_0 =
+    A.class "xl:tw-scale-x-0"
+
+
+xl_tw_scale_x_50 : Html.Attribute msg
+xl_tw_scale_x_50 =
+    A.class "xl:tw-scale-x-50"
+
+
+xl_tw_scale_x_75 : Html.Attribute msg
+xl_tw_scale_x_75 =
+    A.class "xl:tw-scale-x-75"
+
+
+xl_tw_scale_x_90 : Html.Attribute msg
+xl_tw_scale_x_90 =
+    A.class "xl:tw-scale-x-90"
+
+
+xl_tw_scale_x_95 : Html.Attribute msg
+xl_tw_scale_x_95 =
+    A.class "xl:tw-scale-x-95"
+
+
+xl_tw_scale_x_100 : Html.Attribute msg
+xl_tw_scale_x_100 =
+    A.class "xl:tw-scale-x-100"
+
+
+xl_tw_scale_x_105 : Html.Attribute msg
+xl_tw_scale_x_105 =
+    A.class "xl:tw-scale-x-105"
+
+
+xl_tw_scale_x_110 : Html.Attribute msg
+xl_tw_scale_x_110 =
+    A.class "xl:tw-scale-x-110"
+
+
+xl_tw_scale_x_125 : Html.Attribute msg
+xl_tw_scale_x_125 =
+    A.class "xl:tw-scale-x-125"
+
+
+xl_tw_scale_x_150 : Html.Attribute msg
+xl_tw_scale_x_150 =
+    A.class "xl:tw-scale-x-150"
+
+
+xl_tw_scale_y_0 : Html.Attribute msg
+xl_tw_scale_y_0 =
+    A.class "xl:tw-scale-y-0"
+
+
+xl_tw_scale_y_50 : Html.Attribute msg
+xl_tw_scale_y_50 =
+    A.class "xl:tw-scale-y-50"
+
+
+xl_tw_scale_y_75 : Html.Attribute msg
+xl_tw_scale_y_75 =
+    A.class "xl:tw-scale-y-75"
+
+
+xl_tw_scale_y_90 : Html.Attribute msg
+xl_tw_scale_y_90 =
+    A.class "xl:tw-scale-y-90"
+
+
+xl_tw_scale_y_95 : Html.Attribute msg
+xl_tw_scale_y_95 =
+    A.class "xl:tw-scale-y-95"
+
+
+xl_tw_scale_y_100 : Html.Attribute msg
+xl_tw_scale_y_100 =
+    A.class "xl:tw-scale-y-100"
+
+
+xl_tw_scale_y_105 : Html.Attribute msg
+xl_tw_scale_y_105 =
+    A.class "xl:tw-scale-y-105"
+
+
+xl_tw_scale_y_110 : Html.Attribute msg
+xl_tw_scale_y_110 =
+    A.class "xl:tw-scale-y-110"
+
+
+xl_tw_scale_y_125 : Html.Attribute msg
+xl_tw_scale_y_125 =
+    A.class "xl:tw-scale-y-125"
+
+
+xl_tw_scale_y_150 : Html.Attribute msg
+xl_tw_scale_y_150 =
+    A.class "xl:tw-scale-y-150"
+
+
+xl_hover_tw_scale_0 : Html.Attribute msg
+xl_hover_tw_scale_0 =
+    A.class "xl:hover:tw-scale-0"
+
+
+xl_hover_tw_scale_50 : Html.Attribute msg
+xl_hover_tw_scale_50 =
+    A.class "xl:hover:tw-scale-50"
+
+
+xl_hover_tw_scale_75 : Html.Attribute msg
+xl_hover_tw_scale_75 =
+    A.class "xl:hover:tw-scale-75"
+
+
+xl_hover_tw_scale_90 : Html.Attribute msg
+xl_hover_tw_scale_90 =
+    A.class "xl:hover:tw-scale-90"
+
+
+xl_hover_tw_scale_95 : Html.Attribute msg
+xl_hover_tw_scale_95 =
+    A.class "xl:hover:tw-scale-95"
+
+
+xl_hover_tw_scale_100 : Html.Attribute msg
+xl_hover_tw_scale_100 =
+    A.class "xl:hover:tw-scale-100"
+
+
+xl_hover_tw_scale_105 : Html.Attribute msg
+xl_hover_tw_scale_105 =
+    A.class "xl:hover:tw-scale-105"
+
+
+xl_hover_tw_scale_110 : Html.Attribute msg
+xl_hover_tw_scale_110 =
+    A.class "xl:hover:tw-scale-110"
+
+
+xl_hover_tw_scale_125 : Html.Attribute msg
+xl_hover_tw_scale_125 =
+    A.class "xl:hover:tw-scale-125"
+
+
+xl_hover_tw_scale_150 : Html.Attribute msg
+xl_hover_tw_scale_150 =
+    A.class "xl:hover:tw-scale-150"
+
+
+xl_hover_tw_scale_x_0 : Html.Attribute msg
+xl_hover_tw_scale_x_0 =
+    A.class "xl:hover:tw-scale-x-0"
+
+
+xl_hover_tw_scale_x_50 : Html.Attribute msg
+xl_hover_tw_scale_x_50 =
+    A.class "xl:hover:tw-scale-x-50"
+
+
+xl_hover_tw_scale_x_75 : Html.Attribute msg
+xl_hover_tw_scale_x_75 =
+    A.class "xl:hover:tw-scale-x-75"
+
+
+xl_hover_tw_scale_x_90 : Html.Attribute msg
+xl_hover_tw_scale_x_90 =
+    A.class "xl:hover:tw-scale-x-90"
+
+
+xl_hover_tw_scale_x_95 : Html.Attribute msg
+xl_hover_tw_scale_x_95 =
+    A.class "xl:hover:tw-scale-x-95"
+
+
+xl_hover_tw_scale_x_100 : Html.Attribute msg
+xl_hover_tw_scale_x_100 =
+    A.class "xl:hover:tw-scale-x-100"
+
+
+xl_hover_tw_scale_x_105 : Html.Attribute msg
+xl_hover_tw_scale_x_105 =
+    A.class "xl:hover:tw-scale-x-105"
+
+
+xl_hover_tw_scale_x_110 : Html.Attribute msg
+xl_hover_tw_scale_x_110 =
+    A.class "xl:hover:tw-scale-x-110"
+
+
+xl_hover_tw_scale_x_125 : Html.Attribute msg
+xl_hover_tw_scale_x_125 =
+    A.class "xl:hover:tw-scale-x-125"
+
+
+xl_hover_tw_scale_x_150 : Html.Attribute msg
+xl_hover_tw_scale_x_150 =
+    A.class "xl:hover:tw-scale-x-150"
+
+
+xl_hover_tw_scale_y_0 : Html.Attribute msg
+xl_hover_tw_scale_y_0 =
+    A.class "xl:hover:tw-scale-y-0"
+
+
+xl_hover_tw_scale_y_50 : Html.Attribute msg
+xl_hover_tw_scale_y_50 =
+    A.class "xl:hover:tw-scale-y-50"
+
+
+xl_hover_tw_scale_y_75 : Html.Attribute msg
+xl_hover_tw_scale_y_75 =
+    A.class "xl:hover:tw-scale-y-75"
+
+
+xl_hover_tw_scale_y_90 : Html.Attribute msg
+xl_hover_tw_scale_y_90 =
+    A.class "xl:hover:tw-scale-y-90"
+
+
+xl_hover_tw_scale_y_95 : Html.Attribute msg
+xl_hover_tw_scale_y_95 =
+    A.class "xl:hover:tw-scale-y-95"
+
+
+xl_hover_tw_scale_y_100 : Html.Attribute msg
+xl_hover_tw_scale_y_100 =
+    A.class "xl:hover:tw-scale-y-100"
+
+
+xl_hover_tw_scale_y_105 : Html.Attribute msg
+xl_hover_tw_scale_y_105 =
+    A.class "xl:hover:tw-scale-y-105"
+
+
+xl_hover_tw_scale_y_110 : Html.Attribute msg
+xl_hover_tw_scale_y_110 =
+    A.class "xl:hover:tw-scale-y-110"
+
+
+xl_hover_tw_scale_y_125 : Html.Attribute msg
+xl_hover_tw_scale_y_125 =
+    A.class "xl:hover:tw-scale-y-125"
+
+
+xl_hover_tw_scale_y_150 : Html.Attribute msg
+xl_hover_tw_scale_y_150 =
+    A.class "xl:hover:tw-scale-y-150"
+
+
+xl_focus_tw_scale_0 : Html.Attribute msg
+xl_focus_tw_scale_0 =
+    A.class "xl:focus:tw-scale-0"
+
+
+xl_focus_tw_scale_50 : Html.Attribute msg
+xl_focus_tw_scale_50 =
+    A.class "xl:focus:tw-scale-50"
+
+
+xl_focus_tw_scale_75 : Html.Attribute msg
+xl_focus_tw_scale_75 =
+    A.class "xl:focus:tw-scale-75"
+
+
+xl_focus_tw_scale_90 : Html.Attribute msg
+xl_focus_tw_scale_90 =
+    A.class "xl:focus:tw-scale-90"
+
+
+xl_focus_tw_scale_95 : Html.Attribute msg
+xl_focus_tw_scale_95 =
+    A.class "xl:focus:tw-scale-95"
+
+
+xl_focus_tw_scale_100 : Html.Attribute msg
+xl_focus_tw_scale_100 =
+    A.class "xl:focus:tw-scale-100"
+
+
+xl_focus_tw_scale_105 : Html.Attribute msg
+xl_focus_tw_scale_105 =
+    A.class "xl:focus:tw-scale-105"
+
+
+xl_focus_tw_scale_110 : Html.Attribute msg
+xl_focus_tw_scale_110 =
+    A.class "xl:focus:tw-scale-110"
+
+
+xl_focus_tw_scale_125 : Html.Attribute msg
+xl_focus_tw_scale_125 =
+    A.class "xl:focus:tw-scale-125"
+
+
+xl_focus_tw_scale_150 : Html.Attribute msg
+xl_focus_tw_scale_150 =
+    A.class "xl:focus:tw-scale-150"
+
+
+xl_focus_tw_scale_x_0 : Html.Attribute msg
+xl_focus_tw_scale_x_0 =
+    A.class "xl:focus:tw-scale-x-0"
+
+
+xl_focus_tw_scale_x_50 : Html.Attribute msg
+xl_focus_tw_scale_x_50 =
+    A.class "xl:focus:tw-scale-x-50"
+
+
+xl_focus_tw_scale_x_75 : Html.Attribute msg
+xl_focus_tw_scale_x_75 =
+    A.class "xl:focus:tw-scale-x-75"
+
+
+xl_focus_tw_scale_x_90 : Html.Attribute msg
+xl_focus_tw_scale_x_90 =
+    A.class "xl:focus:tw-scale-x-90"
+
+
+xl_focus_tw_scale_x_95 : Html.Attribute msg
+xl_focus_tw_scale_x_95 =
+    A.class "xl:focus:tw-scale-x-95"
+
+
+xl_focus_tw_scale_x_100 : Html.Attribute msg
+xl_focus_tw_scale_x_100 =
+    A.class "xl:focus:tw-scale-x-100"
+
+
+xl_focus_tw_scale_x_105 : Html.Attribute msg
+xl_focus_tw_scale_x_105 =
+    A.class "xl:focus:tw-scale-x-105"
+
+
+xl_focus_tw_scale_x_110 : Html.Attribute msg
+xl_focus_tw_scale_x_110 =
+    A.class "xl:focus:tw-scale-x-110"
+
+
+xl_focus_tw_scale_x_125 : Html.Attribute msg
+xl_focus_tw_scale_x_125 =
+    A.class "xl:focus:tw-scale-x-125"
+
+
+xl_focus_tw_scale_x_150 : Html.Attribute msg
+xl_focus_tw_scale_x_150 =
+    A.class "xl:focus:tw-scale-x-150"
+
+
+xl_focus_tw_scale_y_0 : Html.Attribute msg
+xl_focus_tw_scale_y_0 =
+    A.class "xl:focus:tw-scale-y-0"
+
+
+xl_focus_tw_scale_y_50 : Html.Attribute msg
+xl_focus_tw_scale_y_50 =
+    A.class "xl:focus:tw-scale-y-50"
+
+
+xl_focus_tw_scale_y_75 : Html.Attribute msg
+xl_focus_tw_scale_y_75 =
+    A.class "xl:focus:tw-scale-y-75"
+
+
+xl_focus_tw_scale_y_90 : Html.Attribute msg
+xl_focus_tw_scale_y_90 =
+    A.class "xl:focus:tw-scale-y-90"
+
+
+xl_focus_tw_scale_y_95 : Html.Attribute msg
+xl_focus_tw_scale_y_95 =
+    A.class "xl:focus:tw-scale-y-95"
+
+
+xl_focus_tw_scale_y_100 : Html.Attribute msg
+xl_focus_tw_scale_y_100 =
+    A.class "xl:focus:tw-scale-y-100"
+
+
+xl_focus_tw_scale_y_105 : Html.Attribute msg
+xl_focus_tw_scale_y_105 =
+    A.class "xl:focus:tw-scale-y-105"
+
+
+xl_focus_tw_scale_y_110 : Html.Attribute msg
+xl_focus_tw_scale_y_110 =
+    A.class "xl:focus:tw-scale-y-110"
+
+
+xl_focus_tw_scale_y_125 : Html.Attribute msg
+xl_focus_tw_scale_y_125 =
+    A.class "xl:focus:tw-scale-y-125"
+
+
+xl_focus_tw_scale_y_150 : Html.Attribute msg
+xl_focus_tw_scale_y_150 =
+    A.class "xl:focus:tw-scale-y-150"
+
+
+xl_tw_rotate_0 : Html.Attribute msg
+xl_tw_rotate_0 =
+    A.class "xl:tw-rotate-0"
+
+
+xl_tw_rotate_45 : Html.Attribute msg
+xl_tw_rotate_45 =
+    A.class "xl:tw-rotate-45"
+
+
+xl_tw_rotate_90 : Html.Attribute msg
+xl_tw_rotate_90 =
+    A.class "xl:tw-rotate-90"
+
+
+xl_tw_rotate_180 : Html.Attribute msg
+xl_tw_rotate_180 =
+    A.class "xl:tw-rotate-180"
+
+
+xl_tw_neg_rotate_180 : Html.Attribute msg
+xl_tw_neg_rotate_180 =
+    A.class "xl:tw--rotate-180"
+
+
+xl_tw_neg_rotate_90 : Html.Attribute msg
+xl_tw_neg_rotate_90 =
+    A.class "xl:tw--rotate-90"
+
+
+xl_tw_neg_rotate_45 : Html.Attribute msg
+xl_tw_neg_rotate_45 =
+    A.class "xl:tw--rotate-45"
+
+
+xl_hover_tw_rotate_0 : Html.Attribute msg
+xl_hover_tw_rotate_0 =
+    A.class "xl:hover:tw-rotate-0"
+
+
+xl_hover_tw_rotate_45 : Html.Attribute msg
+xl_hover_tw_rotate_45 =
+    A.class "xl:hover:tw-rotate-45"
+
+
+xl_hover_tw_rotate_90 : Html.Attribute msg
+xl_hover_tw_rotate_90 =
+    A.class "xl:hover:tw-rotate-90"
+
+
+xl_hover_tw_rotate_180 : Html.Attribute msg
+xl_hover_tw_rotate_180 =
+    A.class "xl:hover:tw-rotate-180"
+
+
+xl_hover_tw_neg_rotate_180 : Html.Attribute msg
+xl_hover_tw_neg_rotate_180 =
+    A.class "xl:hover:tw--rotate-180"
+
+
+xl_hover_tw_neg_rotate_90 : Html.Attribute msg
+xl_hover_tw_neg_rotate_90 =
+    A.class "xl:hover:tw--rotate-90"
+
+
+xl_hover_tw_neg_rotate_45 : Html.Attribute msg
+xl_hover_tw_neg_rotate_45 =
+    A.class "xl:hover:tw--rotate-45"
+
+
+xl_focus_tw_rotate_0 : Html.Attribute msg
+xl_focus_tw_rotate_0 =
+    A.class "xl:focus:tw-rotate-0"
+
+
+xl_focus_tw_rotate_45 : Html.Attribute msg
+xl_focus_tw_rotate_45 =
+    A.class "xl:focus:tw-rotate-45"
+
+
+xl_focus_tw_rotate_90 : Html.Attribute msg
+xl_focus_tw_rotate_90 =
+    A.class "xl:focus:tw-rotate-90"
+
+
+xl_focus_tw_rotate_180 : Html.Attribute msg
+xl_focus_tw_rotate_180 =
+    A.class "xl:focus:tw-rotate-180"
+
+
+xl_focus_tw_neg_rotate_180 : Html.Attribute msg
+xl_focus_tw_neg_rotate_180 =
+    A.class "xl:focus:tw--rotate-180"
+
+
+xl_focus_tw_neg_rotate_90 : Html.Attribute msg
+xl_focus_tw_neg_rotate_90 =
+    A.class "xl:focus:tw--rotate-90"
+
+
+xl_focus_tw_neg_rotate_45 : Html.Attribute msg
+xl_focus_tw_neg_rotate_45 =
+    A.class "xl:focus:tw--rotate-45"
+
+
+xl_tw_translate_x_0 : Html.Attribute msg
+xl_tw_translate_x_0 =
+    A.class "xl:tw-translate-x-0"
+
+
+xl_tw_translate_x_1 : Html.Attribute msg
+xl_tw_translate_x_1 =
+    A.class "xl:tw-translate-x-1"
+
+
+xl_tw_translate_x_2 : Html.Attribute msg
+xl_tw_translate_x_2 =
+    A.class "xl:tw-translate-x-2"
+
+
+xl_tw_translate_x_3 : Html.Attribute msg
+xl_tw_translate_x_3 =
+    A.class "xl:tw-translate-x-3"
+
+
+xl_tw_translate_x_4 : Html.Attribute msg
+xl_tw_translate_x_4 =
+    A.class "xl:tw-translate-x-4"
+
+
+xl_tw_translate_x_5 : Html.Attribute msg
+xl_tw_translate_x_5 =
+    A.class "xl:tw-translate-x-5"
+
+
+xl_tw_translate_x_6 : Html.Attribute msg
+xl_tw_translate_x_6 =
+    A.class "xl:tw-translate-x-6"
+
+
+xl_tw_translate_x_8 : Html.Attribute msg
+xl_tw_translate_x_8 =
+    A.class "xl:tw-translate-x-8"
+
+
+xl_tw_translate_x_10 : Html.Attribute msg
+xl_tw_translate_x_10 =
+    A.class "xl:tw-translate-x-10"
+
+
+xl_tw_translate_x_12 : Html.Attribute msg
+xl_tw_translate_x_12 =
+    A.class "xl:tw-translate-x-12"
+
+
+xl_tw_translate_x_16 : Html.Attribute msg
+xl_tw_translate_x_16 =
+    A.class "xl:tw-translate-x-16"
+
+
+xl_tw_translate_x_20 : Html.Attribute msg
+xl_tw_translate_x_20 =
+    A.class "xl:tw-translate-x-20"
+
+
+xl_tw_translate_x_24 : Html.Attribute msg
+xl_tw_translate_x_24 =
+    A.class "xl:tw-translate-x-24"
+
+
+xl_tw_translate_x_32 : Html.Attribute msg
+xl_tw_translate_x_32 =
+    A.class "xl:tw-translate-x-32"
+
+
+xl_tw_translate_x_40 : Html.Attribute msg
+xl_tw_translate_x_40 =
+    A.class "xl:tw-translate-x-40"
+
+
+xl_tw_translate_x_48 : Html.Attribute msg
+xl_tw_translate_x_48 =
+    A.class "xl:tw-translate-x-48"
+
+
+xl_tw_translate_x_56 : Html.Attribute msg
+xl_tw_translate_x_56 =
+    A.class "xl:tw-translate-x-56"
+
+
+xl_tw_translate_x_64 : Html.Attribute msg
+xl_tw_translate_x_64 =
+    A.class "xl:tw-translate-x-64"
+
+
+xl_tw_translate_x_px : Html.Attribute msg
+xl_tw_translate_x_px =
+    A.class "xl:tw-translate-x-px"
+
+
+xl_tw_neg_translate_x_1 : Html.Attribute msg
+xl_tw_neg_translate_x_1 =
+    A.class "xl:tw--translate-x-1"
+
+
+xl_tw_neg_translate_x_2 : Html.Attribute msg
+xl_tw_neg_translate_x_2 =
+    A.class "xl:tw--translate-x-2"
+
+
+xl_tw_neg_translate_x_3 : Html.Attribute msg
+xl_tw_neg_translate_x_3 =
+    A.class "xl:tw--translate-x-3"
+
+
+xl_tw_neg_translate_x_4 : Html.Attribute msg
+xl_tw_neg_translate_x_4 =
+    A.class "xl:tw--translate-x-4"
+
+
+xl_tw_neg_translate_x_5 : Html.Attribute msg
+xl_tw_neg_translate_x_5 =
+    A.class "xl:tw--translate-x-5"
+
+
+xl_tw_neg_translate_x_6 : Html.Attribute msg
+xl_tw_neg_translate_x_6 =
+    A.class "xl:tw--translate-x-6"
+
+
+xl_tw_neg_translate_x_8 : Html.Attribute msg
+xl_tw_neg_translate_x_8 =
+    A.class "xl:tw--translate-x-8"
+
+
+xl_tw_neg_translate_x_10 : Html.Attribute msg
+xl_tw_neg_translate_x_10 =
+    A.class "xl:tw--translate-x-10"
+
+
+xl_tw_neg_translate_x_12 : Html.Attribute msg
+xl_tw_neg_translate_x_12 =
+    A.class "xl:tw--translate-x-12"
+
+
+xl_tw_neg_translate_x_16 : Html.Attribute msg
+xl_tw_neg_translate_x_16 =
+    A.class "xl:tw--translate-x-16"
+
+
+xl_tw_neg_translate_x_20 : Html.Attribute msg
+xl_tw_neg_translate_x_20 =
+    A.class "xl:tw--translate-x-20"
+
+
+xl_tw_neg_translate_x_24 : Html.Attribute msg
+xl_tw_neg_translate_x_24 =
+    A.class "xl:tw--translate-x-24"
+
+
+xl_tw_neg_translate_x_32 : Html.Attribute msg
+xl_tw_neg_translate_x_32 =
+    A.class "xl:tw--translate-x-32"
+
+
+xl_tw_neg_translate_x_40 : Html.Attribute msg
+xl_tw_neg_translate_x_40 =
+    A.class "xl:tw--translate-x-40"
+
+
+xl_tw_neg_translate_x_48 : Html.Attribute msg
+xl_tw_neg_translate_x_48 =
+    A.class "xl:tw--translate-x-48"
+
+
+xl_tw_neg_translate_x_56 : Html.Attribute msg
+xl_tw_neg_translate_x_56 =
+    A.class "xl:tw--translate-x-56"
+
+
+xl_tw_neg_translate_x_64 : Html.Attribute msg
+xl_tw_neg_translate_x_64 =
+    A.class "xl:tw--translate-x-64"
+
+
+xl_tw_neg_translate_x_px : Html.Attribute msg
+xl_tw_neg_translate_x_px =
+    A.class "xl:tw--translate-x-px"
+
+
+xl_tw_neg_translate_x_full : Html.Attribute msg
+xl_tw_neg_translate_x_full =
+    A.class "xl:tw--translate-x-full"
+
+
+xl_tw_neg_translate_x_1over2 : Html.Attribute msg
+xl_tw_neg_translate_x_1over2 =
+    A.class "xl:tw--translate-x-1/2"
+
+
+xl_tw_translate_x_1over2 : Html.Attribute msg
+xl_tw_translate_x_1over2 =
+    A.class "xl:tw-translate-x-1/2"
+
+
+xl_tw_translate_x_full : Html.Attribute msg
+xl_tw_translate_x_full =
+    A.class "xl:tw-translate-x-full"
+
+
+xl_tw_translate_y_0 : Html.Attribute msg
+xl_tw_translate_y_0 =
+    A.class "xl:tw-translate-y-0"
+
+
+xl_tw_translate_y_1 : Html.Attribute msg
+xl_tw_translate_y_1 =
+    A.class "xl:tw-translate-y-1"
+
+
+xl_tw_translate_y_2 : Html.Attribute msg
+xl_tw_translate_y_2 =
+    A.class "xl:tw-translate-y-2"
+
+
+xl_tw_translate_y_3 : Html.Attribute msg
+xl_tw_translate_y_3 =
+    A.class "xl:tw-translate-y-3"
+
+
+xl_tw_translate_y_4 : Html.Attribute msg
+xl_tw_translate_y_4 =
+    A.class "xl:tw-translate-y-4"
+
+
+xl_tw_translate_y_5 : Html.Attribute msg
+xl_tw_translate_y_5 =
+    A.class "xl:tw-translate-y-5"
+
+
+xl_tw_translate_y_6 : Html.Attribute msg
+xl_tw_translate_y_6 =
+    A.class "xl:tw-translate-y-6"
+
+
+xl_tw_translate_y_8 : Html.Attribute msg
+xl_tw_translate_y_8 =
+    A.class "xl:tw-translate-y-8"
+
+
+xl_tw_translate_y_10 : Html.Attribute msg
+xl_tw_translate_y_10 =
+    A.class "xl:tw-translate-y-10"
+
+
+xl_tw_translate_y_12 : Html.Attribute msg
+xl_tw_translate_y_12 =
+    A.class "xl:tw-translate-y-12"
+
+
+xl_tw_translate_y_16 : Html.Attribute msg
+xl_tw_translate_y_16 =
+    A.class "xl:tw-translate-y-16"
+
+
+xl_tw_translate_y_20 : Html.Attribute msg
+xl_tw_translate_y_20 =
+    A.class "xl:tw-translate-y-20"
+
+
+xl_tw_translate_y_24 : Html.Attribute msg
+xl_tw_translate_y_24 =
+    A.class "xl:tw-translate-y-24"
+
+
+xl_tw_translate_y_32 : Html.Attribute msg
+xl_tw_translate_y_32 =
+    A.class "xl:tw-translate-y-32"
+
+
+xl_tw_translate_y_40 : Html.Attribute msg
+xl_tw_translate_y_40 =
+    A.class "xl:tw-translate-y-40"
+
+
+xl_tw_translate_y_48 : Html.Attribute msg
+xl_tw_translate_y_48 =
+    A.class "xl:tw-translate-y-48"
+
+
+xl_tw_translate_y_56 : Html.Attribute msg
+xl_tw_translate_y_56 =
+    A.class "xl:tw-translate-y-56"
+
+
+xl_tw_translate_y_64 : Html.Attribute msg
+xl_tw_translate_y_64 =
+    A.class "xl:tw-translate-y-64"
+
+
+xl_tw_translate_y_px : Html.Attribute msg
+xl_tw_translate_y_px =
+    A.class "xl:tw-translate-y-px"
+
+
+xl_tw_neg_translate_y_1 : Html.Attribute msg
+xl_tw_neg_translate_y_1 =
+    A.class "xl:tw--translate-y-1"
+
+
+xl_tw_neg_translate_y_2 : Html.Attribute msg
+xl_tw_neg_translate_y_2 =
+    A.class "xl:tw--translate-y-2"
+
+
+xl_tw_neg_translate_y_3 : Html.Attribute msg
+xl_tw_neg_translate_y_3 =
+    A.class "xl:tw--translate-y-3"
+
+
+xl_tw_neg_translate_y_4 : Html.Attribute msg
+xl_tw_neg_translate_y_4 =
+    A.class "xl:tw--translate-y-4"
+
+
+xl_tw_neg_translate_y_5 : Html.Attribute msg
+xl_tw_neg_translate_y_5 =
+    A.class "xl:tw--translate-y-5"
+
+
+xl_tw_neg_translate_y_6 : Html.Attribute msg
+xl_tw_neg_translate_y_6 =
+    A.class "xl:tw--translate-y-6"
+
+
+xl_tw_neg_translate_y_8 : Html.Attribute msg
+xl_tw_neg_translate_y_8 =
+    A.class "xl:tw--translate-y-8"
+
+
+xl_tw_neg_translate_y_10 : Html.Attribute msg
+xl_tw_neg_translate_y_10 =
+    A.class "xl:tw--translate-y-10"
+
+
+xl_tw_neg_translate_y_12 : Html.Attribute msg
+xl_tw_neg_translate_y_12 =
+    A.class "xl:tw--translate-y-12"
+
+
+xl_tw_neg_translate_y_16 : Html.Attribute msg
+xl_tw_neg_translate_y_16 =
+    A.class "xl:tw--translate-y-16"
+
+
+xl_tw_neg_translate_y_20 : Html.Attribute msg
+xl_tw_neg_translate_y_20 =
+    A.class "xl:tw--translate-y-20"
+
+
+xl_tw_neg_translate_y_24 : Html.Attribute msg
+xl_tw_neg_translate_y_24 =
+    A.class "xl:tw--translate-y-24"
+
+
+xl_tw_neg_translate_y_32 : Html.Attribute msg
+xl_tw_neg_translate_y_32 =
+    A.class "xl:tw--translate-y-32"
+
+
+xl_tw_neg_translate_y_40 : Html.Attribute msg
+xl_tw_neg_translate_y_40 =
+    A.class "xl:tw--translate-y-40"
+
+
+xl_tw_neg_translate_y_48 : Html.Attribute msg
+xl_tw_neg_translate_y_48 =
+    A.class "xl:tw--translate-y-48"
+
+
+xl_tw_neg_translate_y_56 : Html.Attribute msg
+xl_tw_neg_translate_y_56 =
+    A.class "xl:tw--translate-y-56"
+
+
+xl_tw_neg_translate_y_64 : Html.Attribute msg
+xl_tw_neg_translate_y_64 =
+    A.class "xl:tw--translate-y-64"
+
+
+xl_tw_neg_translate_y_px : Html.Attribute msg
+xl_tw_neg_translate_y_px =
+    A.class "xl:tw--translate-y-px"
+
+
+xl_tw_neg_translate_y_full : Html.Attribute msg
+xl_tw_neg_translate_y_full =
+    A.class "xl:tw--translate-y-full"
+
+
+xl_tw_neg_translate_y_1over2 : Html.Attribute msg
+xl_tw_neg_translate_y_1over2 =
+    A.class "xl:tw--translate-y-1/2"
+
+
+xl_tw_translate_y_1over2 : Html.Attribute msg
+xl_tw_translate_y_1over2 =
+    A.class "xl:tw-translate-y-1/2"
+
+
+xl_tw_translate_y_full : Html.Attribute msg
+xl_tw_translate_y_full =
+    A.class "xl:tw-translate-y-full"
+
+
+xl_hover_tw_translate_x_0 : Html.Attribute msg
+xl_hover_tw_translate_x_0 =
+    A.class "xl:hover:tw-translate-x-0"
+
+
+xl_hover_tw_translate_x_1 : Html.Attribute msg
+xl_hover_tw_translate_x_1 =
+    A.class "xl:hover:tw-translate-x-1"
+
+
+xl_hover_tw_translate_x_2 : Html.Attribute msg
+xl_hover_tw_translate_x_2 =
+    A.class "xl:hover:tw-translate-x-2"
+
+
+xl_hover_tw_translate_x_3 : Html.Attribute msg
+xl_hover_tw_translate_x_3 =
+    A.class "xl:hover:tw-translate-x-3"
+
+
+xl_hover_tw_translate_x_4 : Html.Attribute msg
+xl_hover_tw_translate_x_4 =
+    A.class "xl:hover:tw-translate-x-4"
+
+
+xl_hover_tw_translate_x_5 : Html.Attribute msg
+xl_hover_tw_translate_x_5 =
+    A.class "xl:hover:tw-translate-x-5"
+
+
+xl_hover_tw_translate_x_6 : Html.Attribute msg
+xl_hover_tw_translate_x_6 =
+    A.class "xl:hover:tw-translate-x-6"
+
+
+xl_hover_tw_translate_x_8 : Html.Attribute msg
+xl_hover_tw_translate_x_8 =
+    A.class "xl:hover:tw-translate-x-8"
+
+
+xl_hover_tw_translate_x_10 : Html.Attribute msg
+xl_hover_tw_translate_x_10 =
+    A.class "xl:hover:tw-translate-x-10"
+
+
+xl_hover_tw_translate_x_12 : Html.Attribute msg
+xl_hover_tw_translate_x_12 =
+    A.class "xl:hover:tw-translate-x-12"
+
+
+xl_hover_tw_translate_x_16 : Html.Attribute msg
+xl_hover_tw_translate_x_16 =
+    A.class "xl:hover:tw-translate-x-16"
+
+
+xl_hover_tw_translate_x_20 : Html.Attribute msg
+xl_hover_tw_translate_x_20 =
+    A.class "xl:hover:tw-translate-x-20"
+
+
+xl_hover_tw_translate_x_24 : Html.Attribute msg
+xl_hover_tw_translate_x_24 =
+    A.class "xl:hover:tw-translate-x-24"
+
+
+xl_hover_tw_translate_x_32 : Html.Attribute msg
+xl_hover_tw_translate_x_32 =
+    A.class "xl:hover:tw-translate-x-32"
+
+
+xl_hover_tw_translate_x_40 : Html.Attribute msg
+xl_hover_tw_translate_x_40 =
+    A.class "xl:hover:tw-translate-x-40"
+
+
+xl_hover_tw_translate_x_48 : Html.Attribute msg
+xl_hover_tw_translate_x_48 =
+    A.class "xl:hover:tw-translate-x-48"
+
+
+xl_hover_tw_translate_x_56 : Html.Attribute msg
+xl_hover_tw_translate_x_56 =
+    A.class "xl:hover:tw-translate-x-56"
+
+
+xl_hover_tw_translate_x_64 : Html.Attribute msg
+xl_hover_tw_translate_x_64 =
+    A.class "xl:hover:tw-translate-x-64"
+
+
+xl_hover_tw_translate_x_px : Html.Attribute msg
+xl_hover_tw_translate_x_px =
+    A.class "xl:hover:tw-translate-x-px"
+
+
+xl_hover_tw_neg_translate_x_1 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_1 =
+    A.class "xl:hover:tw--translate-x-1"
+
+
+xl_hover_tw_neg_translate_x_2 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_2 =
+    A.class "xl:hover:tw--translate-x-2"
+
+
+xl_hover_tw_neg_translate_x_3 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_3 =
+    A.class "xl:hover:tw--translate-x-3"
+
+
+xl_hover_tw_neg_translate_x_4 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_4 =
+    A.class "xl:hover:tw--translate-x-4"
+
+
+xl_hover_tw_neg_translate_x_5 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_5 =
+    A.class "xl:hover:tw--translate-x-5"
+
+
+xl_hover_tw_neg_translate_x_6 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_6 =
+    A.class "xl:hover:tw--translate-x-6"
+
+
+xl_hover_tw_neg_translate_x_8 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_8 =
+    A.class "xl:hover:tw--translate-x-8"
+
+
+xl_hover_tw_neg_translate_x_10 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_10 =
+    A.class "xl:hover:tw--translate-x-10"
+
+
+xl_hover_tw_neg_translate_x_12 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_12 =
+    A.class "xl:hover:tw--translate-x-12"
+
+
+xl_hover_tw_neg_translate_x_16 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_16 =
+    A.class "xl:hover:tw--translate-x-16"
+
+
+xl_hover_tw_neg_translate_x_20 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_20 =
+    A.class "xl:hover:tw--translate-x-20"
+
+
+xl_hover_tw_neg_translate_x_24 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_24 =
+    A.class "xl:hover:tw--translate-x-24"
+
+
+xl_hover_tw_neg_translate_x_32 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_32 =
+    A.class "xl:hover:tw--translate-x-32"
+
+
+xl_hover_tw_neg_translate_x_40 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_40 =
+    A.class "xl:hover:tw--translate-x-40"
+
+
+xl_hover_tw_neg_translate_x_48 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_48 =
+    A.class "xl:hover:tw--translate-x-48"
+
+
+xl_hover_tw_neg_translate_x_56 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_56 =
+    A.class "xl:hover:tw--translate-x-56"
+
+
+xl_hover_tw_neg_translate_x_64 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_64 =
+    A.class "xl:hover:tw--translate-x-64"
+
+
+xl_hover_tw_neg_translate_x_px : Html.Attribute msg
+xl_hover_tw_neg_translate_x_px =
+    A.class "xl:hover:tw--translate-x-px"
+
+
+xl_hover_tw_neg_translate_x_full : Html.Attribute msg
+xl_hover_tw_neg_translate_x_full =
+    A.class "xl:hover:tw--translate-x-full"
+
+
+xl_hover_tw_neg_translate_x_1over2 : Html.Attribute msg
+xl_hover_tw_neg_translate_x_1over2 =
+    A.class "xl:hover:tw--translate-x-1/2"
+
+
+xl_hover_tw_translate_x_1over2 : Html.Attribute msg
+xl_hover_tw_translate_x_1over2 =
+    A.class "xl:hover:tw-translate-x-1/2"
+
+
+xl_hover_tw_translate_x_full : Html.Attribute msg
+xl_hover_tw_translate_x_full =
+    A.class "xl:hover:tw-translate-x-full"
+
+
+xl_hover_tw_translate_y_0 : Html.Attribute msg
+xl_hover_tw_translate_y_0 =
+    A.class "xl:hover:tw-translate-y-0"
+
+
+xl_hover_tw_translate_y_1 : Html.Attribute msg
+xl_hover_tw_translate_y_1 =
+    A.class "xl:hover:tw-translate-y-1"
+
+
+xl_hover_tw_translate_y_2 : Html.Attribute msg
+xl_hover_tw_translate_y_2 =
+    A.class "xl:hover:tw-translate-y-2"
+
+
+xl_hover_tw_translate_y_3 : Html.Attribute msg
+xl_hover_tw_translate_y_3 =
+    A.class "xl:hover:tw-translate-y-3"
+
+
+xl_hover_tw_translate_y_4 : Html.Attribute msg
+xl_hover_tw_translate_y_4 =
+    A.class "xl:hover:tw-translate-y-4"
+
+
+xl_hover_tw_translate_y_5 : Html.Attribute msg
+xl_hover_tw_translate_y_5 =
+    A.class "xl:hover:tw-translate-y-5"
+
+
+xl_hover_tw_translate_y_6 : Html.Attribute msg
+xl_hover_tw_translate_y_6 =
+    A.class "xl:hover:tw-translate-y-6"
+
+
+xl_hover_tw_translate_y_8 : Html.Attribute msg
+xl_hover_tw_translate_y_8 =
+    A.class "xl:hover:tw-translate-y-8"
+
+
+xl_hover_tw_translate_y_10 : Html.Attribute msg
+xl_hover_tw_translate_y_10 =
+    A.class "xl:hover:tw-translate-y-10"
+
+
+xl_hover_tw_translate_y_12 : Html.Attribute msg
+xl_hover_tw_translate_y_12 =
+    A.class "xl:hover:tw-translate-y-12"
+
+
+xl_hover_tw_translate_y_16 : Html.Attribute msg
+xl_hover_tw_translate_y_16 =
+    A.class "xl:hover:tw-translate-y-16"
+
+
+xl_hover_tw_translate_y_20 : Html.Attribute msg
+xl_hover_tw_translate_y_20 =
+    A.class "xl:hover:tw-translate-y-20"
+
+
+xl_hover_tw_translate_y_24 : Html.Attribute msg
+xl_hover_tw_translate_y_24 =
+    A.class "xl:hover:tw-translate-y-24"
+
+
+xl_hover_tw_translate_y_32 : Html.Attribute msg
+xl_hover_tw_translate_y_32 =
+    A.class "xl:hover:tw-translate-y-32"
+
+
+xl_hover_tw_translate_y_40 : Html.Attribute msg
+xl_hover_tw_translate_y_40 =
+    A.class "xl:hover:tw-translate-y-40"
+
+
+xl_hover_tw_translate_y_48 : Html.Attribute msg
+xl_hover_tw_translate_y_48 =
+    A.class "xl:hover:tw-translate-y-48"
+
+
+xl_hover_tw_translate_y_56 : Html.Attribute msg
+xl_hover_tw_translate_y_56 =
+    A.class "xl:hover:tw-translate-y-56"
+
+
+xl_hover_tw_translate_y_64 : Html.Attribute msg
+xl_hover_tw_translate_y_64 =
+    A.class "xl:hover:tw-translate-y-64"
+
+
+xl_hover_tw_translate_y_px : Html.Attribute msg
+xl_hover_tw_translate_y_px =
+    A.class "xl:hover:tw-translate-y-px"
+
+
+xl_hover_tw_neg_translate_y_1 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_1 =
+    A.class "xl:hover:tw--translate-y-1"
+
+
+xl_hover_tw_neg_translate_y_2 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_2 =
+    A.class "xl:hover:tw--translate-y-2"
+
+
+xl_hover_tw_neg_translate_y_3 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_3 =
+    A.class "xl:hover:tw--translate-y-3"
+
+
+xl_hover_tw_neg_translate_y_4 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_4 =
+    A.class "xl:hover:tw--translate-y-4"
+
+
+xl_hover_tw_neg_translate_y_5 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_5 =
+    A.class "xl:hover:tw--translate-y-5"
+
+
+xl_hover_tw_neg_translate_y_6 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_6 =
+    A.class "xl:hover:tw--translate-y-6"
+
+
+xl_hover_tw_neg_translate_y_8 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_8 =
+    A.class "xl:hover:tw--translate-y-8"
+
+
+xl_hover_tw_neg_translate_y_10 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_10 =
+    A.class "xl:hover:tw--translate-y-10"
+
+
+xl_hover_tw_neg_translate_y_12 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_12 =
+    A.class "xl:hover:tw--translate-y-12"
+
+
+xl_hover_tw_neg_translate_y_16 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_16 =
+    A.class "xl:hover:tw--translate-y-16"
+
+
+xl_hover_tw_neg_translate_y_20 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_20 =
+    A.class "xl:hover:tw--translate-y-20"
+
+
+xl_hover_tw_neg_translate_y_24 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_24 =
+    A.class "xl:hover:tw--translate-y-24"
+
+
+xl_hover_tw_neg_translate_y_32 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_32 =
+    A.class "xl:hover:tw--translate-y-32"
+
+
+xl_hover_tw_neg_translate_y_40 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_40 =
+    A.class "xl:hover:tw--translate-y-40"
+
+
+xl_hover_tw_neg_translate_y_48 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_48 =
+    A.class "xl:hover:tw--translate-y-48"
+
+
+xl_hover_tw_neg_translate_y_56 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_56 =
+    A.class "xl:hover:tw--translate-y-56"
+
+
+xl_hover_tw_neg_translate_y_64 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_64 =
+    A.class "xl:hover:tw--translate-y-64"
+
+
+xl_hover_tw_neg_translate_y_px : Html.Attribute msg
+xl_hover_tw_neg_translate_y_px =
+    A.class "xl:hover:tw--translate-y-px"
+
+
+xl_hover_tw_neg_translate_y_full : Html.Attribute msg
+xl_hover_tw_neg_translate_y_full =
+    A.class "xl:hover:tw--translate-y-full"
+
+
+xl_hover_tw_neg_translate_y_1over2 : Html.Attribute msg
+xl_hover_tw_neg_translate_y_1over2 =
+    A.class "xl:hover:tw--translate-y-1/2"
+
+
+xl_hover_tw_translate_y_1over2 : Html.Attribute msg
+xl_hover_tw_translate_y_1over2 =
+    A.class "xl:hover:tw-translate-y-1/2"
+
+
+xl_hover_tw_translate_y_full : Html.Attribute msg
+xl_hover_tw_translate_y_full =
+    A.class "xl:hover:tw-translate-y-full"
+
+
+xl_focus_tw_translate_x_0 : Html.Attribute msg
+xl_focus_tw_translate_x_0 =
+    A.class "xl:focus:tw-translate-x-0"
+
+
+xl_focus_tw_translate_x_1 : Html.Attribute msg
+xl_focus_tw_translate_x_1 =
+    A.class "xl:focus:tw-translate-x-1"
+
+
+xl_focus_tw_translate_x_2 : Html.Attribute msg
+xl_focus_tw_translate_x_2 =
+    A.class "xl:focus:tw-translate-x-2"
+
+
+xl_focus_tw_translate_x_3 : Html.Attribute msg
+xl_focus_tw_translate_x_3 =
+    A.class "xl:focus:tw-translate-x-3"
+
+
+xl_focus_tw_translate_x_4 : Html.Attribute msg
+xl_focus_tw_translate_x_4 =
+    A.class "xl:focus:tw-translate-x-4"
+
+
+xl_focus_tw_translate_x_5 : Html.Attribute msg
+xl_focus_tw_translate_x_5 =
+    A.class "xl:focus:tw-translate-x-5"
+
+
+xl_focus_tw_translate_x_6 : Html.Attribute msg
+xl_focus_tw_translate_x_6 =
+    A.class "xl:focus:tw-translate-x-6"
+
+
+xl_focus_tw_translate_x_8 : Html.Attribute msg
+xl_focus_tw_translate_x_8 =
+    A.class "xl:focus:tw-translate-x-8"
+
+
+xl_focus_tw_translate_x_10 : Html.Attribute msg
+xl_focus_tw_translate_x_10 =
+    A.class "xl:focus:tw-translate-x-10"
+
+
+xl_focus_tw_translate_x_12 : Html.Attribute msg
+xl_focus_tw_translate_x_12 =
+    A.class "xl:focus:tw-translate-x-12"
+
+
+xl_focus_tw_translate_x_16 : Html.Attribute msg
+xl_focus_tw_translate_x_16 =
+    A.class "xl:focus:tw-translate-x-16"
+
+
+xl_focus_tw_translate_x_20 : Html.Attribute msg
+xl_focus_tw_translate_x_20 =
+    A.class "xl:focus:tw-translate-x-20"
+
+
+xl_focus_tw_translate_x_24 : Html.Attribute msg
+xl_focus_tw_translate_x_24 =
+    A.class "xl:focus:tw-translate-x-24"
+
+
+xl_focus_tw_translate_x_32 : Html.Attribute msg
+xl_focus_tw_translate_x_32 =
+    A.class "xl:focus:tw-translate-x-32"
+
+
+xl_focus_tw_translate_x_40 : Html.Attribute msg
+xl_focus_tw_translate_x_40 =
+    A.class "xl:focus:tw-translate-x-40"
+
+
+xl_focus_tw_translate_x_48 : Html.Attribute msg
+xl_focus_tw_translate_x_48 =
+    A.class "xl:focus:tw-translate-x-48"
+
+
+xl_focus_tw_translate_x_56 : Html.Attribute msg
+xl_focus_tw_translate_x_56 =
+    A.class "xl:focus:tw-translate-x-56"
+
+
+xl_focus_tw_translate_x_64 : Html.Attribute msg
+xl_focus_tw_translate_x_64 =
+    A.class "xl:focus:tw-translate-x-64"
+
+
+xl_focus_tw_translate_x_px : Html.Attribute msg
+xl_focus_tw_translate_x_px =
+    A.class "xl:focus:tw-translate-x-px"
+
+
+xl_focus_tw_neg_translate_x_1 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_1 =
+    A.class "xl:focus:tw--translate-x-1"
+
+
+xl_focus_tw_neg_translate_x_2 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_2 =
+    A.class "xl:focus:tw--translate-x-2"
+
+
+xl_focus_tw_neg_translate_x_3 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_3 =
+    A.class "xl:focus:tw--translate-x-3"
+
+
+xl_focus_tw_neg_translate_x_4 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_4 =
+    A.class "xl:focus:tw--translate-x-4"
+
+
+xl_focus_tw_neg_translate_x_5 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_5 =
+    A.class "xl:focus:tw--translate-x-5"
+
+
+xl_focus_tw_neg_translate_x_6 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_6 =
+    A.class "xl:focus:tw--translate-x-6"
+
+
+xl_focus_tw_neg_translate_x_8 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_8 =
+    A.class "xl:focus:tw--translate-x-8"
+
+
+xl_focus_tw_neg_translate_x_10 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_10 =
+    A.class "xl:focus:tw--translate-x-10"
+
+
+xl_focus_tw_neg_translate_x_12 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_12 =
+    A.class "xl:focus:tw--translate-x-12"
+
+
+xl_focus_tw_neg_translate_x_16 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_16 =
+    A.class "xl:focus:tw--translate-x-16"
+
+
+xl_focus_tw_neg_translate_x_20 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_20 =
+    A.class "xl:focus:tw--translate-x-20"
+
+
+xl_focus_tw_neg_translate_x_24 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_24 =
+    A.class "xl:focus:tw--translate-x-24"
+
+
+xl_focus_tw_neg_translate_x_32 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_32 =
+    A.class "xl:focus:tw--translate-x-32"
+
+
+xl_focus_tw_neg_translate_x_40 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_40 =
+    A.class "xl:focus:tw--translate-x-40"
+
+
+xl_focus_tw_neg_translate_x_48 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_48 =
+    A.class "xl:focus:tw--translate-x-48"
+
+
+xl_focus_tw_neg_translate_x_56 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_56 =
+    A.class "xl:focus:tw--translate-x-56"
+
+
+xl_focus_tw_neg_translate_x_64 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_64 =
+    A.class "xl:focus:tw--translate-x-64"
+
+
+xl_focus_tw_neg_translate_x_px : Html.Attribute msg
+xl_focus_tw_neg_translate_x_px =
+    A.class "xl:focus:tw--translate-x-px"
+
+
+xl_focus_tw_neg_translate_x_full : Html.Attribute msg
+xl_focus_tw_neg_translate_x_full =
+    A.class "xl:focus:tw--translate-x-full"
+
+
+xl_focus_tw_neg_translate_x_1over2 : Html.Attribute msg
+xl_focus_tw_neg_translate_x_1over2 =
+    A.class "xl:focus:tw--translate-x-1/2"
+
+
+xl_focus_tw_translate_x_1over2 : Html.Attribute msg
+xl_focus_tw_translate_x_1over2 =
+    A.class "xl:focus:tw-translate-x-1/2"
+
+
+xl_focus_tw_translate_x_full : Html.Attribute msg
+xl_focus_tw_translate_x_full =
+    A.class "xl:focus:tw-translate-x-full"
+
+
+xl_focus_tw_translate_y_0 : Html.Attribute msg
+xl_focus_tw_translate_y_0 =
+    A.class "xl:focus:tw-translate-y-0"
+
+
+xl_focus_tw_translate_y_1 : Html.Attribute msg
+xl_focus_tw_translate_y_1 =
+    A.class "xl:focus:tw-translate-y-1"
+
+
+xl_focus_tw_translate_y_2 : Html.Attribute msg
+xl_focus_tw_translate_y_2 =
+    A.class "xl:focus:tw-translate-y-2"
+
+
+xl_focus_tw_translate_y_3 : Html.Attribute msg
+xl_focus_tw_translate_y_3 =
+    A.class "xl:focus:tw-translate-y-3"
+
+
+xl_focus_tw_translate_y_4 : Html.Attribute msg
+xl_focus_tw_translate_y_4 =
+    A.class "xl:focus:tw-translate-y-4"
+
+
+xl_focus_tw_translate_y_5 : Html.Attribute msg
+xl_focus_tw_translate_y_5 =
+    A.class "xl:focus:tw-translate-y-5"
+
+
+xl_focus_tw_translate_y_6 : Html.Attribute msg
+xl_focus_tw_translate_y_6 =
+    A.class "xl:focus:tw-translate-y-6"
+
+
+xl_focus_tw_translate_y_8 : Html.Attribute msg
+xl_focus_tw_translate_y_8 =
+    A.class "xl:focus:tw-translate-y-8"
+
+
+xl_focus_tw_translate_y_10 : Html.Attribute msg
+xl_focus_tw_translate_y_10 =
+    A.class "xl:focus:tw-translate-y-10"
+
+
+xl_focus_tw_translate_y_12 : Html.Attribute msg
+xl_focus_tw_translate_y_12 =
+    A.class "xl:focus:tw-translate-y-12"
+
+
+xl_focus_tw_translate_y_16 : Html.Attribute msg
+xl_focus_tw_translate_y_16 =
+    A.class "xl:focus:tw-translate-y-16"
+
+
+xl_focus_tw_translate_y_20 : Html.Attribute msg
+xl_focus_tw_translate_y_20 =
+    A.class "xl:focus:tw-translate-y-20"
+
+
+xl_focus_tw_translate_y_24 : Html.Attribute msg
+xl_focus_tw_translate_y_24 =
+    A.class "xl:focus:tw-translate-y-24"
+
+
+xl_focus_tw_translate_y_32 : Html.Attribute msg
+xl_focus_tw_translate_y_32 =
+    A.class "xl:focus:tw-translate-y-32"
+
+
+xl_focus_tw_translate_y_40 : Html.Attribute msg
+xl_focus_tw_translate_y_40 =
+    A.class "xl:focus:tw-translate-y-40"
+
+
+xl_focus_tw_translate_y_48 : Html.Attribute msg
+xl_focus_tw_translate_y_48 =
+    A.class "xl:focus:tw-translate-y-48"
+
+
+xl_focus_tw_translate_y_56 : Html.Attribute msg
+xl_focus_tw_translate_y_56 =
+    A.class "xl:focus:tw-translate-y-56"
+
+
+xl_focus_tw_translate_y_64 : Html.Attribute msg
+xl_focus_tw_translate_y_64 =
+    A.class "xl:focus:tw-translate-y-64"
+
+
+xl_focus_tw_translate_y_px : Html.Attribute msg
+xl_focus_tw_translate_y_px =
+    A.class "xl:focus:tw-translate-y-px"
+
+
+xl_focus_tw_neg_translate_y_1 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_1 =
+    A.class "xl:focus:tw--translate-y-1"
+
+
+xl_focus_tw_neg_translate_y_2 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_2 =
+    A.class "xl:focus:tw--translate-y-2"
+
+
+xl_focus_tw_neg_translate_y_3 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_3 =
+    A.class "xl:focus:tw--translate-y-3"
+
+
+xl_focus_tw_neg_translate_y_4 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_4 =
+    A.class "xl:focus:tw--translate-y-4"
+
+
+xl_focus_tw_neg_translate_y_5 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_5 =
+    A.class "xl:focus:tw--translate-y-5"
+
+
+xl_focus_tw_neg_translate_y_6 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_6 =
+    A.class "xl:focus:tw--translate-y-6"
+
+
+xl_focus_tw_neg_translate_y_8 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_8 =
+    A.class "xl:focus:tw--translate-y-8"
+
+
+xl_focus_tw_neg_translate_y_10 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_10 =
+    A.class "xl:focus:tw--translate-y-10"
+
+
+xl_focus_tw_neg_translate_y_12 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_12 =
+    A.class "xl:focus:tw--translate-y-12"
+
+
+xl_focus_tw_neg_translate_y_16 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_16 =
+    A.class "xl:focus:tw--translate-y-16"
+
+
+xl_focus_tw_neg_translate_y_20 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_20 =
+    A.class "xl:focus:tw--translate-y-20"
+
+
+xl_focus_tw_neg_translate_y_24 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_24 =
+    A.class "xl:focus:tw--translate-y-24"
+
+
+xl_focus_tw_neg_translate_y_32 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_32 =
+    A.class "xl:focus:tw--translate-y-32"
+
+
+xl_focus_tw_neg_translate_y_40 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_40 =
+    A.class "xl:focus:tw--translate-y-40"
+
+
+xl_focus_tw_neg_translate_y_48 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_48 =
+    A.class "xl:focus:tw--translate-y-48"
+
+
+xl_focus_tw_neg_translate_y_56 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_56 =
+    A.class "xl:focus:tw--translate-y-56"
+
+
+xl_focus_tw_neg_translate_y_64 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_64 =
+    A.class "xl:focus:tw--translate-y-64"
+
+
+xl_focus_tw_neg_translate_y_px : Html.Attribute msg
+xl_focus_tw_neg_translate_y_px =
+    A.class "xl:focus:tw--translate-y-px"
+
+
+xl_focus_tw_neg_translate_y_full : Html.Attribute msg
+xl_focus_tw_neg_translate_y_full =
+    A.class "xl:focus:tw--translate-y-full"
+
+
+xl_focus_tw_neg_translate_y_1over2 : Html.Attribute msg
+xl_focus_tw_neg_translate_y_1over2 =
+    A.class "xl:focus:tw--translate-y-1/2"
+
+
+xl_focus_tw_translate_y_1over2 : Html.Attribute msg
+xl_focus_tw_translate_y_1over2 =
+    A.class "xl:focus:tw-translate-y-1/2"
+
+
+xl_focus_tw_translate_y_full : Html.Attribute msg
+xl_focus_tw_translate_y_full =
+    A.class "xl:focus:tw-translate-y-full"
+
+
+xl_tw_skew_x_0 : Html.Attribute msg
+xl_tw_skew_x_0 =
+    A.class "xl:tw-skew-x-0"
+
+
+xl_tw_skew_x_3 : Html.Attribute msg
+xl_tw_skew_x_3 =
+    A.class "xl:tw-skew-x-3"
+
+
+xl_tw_skew_x_6 : Html.Attribute msg
+xl_tw_skew_x_6 =
+    A.class "xl:tw-skew-x-6"
+
+
+xl_tw_skew_x_12 : Html.Attribute msg
+xl_tw_skew_x_12 =
+    A.class "xl:tw-skew-x-12"
+
+
+xl_tw_neg_skew_x_12 : Html.Attribute msg
+xl_tw_neg_skew_x_12 =
+    A.class "xl:tw--skew-x-12"
+
+
+xl_tw_neg_skew_x_6 : Html.Attribute msg
+xl_tw_neg_skew_x_6 =
+    A.class "xl:tw--skew-x-6"
+
+
+xl_tw_neg_skew_x_3 : Html.Attribute msg
+xl_tw_neg_skew_x_3 =
+    A.class "xl:tw--skew-x-3"
+
+
+xl_tw_skew_y_0 : Html.Attribute msg
+xl_tw_skew_y_0 =
+    A.class "xl:tw-skew-y-0"
+
+
+xl_tw_skew_y_3 : Html.Attribute msg
+xl_tw_skew_y_3 =
+    A.class "xl:tw-skew-y-3"
+
+
+xl_tw_skew_y_6 : Html.Attribute msg
+xl_tw_skew_y_6 =
+    A.class "xl:tw-skew-y-6"
+
+
+xl_tw_skew_y_12 : Html.Attribute msg
+xl_tw_skew_y_12 =
+    A.class "xl:tw-skew-y-12"
+
+
+xl_tw_neg_skew_y_12 : Html.Attribute msg
+xl_tw_neg_skew_y_12 =
+    A.class "xl:tw--skew-y-12"
+
+
+xl_tw_neg_skew_y_6 : Html.Attribute msg
+xl_tw_neg_skew_y_6 =
+    A.class "xl:tw--skew-y-6"
+
+
+xl_tw_neg_skew_y_3 : Html.Attribute msg
+xl_tw_neg_skew_y_3 =
+    A.class "xl:tw--skew-y-3"
+
+
+xl_hover_tw_skew_x_0 : Html.Attribute msg
+xl_hover_tw_skew_x_0 =
+    A.class "xl:hover:tw-skew-x-0"
+
+
+xl_hover_tw_skew_x_3 : Html.Attribute msg
+xl_hover_tw_skew_x_3 =
+    A.class "xl:hover:tw-skew-x-3"
+
+
+xl_hover_tw_skew_x_6 : Html.Attribute msg
+xl_hover_tw_skew_x_6 =
+    A.class "xl:hover:tw-skew-x-6"
+
+
+xl_hover_tw_skew_x_12 : Html.Attribute msg
+xl_hover_tw_skew_x_12 =
+    A.class "xl:hover:tw-skew-x-12"
+
+
+xl_hover_tw_neg_skew_x_12 : Html.Attribute msg
+xl_hover_tw_neg_skew_x_12 =
+    A.class "xl:hover:tw--skew-x-12"
+
+
+xl_hover_tw_neg_skew_x_6 : Html.Attribute msg
+xl_hover_tw_neg_skew_x_6 =
+    A.class "xl:hover:tw--skew-x-6"
+
+
+xl_hover_tw_neg_skew_x_3 : Html.Attribute msg
+xl_hover_tw_neg_skew_x_3 =
+    A.class "xl:hover:tw--skew-x-3"
+
+
+xl_hover_tw_skew_y_0 : Html.Attribute msg
+xl_hover_tw_skew_y_0 =
+    A.class "xl:hover:tw-skew-y-0"
+
+
+xl_hover_tw_skew_y_3 : Html.Attribute msg
+xl_hover_tw_skew_y_3 =
+    A.class "xl:hover:tw-skew-y-3"
+
+
+xl_hover_tw_skew_y_6 : Html.Attribute msg
+xl_hover_tw_skew_y_6 =
+    A.class "xl:hover:tw-skew-y-6"
+
+
+xl_hover_tw_skew_y_12 : Html.Attribute msg
+xl_hover_tw_skew_y_12 =
+    A.class "xl:hover:tw-skew-y-12"
+
+
+xl_hover_tw_neg_skew_y_12 : Html.Attribute msg
+xl_hover_tw_neg_skew_y_12 =
+    A.class "xl:hover:tw--skew-y-12"
+
+
+xl_hover_tw_neg_skew_y_6 : Html.Attribute msg
+xl_hover_tw_neg_skew_y_6 =
+    A.class "xl:hover:tw--skew-y-6"
+
+
+xl_hover_tw_neg_skew_y_3 : Html.Attribute msg
+xl_hover_tw_neg_skew_y_3 =
+    A.class "xl:hover:tw--skew-y-3"
+
+
+xl_focus_tw_skew_x_0 : Html.Attribute msg
+xl_focus_tw_skew_x_0 =
+    A.class "xl:focus:tw-skew-x-0"
+
+
+xl_focus_tw_skew_x_3 : Html.Attribute msg
+xl_focus_tw_skew_x_3 =
+    A.class "xl:focus:tw-skew-x-3"
+
+
+xl_focus_tw_skew_x_6 : Html.Attribute msg
+xl_focus_tw_skew_x_6 =
+    A.class "xl:focus:tw-skew-x-6"
+
+
+xl_focus_tw_skew_x_12 : Html.Attribute msg
+xl_focus_tw_skew_x_12 =
+    A.class "xl:focus:tw-skew-x-12"
+
+
+xl_focus_tw_neg_skew_x_12 : Html.Attribute msg
+xl_focus_tw_neg_skew_x_12 =
+    A.class "xl:focus:tw--skew-x-12"
+
+
+xl_focus_tw_neg_skew_x_6 : Html.Attribute msg
+xl_focus_tw_neg_skew_x_6 =
+    A.class "xl:focus:tw--skew-x-6"
+
+
+xl_focus_tw_neg_skew_x_3 : Html.Attribute msg
+xl_focus_tw_neg_skew_x_3 =
+    A.class "xl:focus:tw--skew-x-3"
+
+
+xl_focus_tw_skew_y_0 : Html.Attribute msg
+xl_focus_tw_skew_y_0 =
+    A.class "xl:focus:tw-skew-y-0"
+
+
+xl_focus_tw_skew_y_3 : Html.Attribute msg
+xl_focus_tw_skew_y_3 =
+    A.class "xl:focus:tw-skew-y-3"
+
+
+xl_focus_tw_skew_y_6 : Html.Attribute msg
+xl_focus_tw_skew_y_6 =
+    A.class "xl:focus:tw-skew-y-6"
+
+
+xl_focus_tw_skew_y_12 : Html.Attribute msg
+xl_focus_tw_skew_y_12 =
+    A.class "xl:focus:tw-skew-y-12"
+
+
+xl_focus_tw_neg_skew_y_12 : Html.Attribute msg
+xl_focus_tw_neg_skew_y_12 =
+    A.class "xl:focus:tw--skew-y-12"
+
+
+xl_focus_tw_neg_skew_y_6 : Html.Attribute msg
+xl_focus_tw_neg_skew_y_6 =
+    A.class "xl:focus:tw--skew-y-6"
+
+
+xl_focus_tw_neg_skew_y_3 : Html.Attribute msg
+xl_focus_tw_neg_skew_y_3 =
+    A.class "xl:focus:tw--skew-y-3"
+
+
+xl_tw_transition_none : Html.Attribute msg
+xl_tw_transition_none =
+    A.class "xl:tw-transition-none"
+
+
+xl_tw_transition_all : Html.Attribute msg
+xl_tw_transition_all =
+    A.class "xl:tw-transition-all"
+
+
+xl_tw_transition : Html.Attribute msg
+xl_tw_transition =
+    A.class "xl:tw-transition"
+
+
+xl_tw_transition_colors : Html.Attribute msg
+xl_tw_transition_colors =
+    A.class "xl:tw-transition-colors"
+
+
+xl_tw_transition_opacity : Html.Attribute msg
+xl_tw_transition_opacity =
+    A.class "xl:tw-transition-opacity"
+
+
+xl_tw_transition_shadow : Html.Attribute msg
+xl_tw_transition_shadow =
+    A.class "xl:tw-transition-shadow"
+
+
+xl_tw_transition_transform : Html.Attribute msg
+xl_tw_transition_transform =
+    A.class "xl:tw-transition-transform"
+
+
+xl_tw_ease_linear : Html.Attribute msg
+xl_tw_ease_linear =
+    A.class "xl:tw-ease-linear"
+
+
+xl_tw_ease_in : Html.Attribute msg
+xl_tw_ease_in =
+    A.class "xl:tw-ease-in"
+
+
+xl_tw_ease_out : Html.Attribute msg
+xl_tw_ease_out =
+    A.class "xl:tw-ease-out"
+
+
+xl_tw_ease_in_out : Html.Attribute msg
+xl_tw_ease_in_out =
+    A.class "xl:tw-ease-in-out"
+
+
+xl_tw_duration_75 : Html.Attribute msg
+xl_tw_duration_75 =
+    A.class "xl:tw-duration-75"
+
+
+xl_tw_duration_100 : Html.Attribute msg
+xl_tw_duration_100 =
+    A.class "xl:tw-duration-100"
+
+
+xl_tw_duration_150 : Html.Attribute msg
+xl_tw_duration_150 =
+    A.class "xl:tw-duration-150"
+
+
+xl_tw_duration_200 : Html.Attribute msg
+xl_tw_duration_200 =
+    A.class "xl:tw-duration-200"
+
+
+xl_tw_duration_300 : Html.Attribute msg
+xl_tw_duration_300 =
+    A.class "xl:tw-duration-300"
+
+
+xl_tw_duration_500 : Html.Attribute msg
+xl_tw_duration_500 =
+    A.class "xl:tw-duration-500"
+
+
+xl_tw_duration_700 : Html.Attribute msg
+xl_tw_duration_700 =
+    A.class "xl:tw-duration-700"
+
+
+xl_tw_duration_1000 : Html.Attribute msg
+xl_tw_duration_1000 =
+    A.class "xl:tw-duration-1000"
 

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -32,6 +32,11 @@
     mini-svg-data-uri "^1.0.3"
     traverse "^0.6.6"
 
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -60,6 +65,25 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+acorn-node@^1.6.1:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
+  integrity sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==
+  dependencies:
+    acorn "^7.0.0"
+    acorn-walk "^7.0.0"
+    xtend "^4.0.2"
+
+acorn-walk@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.0.0.tgz#c8ba6f0f1aac4b0a9e32d1f0af12be769528f36b"
+  integrity sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg==
+
+acorn@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
+  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
 ajv@^6.5.5:
   version "6.10.2"
@@ -92,6 +116,14 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -186,16 +218,16 @@ atob@^2.1.1:
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 autoprefixer@^9.4.5:
-  version "9.6.5"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.6.5.tgz#98f4afe7e93cccf323287515d426019619775e5e"
-  integrity sha512-rGd50YV8LgwFQ2WQp4XzOTG69u1qQsXn0amww7tjqV5jJuNazgFKYEVItEBngyyvVITKOg20zr2V+9VsrXJQ2g==
+  version "9.7.4"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.7.4.tgz#f8bf3e06707d047f0641d87aee8cfb174b2a5378"
+  integrity sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==
   dependencies:
-    browserslist "^4.7.0"
-    caniuse-lite "^1.0.30000999"
+    browserslist "^4.8.3"
+    caniuse-lite "^1.0.30001020"
     chalk "^2.4.2"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
-    postcss "^7.0.18"
+    postcss "^7.0.26"
     postcss-value-parser "^4.0.2"
 
 aws-sign2@~0.7.0:
@@ -262,14 +294,14 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-browserslist@^4.7.0:
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.1.tgz#bd400d1aea56538580e8c4d5f1c54ac11b5ab468"
-  integrity sha512-QtULFqKIAtiyNx7NhZ/p4rB8m3xDozVo/pi5VgTlADLF2tNigz/QH+v0m5qhn7XfHT7u+607NcCNOnC0HZAlMg==
+browserslist@^4.8.3:
+  version "4.8.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.6.tgz#96406f3f5f0755d272e27a66f4163ca821590a7e"
+  integrity sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==
   dependencies:
-    caniuse-lite "^1.0.30000999"
-    electron-to-chromium "^1.3.284"
-    node-releases "^1.1.36"
+    caniuse-lite "^1.0.30001023"
+    electron-to-chromium "^1.3.341"
+    node-releases "^1.1.47"
 
 bytes@^3.0.0:
   version "3.1.0"
@@ -325,10 +357,10 @@ camelcase@^5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@^1.0.30000999:
-  version "1.0.30001002"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001002.tgz#ba999a737b1abd5bf0fd47efe43a09b9cadbe9b0"
-  integrity sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g==
+caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001023:
+  version "1.0.30001025"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz#30336a8aca7f98618eb3cf38e35184e13d4e5fe6"
+  integrity sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -343,6 +375,14 @@ chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 chokidar@^2.0.0:
   version "2.1.8"
@@ -416,10 +456,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -478,11 +530,6 @@ css-unit-converter@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/css-unit-converter/-/css-unit-converter-1.1.1.tgz#d9b9281adcfd8ced935bdbaba83786897f64e996"
   integrity sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=
-
-cssesc@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-2.0.0.tgz#3b13bd1bb1cb36e1bcb5a4dcd27f54c5dcb35703"
-  integrity sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -547,6 +594,11 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+defined@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
+  integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -567,6 +619,15 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
+detective@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/detective/-/detective-5.2.0.tgz#feb2a77e85b904ecdea459ad897cc90a99bd2a7b"
+  integrity sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==
+  dependencies:
+    acorn-node "^1.6.1"
+    defined "^1.0.0"
+    minimist "^1.1.1"
+
 dir-glob@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
@@ -582,10 +643,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-electron-to-chromium@^1.3.284:
-  version "1.3.292"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.292.tgz#7812fc5138619342f1dd5823df6e9cbb7d2820e9"
-  integrity sha512-hqkem5ANpt6mxVXmhAmlbdG8iicuyM/jEYgmP1tiHPeOLyZoTyGUzrDmJS/xyrrZy9frkW1uQcubicu7f6DS5g==
+electron-to-chromium@^1.3.341:
+  version "1.3.345"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz#2569d0d54a64ef0f32a4b7e8c80afa5fe57c5d98"
+  integrity sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==
 
 elm@^0.19.1-2:
   version "0.19.1-2"
@@ -857,7 +918,19 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.1.2, glob@^7.1.3:
+glob@^7.1.2:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.3:
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.5.tgz#6714c69bee20f3c3e64c4dd905553e532b40cdc0"
   integrity sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==
@@ -883,10 +956,15 @@ globby@^9.0.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
+  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -905,6 +983,11 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -1281,7 +1364,7 @@ lodash.toarray@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
 
-lodash@^4.17.11:
+lodash@^4.17.11, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -1379,7 +1462,7 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
@@ -1483,10 +1566,10 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.36:
-  version "1.1.36"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.36.tgz#44b7cb8254138e87bdbfa47761d0f825e20900b4"
-  integrity sha512-ggXhX6QGyJSjj3r+6ml2LqqC28XOWmKtpb+a15/Zpr9V3yoNazxJNlcQDS9bYaid5FReEWHEgToH1mwoUceWwg==
+node-releases@^1.1.47:
+  version "1.1.47"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.47.tgz#c59ef739a1fd7ecbd9f0b7cf5b7871e8a8b591e4"
+  integrity sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==
   dependencies:
     semver "^6.3.0"
 
@@ -1694,6 +1777,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -1771,12 +1859,12 @@ postcss-load-config@^2.0.0:
     import-cwd "^2.0.0"
 
 postcss-nested@^4.1.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-4.1.2.tgz#8e0570f736bfb4be5136e31901bf2380b819a561"
-  integrity sha512-9bQFr2TezohU3KRSu9f6sfecXmf/x6RXDedl8CHF6fyuyVW7UqgNMRdWMHZQWuFY6Xqs2NYk+Fj4Z4vSOf7PQg==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-4.2.1.tgz#4bc2e5b35e3b1e481ff81e23b700da7f82a8b248"
+  integrity sha512-AMayXX8tS0HCp4O4lolp4ygj9wBn32DJWXvG6gCv+ZvJrEa00GUxJcJEEzMh87BIe6FrWdYkpR2cuyqHKrxmXw==
   dependencies:
-    postcss "^7.0.14"
-    postcss-selector-parser "^5.0.0"
+    postcss "^7.0.21"
+    postcss-selector-parser "^6.0.2"
 
 postcss-reporter@^6.0.0:
   version "6.0.1"
@@ -1788,16 +1876,7 @@ postcss-reporter@^6.0.0:
     log-symbols "^2.2.0"
     postcss "^7.0.7"
 
-postcss-selector-parser@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz#249044356697b33b64f1a8f7c80922dddee7195c"
-  integrity sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==
-  dependencies:
-    cssesc "^2.0.0"
-    indexes-of "^1.0.1"
-    uniq "^1.0.1"
-
-postcss-selector-parser@^6.0.0:
+postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
   integrity sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==
@@ -1825,10 +1904,19 @@ postcss@^6.0.9:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postcss@^7.0.0, postcss@^7.0.11, postcss@^7.0.14, postcss@^7.0.18, postcss@^7.0.7:
+postcss@^7.0.0, postcss@^7.0.18, postcss@^7.0.7:
   version "7.0.18"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.18.tgz#4b9cda95ae6c069c67a4d933029eddd4838ac233"
   integrity sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
+postcss@^7.0.11, postcss@^7.0.14, postcss@^7.0.21, postcss@^7.0.26:
+  version "7.0.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.26.tgz#5ed615cfcab35ba9bbb82414a4fa88ea10429587"
+  integrity sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -2002,6 +2090,13 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
+
+resolve@^1.14.2:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
+  integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
+  dependencies:
+    path-parse "^1.0.6"
 
 ret@~0.1.10:
   version "0.1.15"
@@ -2258,16 +2353,24 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
+
 tailwindcss@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.1.2.tgz#0107dc092c3edee6132b105d896b109c0f66afd6"
-  integrity sha512-mcTzZHXMipnQY9haB17baNJmBTkYYcC8ljfMdB9/97FfhKJIzlglJcyGythuQTOu7r/QIbLfZYYWZhAvaGj95A==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.2.0.tgz#5df317cebac4f3131f275d258a39da1ba3a0f291"
+  integrity sha512-CKvY0ytB3ze5qvynG7qv4XSpQtFNGPbu9pUn8qFdkqgD8Yo/vGss8mhzbqls44YCXTl4G62p3qVZBj45qrd6FQ==
   dependencies:
     autoprefixer "^9.4.5"
     bytes "^3.0.0"
-    chalk "^2.4.1"
+    chalk "^3.0.0"
+    detective "^5.2.0"
     fs-extra "^8.0.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     node-emoji "^1.8.1"
     normalize.css "^8.0.1"
     postcss "^7.0.11"
@@ -2277,6 +2380,7 @@ tailwindcss@^1.1.2:
     postcss-selector-parser "^6.0.0"
     pretty-hrtime "^1.0.3"
     reduce-css-calc "^2.1.6"
+    resolve "^1.14.2"
 
 tar@^4:
   version "4.4.13"
@@ -2450,6 +2554,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+xtend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"

--- a/helpers.js
+++ b/helpers.js
@@ -63,13 +63,13 @@ function toElmName(cls, prefix) {
   var elm = cls;
   // handle negative with prefix
   if (prefix) {
-    re_neg_with_prefix = new RegExp(`(${prefix})-([p|m])`);
+    re_neg_with_prefix = new RegExp(`(${prefix})-([a-z])`);
     elm = elm.replace(re_neg_with_prefix, "$1neg_$2");
   }
   // handle negative at start of string
-  elm = elm.replace(/^-([p|m])/, "_neg_$1");
+  elm = elm.replace(/^-([a-z])/, "_neg_$1");
   // handle negative with variant
-  elm = elm.replace(/:-([p|m])/, "_neg_$1");
+  elm = elm.replace(/:-([a-z])/, "_neg_$1");
   // replace dashes now we have sorted the negative stuff
   elm = elm.replace(/-/g, "_");
   // replace :

--- a/test/tests.js
+++ b/test/tests.js
@@ -77,6 +77,9 @@ describe("fixClass -> toElmName", () => {
   it("negative with variant .sm:-m-24", () => {
     assert.equal(h.toElmName(h.fixClass(".sm:-m-24")), "sm_neg_m_24");
   });
+  it("negative with variant .sm:-translate-x-1", () => {
+    assert.equal(h.toElmName(h.fixClass(".sm:-translate-x-1")), "sm_neg_translate_x_1");
+  });
   it("with prefix", () => {
     assert.equal(
       h.toElmName(h.fixClass(".hover:tw-bg-blue-500:hover"), "tw-"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,290 +2,6 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
-  version "7.5.5"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
-  integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
-  dependencies:
-    "@babel/highlight" "^7.0.0"
-
-"@babel/core@^7.1.0":
-  version "7.6.4"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.4.tgz#6ebd9fe00925f6c3e177bb726a188b5f578088ff"
-  integrity sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==
-  dependencies:
-    "@babel/code-frame" "^7.5.5"
-    "@babel/generator" "^7.6.4"
-    "@babel/helpers" "^7.6.2"
-    "@babel/parser" "^7.6.4"
-    "@babel/template" "^7.6.0"
-    "@babel/traverse" "^7.6.3"
-    "@babel/types" "^7.6.3"
-    convert-source-map "^1.1.0"
-    debug "^4.1.0"
-    json5 "^2.1.0"
-    lodash "^4.17.13"
-    resolve "^1.3.2"
-    semver "^5.4.1"
-    source-map "^0.5.0"
-
-"@babel/generator@^7.4.0", "@babel/generator@^7.6.3", "@babel/generator@^7.6.4":
-  version "7.6.4"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.4.tgz#a4f8437287bf9671b07f483b76e3bb731bc97671"
-  integrity sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==
-  dependencies:
-    "@babel/types" "^7.6.3"
-    jsesc "^2.5.1"
-    lodash "^4.17.13"
-    source-map "^0.5.0"
-
-"@babel/helper-function-name@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
-  integrity sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==
-  dependencies:
-    "@babel/helper-get-function-arity" "^7.0.0"
-    "@babel/template" "^7.1.0"
-    "@babel/types" "^7.0.0"
-
-"@babel/helper-get-function-arity@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
-  integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
-  dependencies:
-    "@babel/types" "^7.0.0"
-
-"@babel/helper-plugin-utils@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
-  integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
-
-"@babel/helper-split-export-declaration@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
-  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
-  dependencies:
-    "@babel/types" "^7.4.4"
-
-"@babel/helpers@^7.6.2":
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.6.2.tgz#681ffe489ea4dcc55f23ce469e58e59c1c045153"
-  integrity sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==
-  dependencies:
-    "@babel/template" "^7.6.0"
-    "@babel/traverse" "^7.6.2"
-    "@babel/types" "^7.6.0"
-
-"@babel/highlight@^7.0.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540"
-  integrity sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==
-  dependencies:
-    chalk "^2.0.0"
-    esutils "^2.0.2"
-    js-tokens "^4.0.0"
-
-"@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.6.0", "@babel/parser@^7.6.3", "@babel/parser@^7.6.4":
-  version "7.6.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.4.tgz#cb9b36a7482110282d5cb6dd424ec9262b473d81"
-  integrity sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==
-
-"@babel/plugin-syntax-object-rest-spread@^7.0.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e"
-  integrity sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
-  integrity sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.6.0"
-    "@babel/types" "^7.6.0"
-
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.6.2", "@babel/traverse@^7.6.3":
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.3.tgz#66d7dba146b086703c0fb10dd588b7364cec47f9"
-  integrity sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==
-  dependencies:
-    "@babel/code-frame" "^7.5.5"
-    "@babel/generator" "^7.6.3"
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.4.4"
-    "@babel/parser" "^7.6.3"
-    "@babel/types" "^7.6.3"
-    debug "^4.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.13"
-
-"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.0", "@babel/types@^7.6.3":
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.3.tgz#3f07d96f854f98e2fbd45c64b0cb942d11e8ba09"
-  integrity sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==
-  dependencies:
-    esutils "^2.0.2"
-    lodash "^4.17.13"
-    to-fast-properties "^2.0.0"
-
-"@cnakazawa/watch@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"
-  integrity sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==
-  dependencies:
-    exec-sh "^0.3.2"
-    minimist "^1.2.0"
-
-"@jest/console@^24.7.1", "@jest/console@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
-  integrity sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==
-  dependencies:
-    "@jest/source-map" "^24.9.0"
-    chalk "^2.0.1"
-    slash "^2.0.0"
-
-"@jest/core@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-24.9.0.tgz#2ceccd0b93181f9c4850e74f2a9ad43d351369c4"
-  integrity sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==
-  dependencies:
-    "@jest/console" "^24.7.1"
-    "@jest/reporters" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.1"
-    exit "^0.1.2"
-    graceful-fs "^4.1.15"
-    jest-changed-files "^24.9.0"
-    jest-config "^24.9.0"
-    jest-haste-map "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-regex-util "^24.3.0"
-    jest-resolve "^24.9.0"
-    jest-resolve-dependencies "^24.9.0"
-    jest-runner "^24.9.0"
-    jest-runtime "^24.9.0"
-    jest-snapshot "^24.9.0"
-    jest-util "^24.9.0"
-    jest-validate "^24.9.0"
-    jest-watcher "^24.9.0"
-    micromatch "^3.1.10"
-    p-each-series "^1.0.0"
-    realpath-native "^1.1.0"
-    rimraf "^2.5.4"
-    slash "^2.0.0"
-    strip-ansi "^5.0.0"
-
-"@jest/environment@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-24.9.0.tgz#21e3afa2d65c0586cbd6cbefe208bafade44ab18"
-  integrity sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==
-  dependencies:
-    "@jest/fake-timers" "^24.9.0"
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    jest-mock "^24.9.0"
-
-"@jest/fake-timers@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.9.0.tgz#ba3e6bf0eecd09a636049896434d306636540c93"
-  integrity sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-mock "^24.9.0"
-
-"@jest/reporters@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-24.9.0.tgz#86660eff8e2b9661d042a8e98a028b8d631a5b43"
-  integrity sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==
-  dependencies:
-    "@jest/environment" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
-    exit "^0.1.2"
-    glob "^7.1.2"
-    istanbul-lib-coverage "^2.0.2"
-    istanbul-lib-instrument "^3.0.1"
-    istanbul-lib-report "^2.0.4"
-    istanbul-lib-source-maps "^3.0.1"
-    istanbul-reports "^2.2.6"
-    jest-haste-map "^24.9.0"
-    jest-resolve "^24.9.0"
-    jest-runtime "^24.9.0"
-    jest-util "^24.9.0"
-    jest-worker "^24.6.0"
-    node-notifier "^5.4.2"
-    slash "^2.0.0"
-    source-map "^0.6.0"
-    string-length "^2.0.0"
-
-"@jest/source-map@^24.3.0", "@jest/source-map@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-24.9.0.tgz#0e263a94430be4b41da683ccc1e6bffe2a191714"
-  integrity sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==
-  dependencies:
-    callsites "^3.0.0"
-    graceful-fs "^4.1.15"
-    source-map "^0.6.0"
-
-"@jest/test-result@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.9.0.tgz#11796e8aa9dbf88ea025757b3152595ad06ba0ca"
-  integrity sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==
-  dependencies:
-    "@jest/console" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    "@types/istanbul-lib-coverage" "^2.0.0"
-
-"@jest/test-sequencer@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz#f8f334f35b625a4f2f355f2fe7e6036dad2e6b31"
-  integrity sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==
-  dependencies:
-    "@jest/test-result" "^24.9.0"
-    jest-haste-map "^24.9.0"
-    jest-runner "^24.9.0"
-    jest-runtime "^24.9.0"
-
-"@jest/transform@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-24.9.0.tgz#4ae2768b296553fadab09e9ec119543c90b16c56"
-  integrity sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==
-  dependencies:
-    "@babel/core" "^7.1.0"
-    "@jest/types" "^24.9.0"
-    babel-plugin-istanbul "^5.1.0"
-    chalk "^2.0.1"
-    convert-source-map "^1.4.0"
-    fast-json-stable-stringify "^2.0.0"
-    graceful-fs "^4.1.15"
-    jest-haste-map "^24.9.0"
-    jest-regex-util "^24.9.0"
-    jest-util "^24.9.0"
-    micromatch "^3.1.10"
-    pirates "^4.0.1"
-    realpath-native "^1.1.0"
-    slash "^2.0.0"
-    source-map "^0.6.1"
-    write-file-atomic "2.4.1"
-
-"@jest/types@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
-  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^13.0.0"
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -299,38 +15,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@types/babel__core@^7.1.0":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
-  integrity sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==
-  dependencies:
-    "@babel/parser" "^7.1.0"
-    "@babel/types" "^7.0.0"
-    "@types/babel__generator" "*"
-    "@types/babel__template" "*"
-    "@types/babel__traverse" "*"
-
-"@types/babel__generator@*":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.0.tgz#f1ec1c104d1bb463556ecb724018ab788d0c172a"
-  integrity sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==
-  dependencies:
-    "@babel/types" "^7.0.0"
-
-"@types/babel__template@*":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.0.2.tgz#4ff63d6b52eddac1de7b975a5223ed32ecea9307"
-  integrity sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
-  dependencies:
-    "@babel/parser" "^7.1.0"
-    "@babel/types" "^7.0.0"
-
-"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.7.tgz#2496e9ff56196cc1429c72034e07eab6121b6f3f"
-  integrity sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==
-  dependencies:
-    "@babel/types" "^7.3.0"
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
 "@types/events@*":
   version "3.0.0"
@@ -346,92 +34,46 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
-  integrity sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==
-
-"@types/istanbul-lib-report@*":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#e5471e7fa33c61358dd38426189c037a58433b8c"
-  integrity sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==
-  dependencies:
-    "@types/istanbul-lib-coverage" "*"
-
-"@types/istanbul-reports@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz#7a8cbf6a406f36c8add871625b278eaf0b0d255a"
-  integrity sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==
-  dependencies:
-    "@types/istanbul-lib-coverage" "*"
-    "@types/istanbul-lib-report" "*"
-
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "12.11.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.2.tgz#75ba3beda30d690b89a5089ca1c6e8e386150b76"
-  integrity sha512-dsfE4BHJkLQW+reOS6b17xhZ/6FB1rB8eRRvO08nn5o+voxf3i74tuyFWNH6djdfgX7Sm5s6LD8t6mJug4dpDw==
-
-"@types/stack-utils@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
-  integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
-
-"@types/yargs-parser@*":
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.1.0.tgz#c563aa192f39350a1d18da36c5a8da382bbd8228"
-  integrity sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==
-
-"@types/yargs@^13.0.0":
-  version "13.0.3"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.3.tgz#76482af3981d4412d65371a318f992d33464a380"
-  integrity sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==
-  dependencies:
-    "@types/yargs-parser" "*"
-
-abab@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.2.tgz#a2fba1b122c69a85caa02d10f9270c7219709a9d"
-  integrity sha512-2scffjvioEmNz0OyDSLGWDfKCVwaKc6l9Pm9kOIREU13ClXZvHpg/nRL5xyjSSSLhOnXqft2HpsAzNEEA8cFFg==
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.0.tgz#b417deda18cf8400f278733499ad5547ed1abec4"
+  integrity sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==
 
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-acorn-globals@^4.1.0:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
-  integrity sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
+acorn-node@^1.6.1:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
+  integrity sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==
   dependencies:
-    acorn "^6.0.1"
-    acorn-walk "^6.0.1"
+    acorn "^7.0.0"
+    acorn-walk "^7.0.0"
+    xtend "^4.0.2"
 
-acorn-walk@^6.0.1:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
-  integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
+acorn-walk@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.0.0.tgz#c8ba6f0f1aac4b0a9e32d1f0af12be769528f36b"
+  integrity sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg==
 
-acorn@^5.5.3:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
-  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
-
-acorn@^6.0.1:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
-  integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
+acorn@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
+  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
 ajv@^6.5.5:
-  version "6.10.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
-  integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.11.0.tgz#c3607cbc8ae392d8a5a536f25b21f8e5f3f87fe9"
+  integrity sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==
   dependencies:
-    fast-deep-equal "^2.0.1"
+    fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
@@ -440,11 +82,6 @@ ansi-colors@3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
   integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
-
-ansi-escapes@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
-  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -456,7 +93,7 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
@@ -467,6 +104,14 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -511,11 +156,6 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
-array-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
-  integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
-
 array-union@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -550,42 +190,32 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-astral-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
-  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
-
 async-each@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
-
-async-limiter@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
-  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-atob@^2.1.1:
+atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 autoprefixer@^9.4.5:
-  version "9.6.5"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.6.5.tgz#98f4afe7e93cccf323287515d426019619775e5e"
-  integrity sha512-rGd50YV8LgwFQ2WQp4XzOTG69u1qQsXn0amww7tjqV5jJuNazgFKYEVItEBngyyvVITKOg20zr2V+9VsrXJQ2g==
+  version "9.7.4"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.7.4.tgz#f8bf3e06707d047f0641d87aee8cfb174b2a5378"
+  integrity sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==
   dependencies:
-    browserslist "^4.7.0"
-    caniuse-lite "^1.0.30000999"
+    browserslist "^4.8.3"
+    caniuse-lite "^1.0.30001020"
     chalk "^2.4.2"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
-    postcss "^7.0.18"
+    postcss "^7.0.26"
     postcss-value-parser "^4.0.2"
 
 aws-sign2@~0.7.0:
@@ -594,47 +224,9 @@ aws-sign2@~0.7.0:
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
-  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
-
-babel-jest@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.9.0.tgz#3fc327cb8467b89d14d7bc70e315104a783ccd54"
-  integrity sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==
-  dependencies:
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    "@types/babel__core" "^7.1.0"
-    babel-plugin-istanbul "^5.1.0"
-    babel-preset-jest "^24.9.0"
-    chalk "^2.4.2"
-    slash "^2.0.0"
-
-babel-plugin-istanbul@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz#df4ade83d897a92df069c4d9a25cf2671293c854"
-  integrity sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    find-up "^3.0.0"
-    istanbul-lib-instrument "^3.3.0"
-    test-exclude "^5.2.3"
-
-babel-plugin-jest-hoist@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz#4f837091eb407e01447c8843cbec546d0002d756"
-  integrity sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==
-  dependencies:
-    "@types/babel__traverse" "^7.0.6"
-
-babel-preset-jest@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz#192b521e2217fb1d1f67cf73f70c336650ad3cdc"
-  integrity sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==
-  dependencies:
-    "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
-    babel-plugin-jest-hoist "^24.9.0"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
+  integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -666,6 +258,13 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -690,43 +289,19 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-browser-process-hrtime@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
-  integrity sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==
-
-browser-resolve@^1.11.3:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
-  integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
-  dependencies:
-    resolve "1.1.7"
-
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-browserslist@^4.7.0:
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.1.tgz#bd400d1aea56538580e8c4d5f1c54ac11b5ab468"
-  integrity sha512-QtULFqKIAtiyNx7NhZ/p4rB8m3xDozVo/pi5VgTlADLF2tNigz/QH+v0m5qhn7XfHT7u+607NcCNOnC0HZAlMg==
+browserslist@^4.8.3:
+  version "4.8.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.6.tgz#96406f3f5f0755d272e27a66f4163ca821590a7e"
+  integrity sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==
   dependencies:
-    caniuse-lite "^1.0.30000999"
-    electron-to-chromium "^1.3.284"
-    node-releases "^1.1.36"
-
-bser@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
-  integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
-  dependencies:
-    node-int64 "^0.4.0"
-
-buffer-from@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+    caniuse-lite "^1.0.30001023"
+    electron-to-chromium "^1.3.341"
+    node-releases "^1.1.47"
 
 bytes@^3.0.0:
   version "3.1.0"
@@ -772,39 +347,27 @@ callsites@^2.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
-callsites@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
-  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
-
 camelcase-css@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
-camelcase@^5.0.0, camelcase@^5.3.1:
+camelcase@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@^1.0.30000999:
-  version "1.0.30001002"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001002.tgz#ba999a737b1abd5bf0fd47efe43a09b9cadbe9b0"
-  integrity sha512-pRuxPE8wdrWmVPKcDmJJiGBxr6lFJq4ivdSeo9FTmGj5Rb8NX3Mby2pARG57MXF15hYAhZ0nHV5XxT2ig4bz3g==
-
-capture-exit@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
-  integrity sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
-  dependencies:
-    rsvp "^4.8.4"
+caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001023:
+  version "1.0.30001025"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz#30336a8aca7f98618eb3cf38e35184e13d4e5fe6"
+  integrity sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==
 
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -812,6 +375,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 chokidar@^2.0.0:
   version "2.1.8"
@@ -836,11 +407,6 @@ chownr@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
   integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
-
-ci-info@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
-  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -870,11 +436,6 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
-
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -895,10 +456,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -906,11 +479,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
-
-commander@~2.20.3:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -926,13 +494,6 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
-
-convert-source-map@^1.1.0, convert-source-map@^1.4.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
-  integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
-  dependencies:
-    safe-buffer "~5.1.1"
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -970,27 +531,10 @@ css-unit-converter@^1.1.1:
   resolved "https://registry.yarnpkg.com/css-unit-converter/-/css-unit-converter-1.1.1.tgz#d9b9281adcfd8ced935bdbaba83786897f64e996"
   integrity sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=
 
-cssesc@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-2.0.0.tgz#3b13bd1bb1cb36e1bcb5a4dcd27f54c5dcb35703"
-  integrity sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==
-
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
-
-cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
-  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
-
-cssstyle@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.4.0.tgz#9d31328229d3c565c61e586b02041a28fccdccf1"
-  integrity sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==
-  dependencies:
-    cssom "0.3.x"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -998,15 +542,6 @@ dashdash@^1.12.0:
   integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   dependencies:
     assert-plus "^1.0.0"
-
-data-urls@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
-  integrity sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==
-  dependencies:
-    abab "^2.0.0"
-    whatwg-mimetype "^2.2.0"
-    whatwg-url "^7.0.0"
 
 debug@3.2.6, debug@^3.2.6:
   version "3.2.6"
@@ -1022,13 +557,6 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
-
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1043,11 +571,6 @@ deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
-
-deep-is@~0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
@@ -1078,6 +601,11 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+defined@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
+  integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -1089,24 +617,23 @@ delegates@^1.0.0:
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
 dependency-graph@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.8.0.tgz#2da2d35ed852ecc24a5d6c17788ba57c3708755b"
-  integrity sha512-DCvzSq2UiMsuLnj/9AL484ummEgLtZIcRS7YvtO38QnpX3vqh9nJ8P+zhu8Ja+SmLrBHO2iDbva20jq38qvBkQ==
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.8.1.tgz#9b8cae3aa2c7bd95ccb3347a09a2d1047a6c3c5a"
+  integrity sha512-g213uqF8fyk40W8SBjm079n3CZB4qSpCrA2ye1fLGzH/4HEgB6tzuW2CbLE7leb4t45/6h44Ud59Su1/ROTfqw==
 
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
-detect-newline@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
-  integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
-
-diff-sequences@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
-  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
+detective@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/detective/-/detective-5.2.0.tgz#feb2a77e85b904ecdea459ad897cc90a99bd2a7b"
+  integrity sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==
+  dependencies:
+    acorn-node "^1.6.1"
+    defined "^1.0.0"
+    minimist "^1.1.1"
 
 diff@3.5.0:
   version "3.5.0"
@@ -1120,13 +647,6 @@ dir-glob@^2.2.2:
   dependencies:
     path-type "^3.0.0"
 
-domexception@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
-  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
-  dependencies:
-    webidl-conversions "^4.0.2"
-
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -1135,15 +655,15 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-electron-to-chromium@^1.3.284:
-  version "1.3.292"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.292.tgz#7812fc5138619342f1dd5823df6e9cbb7d2820e9"
-  integrity sha512-hqkem5ANpt6mxVXmhAmlbdG8iicuyM/jEYgmP1tiHPeOLyZoTyGUzrDmJS/xyrrZy9frkW1uQcubicu7f6DS5g==
+electron-to-chromium@^1.3.341:
+  version "1.3.345"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz#2569d0d54a64ef0f32a4b7e8c80afa5fe57c5d98"
+  integrity sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==
 
 elm@^0.19.1-2:
-  version "0.19.1-2"
-  resolved "https://registry.yarnpkg.com/elm/-/elm-0.19.1-2.tgz#0f5c82739b23ceec05f5077fa9d783687de2a3f8"
-  integrity sha512-d6cQhSfif1L3LgouseJcVxkyKztbrBCkx4RoRVIp4rm9E7P7bJTRDYn94JrotVT5kDntUm5Qb33KMD45rw5wCw==
+  version "0.19.1-3"
+  resolved "https://registry.yarnpkg.com/elm/-/elm-0.19.1-3.tgz#2382aa1943bc79974b5d95b0a6acbe010ee16909"
+  integrity sha512-6y36ewCcVmTOx8lj7cKJs3bhI5qMfoVEigePZ9PhEUNKpwjjML/pU2u2YSpHVAznuCcojoF6KIsrS1Ci7GtVaQ==
   dependencies:
     request "^2.88.0"
 
@@ -1166,26 +686,27 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.5.1:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.16.0.tgz#d3a26dc9c3283ac9750dca569586e976d9dcc06d"
-  integrity sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==
+es-abstract@^1.17.0-next.1:
+  version "1.17.4"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
+  integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
   dependencies:
-    es-to-primitive "^1.2.0"
+    es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
     has "^1.0.3"
-    has-symbols "^1.0.0"
-    is-callable "^1.1.4"
-    is-regex "^1.0.4"
-    object-inspect "^1.6.0"
+    has-symbols "^1.0.1"
+    is-callable "^1.1.5"
+    is-regex "^1.0.5"
+    object-inspect "^1.7.0"
     object-keys "^1.1.1"
-    string.prototype.trimleft "^2.1.0"
-    string.prototype.trimright "^2.1.0"
+    object.assign "^4.1.0"
+    string.prototype.trimleft "^2.1.1"
+    string.prototype.trimright "^2.1.1"
 
-es-to-primitive@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
-  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
   dependencies:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
@@ -1196,42 +717,10 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escodegen@^1.9.1:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.12.0.tgz#f763daf840af172bb3a2b6dd7219c0e17f7ff541"
-  integrity sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==
-  dependencies:
-    esprima "^3.1.3"
-    estraverse "^4.2.0"
-    esutils "^2.0.2"
-    optionator "^0.8.1"
-  optionalDependencies:
-    source-map "~0.6.1"
-
-esprima@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
-  integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
-
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
-
-estraverse@^4.2.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
-  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
-
-esutils@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
-  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
-exec-sh@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
-  integrity sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==
 
 execa@^1.0.0:
   version "1.0.0"
@@ -1246,11 +735,6 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-exit@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
-  integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
-
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -1263,18 +747,6 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-expect@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"
-  integrity sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-styles "^3.2.0"
-    jest-get-type "^24.9.0"
-    jest-matcher-utils "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-regex-util "^24.9.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -1320,10 +792,10 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
-  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+fast-deep-equal@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
+  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
 fast-glob@^2.2.6:
   version "2.2.7"
@@ -1338,21 +810,14 @@ fast-glob@^2.2.6:
     micromatch "^3.1.10"
 
 fast-json-stable-stringify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
-  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@~2.0.4:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
-
-fb-watchman@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
-  integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
-  dependencies:
-    bser "^2.0.0"
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -1435,12 +900,12 @@ fs.realpath@^1.0.0:
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.2.7:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.9.tgz#3f5ed66583ccd6f400b5a00db6f7e861363e388f"
-  integrity sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.11.tgz#67bf57f4758f02ede88fb2a1712fef4d15358be3"
+  integrity sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==
   dependencies:
+    bindings "^1.5.0"
     nan "^2.12.1"
-    node-pre-gyp "^0.12.0"
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -1520,10 +985,10 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.5.tgz#6714c69bee20f3c3e64c4dd905553e532b40cdc0"
-  integrity sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==
+glob@^7.1.2, glob@^7.1.3:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1531,11 +996,6 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-globals@^11.1.0:
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
-  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globby@^9.0.0:
   version "9.2.0"
@@ -1551,31 +1011,15 @@ globby@^9.0.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
-  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
+  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
-
-growly@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
-  integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
-
-handlebars@^4.1.2:
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.4.5.tgz#1b1f94f9bfe7379adda86a8b73fb570265a0dddd"
-  integrity sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==
-  dependencies:
-    neo-async "^2.6.0"
-    optimist "^0.6.1"
-    source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -1595,10 +1039,15 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
-has-symbols@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
-  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-symbols@^1.0.0, has-symbols@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
+  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -1636,7 +1085,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1, has@^1.0.3:
+has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -1648,18 +1097,6 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hosted-git-info@^2.1.4:
-  version "2.8.5"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
-  integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
-
-html-encoding-sniffer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
-  integrity sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==
-  dependencies:
-    whatwg-encoding "^1.0.1"
-
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -1669,7 +1106,7 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.4:
+iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -1710,19 +1147,6 @@ import-from@^2.1.0:
   dependencies:
     resolve-from "^3.0.0"
 
-import-local@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
-  integrity sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==
-  dependencies:
-    pkg-dir "^3.0.0"
-    resolve-cwd "^2.0.0"
-
-imurmurhash@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
-  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
-
 indexes-of@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
@@ -1745,13 +1169,6 @@ ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
-
-invariant@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
 
 invert-kv@^2.0.0:
   version "2.0.0"
@@ -1794,17 +1211,10 @@ is-buffer@~2.0.3:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
-is-callable@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
-  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
-
-is-ci@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
-  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
-  dependencies:
-    ci-info "^2.0.0"
+is-callable@^1.1.4, is-callable@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
+  integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -1821,9 +1231,9 @@ is-data-descriptor@^1.0.0:
     kind-of "^6.0.0"
 
 is-date-object@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
-  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
+  integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -1877,11 +1287,6 @@ is-fullwidth-code-point@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
-is-generator-fn@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
-  integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
-
 is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
@@ -1910,12 +1315,12 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-regex@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
-  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
+is-regex@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
+  integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
   dependencies:
-    has "^1.0.1"
+    has "^1.0.3"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -1923,11 +1328,11 @@ is-stream@^1.1.0:
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
 is-symbol@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
-  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
+  integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
   dependencies:
-    has-symbols "^1.0.0"
+    has-symbols "^1.0.1"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1938,11 +1343,6 @@ is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
-
-is-wsl@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
-  integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -1971,410 +1371,6 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-istanbul-lib-coverage@^2.0.2, istanbul-lib-coverage@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
-  integrity sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
-
-istanbul-lib-instrument@^3.0.1, istanbul-lib-instrument@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz#a5f63d91f0bbc0c3e479ef4c5de027335ec6d630"
-  integrity sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==
-  dependencies:
-    "@babel/generator" "^7.4.0"
-    "@babel/parser" "^7.4.3"
-    "@babel/template" "^7.4.0"
-    "@babel/traverse" "^7.4.3"
-    "@babel/types" "^7.4.0"
-    istanbul-lib-coverage "^2.0.5"
-    semver "^6.0.0"
-
-istanbul-lib-report@^2.0.4:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz#5a8113cd746d43c4889eba36ab10e7d50c9b4f33"
-  integrity sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==
-  dependencies:
-    istanbul-lib-coverage "^2.0.5"
-    make-dir "^2.1.0"
-    supports-color "^6.1.0"
-
-istanbul-lib-source-maps@^3.0.1:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz#284997c48211752ec486253da97e3879defba8c8"
-  integrity sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==
-  dependencies:
-    debug "^4.1.1"
-    istanbul-lib-coverage "^2.0.5"
-    make-dir "^2.1.0"
-    rimraf "^2.6.3"
-    source-map "^0.6.1"
-
-istanbul-reports@^2.2.6:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.6.tgz#7b4f2660d82b29303a8fe6091f8ca4bf058da1af"
-  integrity sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==
-  dependencies:
-    handlebars "^4.1.2"
-
-jest-changed-files@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.9.0.tgz#08d8c15eb79a7fa3fc98269bc14b451ee82f8039"
-  integrity sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    execa "^1.0.0"
-    throat "^4.0.0"
-
-jest-cli@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-24.9.0.tgz#ad2de62d07472d419c6abc301fc432b98b10d2af"
-  integrity sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==
-  dependencies:
-    "@jest/core" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
-    exit "^0.1.2"
-    import-local "^2.0.0"
-    is-ci "^2.0.0"
-    jest-config "^24.9.0"
-    jest-util "^24.9.0"
-    jest-validate "^24.9.0"
-    prompts "^2.0.1"
-    realpath-native "^1.1.0"
-    yargs "^13.3.0"
-
-jest-config@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-24.9.0.tgz#fb1bbc60c73a46af03590719efa4825e6e4dd1b5"
-  integrity sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==
-  dependencies:
-    "@babel/core" "^7.1.0"
-    "@jest/test-sequencer" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    babel-jest "^24.9.0"
-    chalk "^2.0.1"
-    glob "^7.1.1"
-    jest-environment-jsdom "^24.9.0"
-    jest-environment-node "^24.9.0"
-    jest-get-type "^24.9.0"
-    jest-jasmine2 "^24.9.0"
-    jest-regex-util "^24.3.0"
-    jest-resolve "^24.9.0"
-    jest-util "^24.9.0"
-    jest-validate "^24.9.0"
-    micromatch "^3.1.10"
-    pretty-format "^24.9.0"
-    realpath-native "^1.1.0"
-
-jest-diff@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
-  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
-  dependencies:
-    chalk "^2.0.1"
-    diff-sequences "^24.9.0"
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
-
-jest-docblock@^24.3.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.9.0.tgz#7970201802ba560e1c4092cc25cbedf5af5a8ce2"
-  integrity sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==
-  dependencies:
-    detect-newline "^2.1.0"
-
-jest-each@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-24.9.0.tgz#eb2da602e2a610898dbc5f1f6df3ba86b55f8b05"
-  integrity sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
-    jest-get-type "^24.9.0"
-    jest-util "^24.9.0"
-    pretty-format "^24.9.0"
-
-jest-environment-jsdom@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz#4b0806c7fc94f95edb369a69cc2778eec2b7375b"
-  integrity sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==
-  dependencies:
-    "@jest/environment" "^24.9.0"
-    "@jest/fake-timers" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    jest-mock "^24.9.0"
-    jest-util "^24.9.0"
-    jsdom "^11.5.1"
-
-jest-environment-node@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-24.9.0.tgz#333d2d2796f9687f2aeebf0742b519f33c1cbfd3"
-  integrity sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==
-  dependencies:
-    "@jest/environment" "^24.9.0"
-    "@jest/fake-timers" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    jest-mock "^24.9.0"
-    jest-util "^24.9.0"
-
-jest-get-type@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
-  integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
-
-jest-haste-map@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.9.0.tgz#b38a5d64274934e21fa417ae9a9fbeb77ceaac7d"
-  integrity sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    anymatch "^2.0.0"
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.1.15"
-    invariant "^2.2.4"
-    jest-serializer "^24.9.0"
-    jest-util "^24.9.0"
-    jest-worker "^24.9.0"
-    micromatch "^3.1.10"
-    sane "^4.0.3"
-    walker "^1.0.7"
-  optionalDependencies:
-    fsevents "^1.2.7"
-
-jest-jasmine2@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz#1f7b1bd3242c1774e62acabb3646d96afc3be6a0"
-  integrity sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==
-  dependencies:
-    "@babel/traverse" "^7.1.0"
-    "@jest/environment" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
-    co "^4.6.0"
-    expect "^24.9.0"
-    is-generator-fn "^2.0.0"
-    jest-each "^24.9.0"
-    jest-matcher-utils "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-runtime "^24.9.0"
-    jest-snapshot "^24.9.0"
-    jest-util "^24.9.0"
-    pretty-format "^24.9.0"
-    throat "^4.0.0"
-
-jest-leak-detector@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz#b665dea7c77100c5c4f7dfcb153b65cf07dcf96a"
-  integrity sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==
-  dependencies:
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
-
-jest-matcher-utils@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
-  integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
-  dependencies:
-    chalk "^2.0.1"
-    jest-diff "^24.9.0"
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
-
-jest-message-util@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.9.0.tgz#527f54a1e380f5e202a8d1149b0ec872f43119e3"
-  integrity sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    "@types/stack-utils" "^1.0.1"
-    chalk "^2.0.1"
-    micromatch "^3.1.10"
-    slash "^2.0.0"
-    stack-utils "^1.0.1"
-
-jest-mock@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.9.0.tgz#c22835541ee379b908673ad51087a2185c13f1c6"
-  integrity sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==
-  dependencies:
-    "@jest/types" "^24.9.0"
-
-jest-pnp-resolver@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
-  integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
-
-jest-regex-util@^24.3.0, jest-regex-util@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.9.0.tgz#c13fb3380bde22bf6575432c493ea8fe37965636"
-  integrity sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==
-
-jest-resolve-dependencies@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz#ad055198959c4cfba8a4f066c673a3f0786507ab"
-  integrity sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    jest-regex-util "^24.3.0"
-    jest-snapshot "^24.9.0"
-
-jest-resolve@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-24.9.0.tgz#dff04c7687af34c4dd7e524892d9cf77e5d17321"
-  integrity sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    browser-resolve "^1.11.3"
-    chalk "^2.0.1"
-    jest-pnp-resolver "^1.2.1"
-    realpath-native "^1.1.0"
-
-jest-runner@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-24.9.0.tgz#574fafdbd54455c2b34b4bdf4365a23857fcdf42"
-  integrity sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==
-  dependencies:
-    "@jest/console" "^24.7.1"
-    "@jest/environment" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.4.2"
-    exit "^0.1.2"
-    graceful-fs "^4.1.15"
-    jest-config "^24.9.0"
-    jest-docblock "^24.3.0"
-    jest-haste-map "^24.9.0"
-    jest-jasmine2 "^24.9.0"
-    jest-leak-detector "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-resolve "^24.9.0"
-    jest-runtime "^24.9.0"
-    jest-util "^24.9.0"
-    jest-worker "^24.6.0"
-    source-map-support "^0.5.6"
-    throat "^4.0.0"
-
-jest-runtime@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-24.9.0.tgz#9f14583af6a4f7314a6a9d9f0226e1a781c8e4ac"
-  integrity sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==
-  dependencies:
-    "@jest/console" "^24.7.1"
-    "@jest/environment" "^24.9.0"
-    "@jest/source-map" "^24.3.0"
-    "@jest/transform" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    "@types/yargs" "^13.0.0"
-    chalk "^2.0.1"
-    exit "^0.1.2"
-    glob "^7.1.3"
-    graceful-fs "^4.1.15"
-    jest-config "^24.9.0"
-    jest-haste-map "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-mock "^24.9.0"
-    jest-regex-util "^24.3.0"
-    jest-resolve "^24.9.0"
-    jest-snapshot "^24.9.0"
-    jest-util "^24.9.0"
-    jest-validate "^24.9.0"
-    realpath-native "^1.1.0"
-    slash "^2.0.0"
-    strip-bom "^3.0.0"
-    yargs "^13.3.0"
-
-jest-serializer@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-24.9.0.tgz#e6d7d7ef96d31e8b9079a714754c5d5c58288e73"
-  integrity sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==
-
-jest-snapshot@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-24.9.0.tgz#ec8e9ca4f2ec0c5c87ae8f925cf97497b0e951ba"
-  integrity sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==
-  dependencies:
-    "@babel/types" "^7.0.0"
-    "@jest/types" "^24.9.0"
-    chalk "^2.0.1"
-    expect "^24.9.0"
-    jest-diff "^24.9.0"
-    jest-get-type "^24.9.0"
-    jest-matcher-utils "^24.9.0"
-    jest-message-util "^24.9.0"
-    jest-resolve "^24.9.0"
-    mkdirp "^0.5.1"
-    natural-compare "^1.4.0"
-    pretty-format "^24.9.0"
-    semver "^6.2.0"
-
-jest-util@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.9.0.tgz#7396814e48536d2e85a37de3e4c431d7cb140162"
-  integrity sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==
-  dependencies:
-    "@jest/console" "^24.9.0"
-    "@jest/fake-timers" "^24.9.0"
-    "@jest/source-map" "^24.9.0"
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    callsites "^3.0.0"
-    chalk "^2.0.1"
-    graceful-fs "^4.1.15"
-    is-ci "^2.0.0"
-    mkdirp "^0.5.1"
-    slash "^2.0.0"
-    source-map "^0.6.0"
-
-jest-validate@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.9.0.tgz#0775c55360d173cd854e40180756d4ff52def8ab"
-  integrity sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    camelcase "^5.3.1"
-    chalk "^2.0.1"
-    jest-get-type "^24.9.0"
-    leven "^3.1.0"
-    pretty-format "^24.9.0"
-
-jest-watcher@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-24.9.0.tgz#4b56e5d1ceff005f5b88e528dc9afc8dd4ed2b3b"
-  integrity sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==
-  dependencies:
-    "@jest/test-result" "^24.9.0"
-    "@jest/types" "^24.9.0"
-    "@types/yargs" "^13.0.0"
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.1"
-    jest-util "^24.9.0"
-    string-length "^2.0.0"
-
-jest-worker@^24.6.0, jest-worker@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5"
-  integrity sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==
-  dependencies:
-    merge-stream "^2.0.0"
-    supports-color "^6.1.0"
-
-jest@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
-  integrity sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==
-  dependencies:
-    import-local "^2.0.0"
-    jest-cli "^24.9.0"
-
-"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
-  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
 js-yaml@3.13.1, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
@@ -2387,43 +1383,6 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
-
-jsdom@^11.5.1:
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
-  integrity sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==
-  dependencies:
-    abab "^2.0.0"
-    acorn "^5.5.3"
-    acorn-globals "^4.1.0"
-    array-equal "^1.0.0"
-    cssom ">= 0.3.2 < 0.4.0"
-    cssstyle "^1.0.0"
-    data-urls "^1.0.0"
-    domexception "^1.0.1"
-    escodegen "^1.9.1"
-    html-encoding-sniffer "^1.0.2"
-    left-pad "^1.3.0"
-    nwsapi "^2.0.7"
-    parse5 "4.0.0"
-    pn "^1.1.0"
-    request "^2.87.0"
-    request-promise-native "^1.0.5"
-    sax "^1.2.4"
-    symbol-tree "^3.2.2"
-    tough-cookie "^2.3.4"
-    w3c-hr-time "^1.0.1"
-    webidl-conversions "^4.0.2"
-    whatwg-encoding "^1.0.3"
-    whatwg-mimetype "^2.1.0"
-    whatwg-url "^6.4.1"
-    ws "^5.2.0"
-    xml-name-validator "^3.0.0"
-
-jsesc@^2.5.1:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
-  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
@@ -2444,13 +1403,6 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
-
-json5@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
-  integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
-  dependencies:
-    minimist "^1.2.0"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -2489,14 +1441,9 @@ kind-of@^5.0.0:
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
 kind-of@^6.0.0, kind-of@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
-  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
-
-kleur@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
-  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 lcid@^2.0.0:
   version "2.0.0"
@@ -2504,34 +1451,6 @@ lcid@^2.0.0:
   integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
   dependencies:
     invert-kv "^2.0.0"
-
-left-pad@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
-  integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
-
-leven@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
-  integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
-
-levn@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
-  dependencies:
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-
-load-json-file@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
-  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^4.0.0"
-    pify "^3.0.0"
-    strip-bom "^3.0.0"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -2541,17 +1460,12 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash.sortby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
-
 lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15:
+lodash@^4.17.11, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -2562,28 +1476,6 @@ log-symbols@2.2.0, log-symbols@^2.2.0:
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
-
-loose-envify@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
-  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
-  dependencies:
-    js-tokens "^3.0.0 || ^4.0.0"
-
-make-dir@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
-  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
-  dependencies:
-    pify "^4.0.1"
-    semver "^5.6.0"
-
-makeerror@1.0.x:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
-  integrity sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=
-  dependencies:
-    tmpl "1.0.x"
 
 map-age-cleaner@^0.1.1:
   version "0.1.3"
@@ -2613,11 +1505,6 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-merge-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
-  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
-
 merge2@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
@@ -2642,17 +1529,17 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-mime-db@1.40.0:
-  version "1.40.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
-  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+mime-db@1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
+  integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
 
 mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.24"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
-  integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
+  version "2.1.26"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
+  integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
   dependencies:
-    mime-db "1.40.0"
+    mime-db "1.43.0"
 
 mimic-fn@^2.0.0:
   version "2.1.0"
@@ -2675,11 +1562,6 @@ minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
   version "2.9.0"
@@ -2777,24 +1659,14 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-natural-compare@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-
 needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.2.tgz#3342dea100b7160960a450dc8c22160ac712a528"
+  integrity sha512-DUzITvPVDUy6vczKKYTnWc/pBZ0EnjMJnQ3y+Jo5zfKFimJs7S3HFCxCRZYB9FUZcrzUQr3WsmvZgddMEIZv6w==
   dependencies:
     debug "^3.2.6"
     iconv-lite "^0.4.4"
     sax "^1.2.4"
-
-neo-async@^2.6.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
-  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -2816,31 +1688,10 @@ node-environment-flags@1.0.5:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-int64@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
-  integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
-
-node-modules-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
-  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
-
-node-notifier@^5.4.2:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.4.3.tgz#cb72daf94c93904098e28b9c590fd866e464bd50"
-  integrity sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==
-  dependencies:
-    growly "^1.3.0"
-    is-wsl "^1.1.0"
-    semver "^5.5.0"
-    shellwords "^0.1.1"
-    which "^1.3.0"
-
-node-pre-gyp@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
-  integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
+node-pre-gyp@*:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
+  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -2851,12 +1702,12 @@ node-pre-gyp@^0.12.0:
     rc "^1.2.7"
     rimraf "^2.6.1"
     semver "^5.3.0"
-    tar "^4"
+    tar "^4.4.2"
 
-node-releases@^1.1.36:
-  version "1.1.37"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.37.tgz#af787db03833a7cda5d197cbb8262d5527270bd8"
-  integrity sha512-0EOsAEdn6S2vQdDGBWBpmClm5BCkXVkVOURdnhfg7//rxI2XbleRdKig87WuBrk+0PHZ4OhO58fRm9mzWW4jNw==
+node-releases@^1.1.47:
+  version "1.1.47"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.47.tgz#c59ef739a1fd7ecbd9f0b7cf5b7871e8a8b591e4"
+  integrity sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==
   dependencies:
     semver "^6.3.0"
 
@@ -2867,16 +1718,6 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
-
-normalize-package-data@^2.3.2:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
-  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
-  dependencies:
-    hosted-git-info "^2.1.4"
-    resolve "^1.10.0"
-    semver "2 || 3 || 4 || 5"
-    validate-npm-package-license "^3.0.1"
 
 normalize-path@^2.1.1:
   version "2.1.1"
@@ -2901,17 +1742,25 @@ normalize.css@^8.0.1:
   integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
 
 npm-bundled@^1.0.1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
-  integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
+  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+  dependencies:
+    npm-normalize-package-bin "^1.0.1"
+
+npm-normalize-package-bin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
+  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
 
 npm-packlist@^1.1.6:
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.6.tgz#53ba3ed11f8523079f1457376dd379ee4ea42ff4"
-  integrity sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
+  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
+    npm-normalize-package-bin "^1.0.1"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -2940,11 +1789,6 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-nwsapi@^2.0.7:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.4.tgz#e006a878db23636f8e8a67d33ca0e4edf61a842f"
-  integrity sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==
-
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -2964,10 +1808,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
-  integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
+object-inspect@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
+  integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
 
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -2981,7 +1825,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@4.1.0:
+object.assign@4.1.0, object.assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
   integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
@@ -2992,12 +1836,12 @@ object.assign@4.1.0:
     object-keys "^1.0.11"
 
 object.getownpropertydescriptors@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
-  integrity sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
+  integrity sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
   dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.5.1"
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -3012,26 +1856,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
-
-optimist@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
-  integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
-  dependencies:
-    minimist "~0.0.1"
-    wordwrap "~0.0.2"
-
-optionator@^0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
-  integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
-  dependencies:
-    deep-is "~0.1.3"
-    fast-levenshtein "~2.0.4"
-    levn "~0.3.0"
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-    wordwrap "~1.0.0"
 
 os-homedir@^1.0.0:
   version "1.0.2"
@@ -3065,13 +1889,6 @@ p-defer@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
   integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
-p-each-series@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-1.0.0.tgz#930f3d12dd1f50e7434457a22cd6f04ac6ad7f71"
-  integrity sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=
-  dependencies:
-    p-reduce "^1.0.0"
-
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -3083,9 +1900,9 @@ p-is-promise@^2.0.0:
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
-  integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
+  integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
   dependencies:
     p-try "^2.0.0"
 
@@ -3095,11 +1912,6 @@ p-locate@^3.0.0:
   integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
     p-limit "^2.0.0"
-
-p-reduce@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
-  integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -3113,11 +1925,6 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
-
-parse5@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
-  integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -3176,25 +1983,6 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pirates@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
-  integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
-  dependencies:
-    node-modules-regexp "^1.0.0"
-
-pkg-dir@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
-  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
-  dependencies:
-    find-up "^3.0.0"
-
-pn@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
-  integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
-
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -3245,12 +2033,12 @@ postcss-load-config@^2.0.0:
     import-cwd "^2.0.0"
 
 postcss-nested@^4.1.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-4.1.2.tgz#8e0570f736bfb4be5136e31901bf2380b819a561"
-  integrity sha512-9bQFr2TezohU3KRSu9f6sfecXmf/x6RXDedl8CHF6fyuyVW7UqgNMRdWMHZQWuFY6Xqs2NYk+Fj4Z4vSOf7PQg==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-4.2.1.tgz#4bc2e5b35e3b1e481ff81e23b700da7f82a8b248"
+  integrity sha512-AMayXX8tS0HCp4O4lolp4ygj9wBn32DJWXvG6gCv+ZvJrEa00GUxJcJEEzMh87BIe6FrWdYkpR2cuyqHKrxmXw==
   dependencies:
-    postcss "^7.0.14"
-    postcss-selector-parser "^5.0.0"
+    postcss "^7.0.21"
+    postcss-selector-parser "^6.0.2"
 
 postcss-reporter@^6.0.0:
   version "6.0.1"
@@ -3262,16 +2050,7 @@ postcss-reporter@^6.0.0:
     log-symbols "^2.2.0"
     postcss "^7.0.7"
 
-postcss-selector-parser@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz#249044356697b33b64f1a8f7c80922dddee7195c"
-  integrity sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==
-  dependencies:
-    cssesc "^2.0.0"
-    indexes-of "^1.0.1"
-    uniq "^1.0.1"
-
-postcss-selector-parser@^6.0.0:
+postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
   integrity sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==
@@ -3299,29 +2078,14 @@ postcss@^6.0.9:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postcss@^7.0.0, postcss@^7.0.11, postcss@^7.0.14, postcss@^7.0.18, postcss@^7.0.7:
-  version "7.0.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.18.tgz#4b9cda95ae6c069c67a4d933029eddd4838ac233"
-  integrity sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==
+postcss@^7.0.0, postcss@^7.0.11, postcss@^7.0.18, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.7:
+  version "7.0.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.26.tgz#5ed615cfcab35ba9bbb82414a4fa88ea10429587"
+  integrity sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
-
-prelude-ls@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
-  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
-
-pretty-format@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
 
 pretty-hrtime@^1.0.3:
   version "1.0.3"
@@ -3333,18 +2097,10 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-prompts@^2.0.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.2.1.tgz#f901dd2a2dfee080359c0e20059b24188d75ad35"
-  integrity sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==
-  dependencies:
-    kleur "^3.0.3"
-    sisteransi "^1.0.3"
-
-psl@^1.1.24, psl@^1.1.28:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.4.0.tgz#5dd26156cdb69fa1fdb8ab1991667d3f80ced7c2"
-  integrity sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==
+psl@^1.1.24:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.7.0.tgz#f1c4c47a8ef97167dea5d6bbf4816d736e884a3c"
+  integrity sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==
 
 pump@^3.0.0:
   version "3.0.0"
@@ -3359,7 +2115,7 @@ punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -3379,11 +2135,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-is@^16.8.4:
-  version "16.11.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
-  integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
-
 read-cache@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
@@ -3391,27 +2142,10 @@ read-cache@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
-read-pkg-up@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-4.0.0.tgz#1b221c6088ba7799601c808f91161c66e58f8978"
-  integrity sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==
-  dependencies:
-    find-up "^3.0.0"
-    read-pkg "^3.0.0"
-
-read-pkg@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
-  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
-  dependencies:
-    load-json-file "^4.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^3.0.0"
-
 readable-stream@^2.0.2, readable-stream@^2.0.6:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
-  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -3429,13 +2163,6 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
-
-realpath-native@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
-  integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
-  dependencies:
-    util.promisify "^1.0.0"
 
 reduce-css-calc@^2.1.6:
   version "2.1.7"
@@ -3468,23 +2195,7 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-request-promise-core@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
-  integrity sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==
-  dependencies:
-    lodash "^4.17.11"
-
-request-promise-native@^1.0.5:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.7.tgz#a49868a624bdea5069f1251d0a836e0d89aa2c59"
-  integrity sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==
-  dependencies:
-    request-promise-core "1.1.2"
-    stealthy-require "^1.1.1"
-    tough-cookie "^2.3.3"
-
-request@^2.87.0, request@^2.88.0:
+request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -3525,13 +2236,6 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
-resolve-cwd@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
-  integrity sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=
-  dependencies:
-    resolve-from "^3.0.0"
-
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
@@ -3542,15 +2246,10 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
-
-resolve@^1.10.0, resolve@^1.3.2:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
-  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+resolve@^1.14.2:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
+  integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
   dependencies:
     path-parse "^1.0.6"
 
@@ -3559,17 +2258,12 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
+rimraf@^2.6.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
-
-rsvp@^4.8.4:
-  version "4.8.5"
-  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
-  integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.0"
@@ -3593,32 +2287,17 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sane@^4.0.3:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-4.1.0.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded"
-  integrity sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==
-  dependencies:
-    "@cnakazawa/watch" "^1.0.3"
-    anymatch "^2.0.0"
-    capture-exit "^2.0.0"
-    exec-sh "^0.3.2"
-    execa "^1.0.0"
-    fb-watchman "^2.0.0"
-    micromatch "^3.1.4"
-    minimist "^1.1.1"
-    walker "~1.0.5"
-
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.0:
+semver@^5.3.0, semver@^5.5.0, semver@^5.7.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
+semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -3650,20 +2329,10 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shellwords@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
-  integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
-
-signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
-
-sisteransi@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.3.tgz#98168d62b79e3a5e758e27ae63c4a053d748f4eb"
-  integrity sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==
 
 slash@^2.0.0:
   version "2.0.0"
@@ -3701,64 +2370,30 @@ snapdragon@^0.8.1:
     use "^3.1.0"
 
 source-map-resolve@^0.5.0:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
-  integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
+  integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
   dependencies:
-    atob "^2.1.1"
+    atob "^2.1.2"
     decode-uri-component "^0.2.0"
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
-
-source-map-support@^0.5.6:
-  version "0.5.13"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
-  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
 
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@^0.5.0, source-map@^0.5.6:
+source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-spdx-correct@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
-  integrity sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
-  dependencies:
-    spdx-expression-parse "^3.0.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-exceptions@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
-  integrity sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==
-
-spdx-expression-parse@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
-  integrity sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
-  dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-license-ids@^3.0.0:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
-  integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -3787,11 +2422,6 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-stack-utils@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
-  integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
-
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -3799,19 +2429,6 @@ static-extend@^0.1.1:
   dependencies:
     define-property "^0.2.5"
     object-copy "^0.1.0"
-
-stealthy-require@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
-
-string-length@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
-  integrity sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=
-  dependencies:
-    astral-regex "^1.0.0"
-    strip-ansi "^4.0.0"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -3839,18 +2456,18 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string.prototype.trimleft@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
-  integrity sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==
+string.prototype.trimleft@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz#9bdb8ac6abd6d602b17a4ed321870d2f8dcefc74"
+  integrity sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==
   dependencies:
     define-properties "^1.1.3"
     function-bind "^1.1.1"
 
-string.prototype.trimright@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz#669d164be9df9b6f7559fa8e89945b168a5a6c58"
-  integrity sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==
+string.prototype.trimright@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz#440314b15996c866ce8a0341894d45186200c5d9"
+  integrity sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==
   dependencies:
     define-properties "^1.1.3"
     function-bind "^1.1.1"
@@ -3883,11 +2500,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
-
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -3919,21 +2531,24 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-symbol-tree@^3.2.2:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
-  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
 
 tailwindcss@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.1.2.tgz#0107dc092c3edee6132b105d896b109c0f66afd6"
-  integrity sha512-mcTzZHXMipnQY9haB17baNJmBTkYYcC8ljfMdB9/97FfhKJIzlglJcyGythuQTOu7r/QIbLfZYYWZhAvaGj95A==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.2.0.tgz#5df317cebac4f3131f275d258a39da1ba3a0f291"
+  integrity sha512-CKvY0ytB3ze5qvynG7qv4XSpQtFNGPbu9pUn8qFdkqgD8Yo/vGss8mhzbqls44YCXTl4G62p3qVZBj45qrd6FQ==
   dependencies:
     autoprefixer "^9.4.5"
     bytes "^3.0.0"
-    chalk "^2.4.1"
+    chalk "^3.0.0"
+    detective "^5.2.0"
     fs-extra "^8.0.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     node-emoji "^1.8.1"
     normalize.css "^8.0.1"
     postcss "^7.0.11"
@@ -3943,8 +2558,9 @@ tailwindcss@^1.1.2:
     postcss-selector-parser "^6.0.0"
     pretty-hrtime "^1.0.3"
     reduce-css-calc "^2.1.6"
+    resolve "^1.14.2"
 
-tar@^4:
+tar@^4.4.2:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
@@ -3956,31 +2572,6 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
-
-test-exclude@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.3.tgz#c3d3e1e311eb7ee405e092dac10aefd09091eac0"
-  integrity sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==
-  dependencies:
-    glob "^7.1.3"
-    minimatch "^3.0.4"
-    read-pkg-up "^4.0.0"
-    require-main-filename "^2.0.0"
-
-throat@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
-  integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
-
-tmpl@1.0.x:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
-  integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
-
-to-fast-properties@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
-  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
 to-object-path@^0.3.0:
   version "0.3.0"
@@ -4007,14 +2598,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-tough-cookie@^2.3.3, tough-cookie@^2.3.4:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
 tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
@@ -4022,13 +2605,6 @@ tough-cookie@~2.4.3:
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
-
-tr46@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
-  integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
-  dependencies:
-    punycode "^2.1.0"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -4041,21 +2617,6 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
-
-type-check@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
-  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
-  dependencies:
-    prelude-ls "~1.1.2"
-
-uglify-js@^3.1.4:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.3.tgz#1351533bbe22cc698f012589ed6bd4cbd971bff8"
-  integrity sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==
-  dependencies:
-    commander "~2.20.3"
-    source-map "~0.6.1"
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -4112,26 +2673,10 @@ util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-util.promisify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
-  integrity sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==
-  dependencies:
-    define-properties "^1.1.2"
-    object.getownpropertydescriptors "^2.0.3"
-
 uuid@^3.3.2:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
-  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
-
-validate-npm-package-license@^3.0.1:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
-  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
-  dependencies:
-    spdx-correct "^3.0.0"
-    spdx-expression-parse "^3.0.0"
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 verror@1.10.0:
   version "1.10.0"
@@ -4142,61 +2687,12 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-w3c-hr-time@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
-  integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
-  dependencies:
-    browser-process-hrtime "^0.1.2"
-
-walker@^1.0.7, walker@~1.0.5:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
-  integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
-  dependencies:
-    makeerror "1.0.x"
-
-webidl-conversions@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
-  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-
-whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
-  integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
-  dependencies:
-    iconv-lite "0.4.24"
-
-whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
-  integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
-
-whatwg-url@^6.4.1:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
-  integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.1"
-    webidl-conversions "^4.0.2"
-
-whatwg-url@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.1.0.tgz#c2c492f1eca612988efd3d2266be1b9fc6170d06"
-  integrity sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.1"
-    webidl-conversions "^4.0.2"
-
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@1.3.1, which@^1.2.9, which@^1.3.0:
+which@1.3.1, which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -4209,16 +2705,6 @@ wide-align@1.1.3, wide-align@^1.1.0:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
-
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
-  integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
-
-wordwrap@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
@@ -4242,26 +2728,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
-  integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
-  dependencies:
-    graceful-fs "^4.1.11"
-    imurmurhash "^0.1.4"
-    signal-exit "^3.0.2"
-
-ws@^5.2.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
-  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
-  dependencies:
-    async-limiter "~1.0.0"
-
-xml-name-validator@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
-  integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+xtend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Hey 👋
Thanks for this library!

The [next version](https://github.com/tailwindcss/tailwindcss/releases/tag/v1.2.0-canary.4) of Tailwind has more classes that are negative (ie. start with a dash `-`). New classes include transforms, such as `-translate-x-1`. So instead of checking just the letter `m` and `p`, it now checks all the letters.