### PR TITLE
Change main plugin method to return Promise wrapping the file write operation

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,12 +23,11 @@ module.exports = postcss.plugin("postcss-elm-tailwind", opts => {
       h.elmBody(classes);
 
     // writing to disk
-    fs.writeFileSync(opts.elmFile, elmModule, err => {
-      if (err) {
-        return console.log(err);
-      }
-
-      console.log(opts.elmFile, "was saved!");
+    return new Promise((resolve, reject) => {
+      fs.writeFile(opts.elmFile, elmModule, err => {
+        if (err) return reject(err)
+        resolve()
+      });
     });
   };
 });

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = postcss.plugin("postcss-elm-tailwind", opts => {
       h.elmBody(classes);
 
     // writing to disk
-    fs.writeFile(opts.elmFile, elmModule, err => {
+    fs.writeFileSync(opts.elmFile, elmModule, err => {
       if (err) {
         return console.log(err);
       }

--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ module.exports = postcss.plugin("postcss-elm-tailwind", opts => {
     // writing to disk
     return new Promise((resolve, reject) => {
       fs.writeFile(opts.elmFile, elmModule, err => {
-        if (err) return reject(err)
-        resolve()
+        if (err) return reject(err);
+        resolve();
       });
     });
   };


### PR DESCRIPTION
Hey @monty5811. I was looking into the intermittent problem I'm getting (mentioned it on the Elm slack) where sometimes the parcel build fails because it looks like `TW.elm` is invalid: looks like it's halfway through being written. As part of this, I looked into the source code and noticed you're using `fs.writeFile` but not returning anything that wraps that async operation. I wonder if that might be related as the plugin will think it's completed before the file write operation is done.

I looked at the docs for postcss plugins and found this section: https://github.com/postcss/postcss/blob/master/docs/guidelines/plugin.md#22-use-asynchronous-methods-whenever-possible

So here's a PR to change it to use that approach. I know nothing about postcss plugins, so this might not be the right approach at all, so obviously feel free to reject the PR if you disagree :-)

Note that I also took out the bit where you write to the console that the file was written. Wasn't sure if you wanted that included or not, so let me know if you want me to add that back in before resolving the promise.