### PR TITLE
Some suggestions

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -48,7 +48,7 @@ function fixClass(cls) {
   cls = cls.replace(/^(\.)/, "");
   // remove extras at end
   cls = cls.replace(
-    /:(responsive|group-hover|focus-within|first|last|odd|even|hover|focus|active|visited|disabled)$/,
+    /:(focus-within|first-child|last-child|odd|even|hover|focus|active|visited|disabled)$/,
     ""
   );
   // remove extras at end
@@ -87,7 +87,7 @@ function toElmName(cls, opts) {
   // replace dashes now we have sorted the negative stuff
   elm = elm.replace(/-/g, "_");
   // replace :
-  elm = elm.replace(/:/g, "_");
+  elm = elm.replace(/:/g, "__");
   // handle fractions
   elm = elm.replace(/\//g, "over");
   // clean up

--- a/index.js
+++ b/index.js
@@ -12,18 +12,9 @@ module.exports = postcss.plugin("postcss-elm-tailwind", opts => {
   return (root, result) => {
     // Transform CSS AST here
     root.walkRules(rule => {
-      if (!rule.selector.startsWith(".")) {
-        // keep only classes
-        return;
-      }
-
-      let cls = rule.selector;
-
-      cls = h.fixClass(cls);
-      let elm = h.toElmName(cls, opts);
-
-      classes.set(cls, h.elmFunction(cls, elm));
-      elm_fns.push(elm);
+      rule.selector
+        .split(" ")
+        .forEach(selector => processSelector(selector, opts));
     });
 
     const elmModule =
@@ -39,3 +30,18 @@ module.exports = postcss.plugin("postcss-elm-tailwind", opts => {
     });
   };
 });
+
+function processSelector(selector, opts) {
+  if (!selector.startsWith(".")) {
+    // Keep only classes
+    return;
+  }
+
+  let cls, elm;
+
+  cls = h.fixClass(selector);
+  elm = h.toElmName(cls, opts);
+
+  classes.set(cls, h.elmFunction(cls, elm));
+  elm_fns.push(elm);
+}


### PR DESCRIPTION
Hey @monty5811 
Here are those suggestions I talked about a while ago.
In order of appearance:

1. Regarding `// remove extras at end`:
`first` and `last` suffixes aren't used, they are actually `first-child` and `last-child`.
`responsive` and `group-hover` suffixes don't exist, so I removed these.

2. Regarding `// replace :`:
I feel like `lg__text_gray_700` reads better than `lg_text_gray_700`, and also indicates better that `lg` is a prefix with a colon.

3. Regarding `root.walkRules`:
Sometimes selectors consist out of multiple classes, so we need to split those up in multiple segments. For example, there's `.group-hover` which is prefixed by `.group `, because you add the group class to the parent element ([more info](https://tailwindcss.com/docs/pseudo-class-variants/#group-hover)).