### PR TITLE
Simplify selector processing

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,11 +11,8 @@ module.exports = postcss.plugin("postcss-elm-tailwind", opts => {
 
   return (root, result) => {
     // Transform CSS AST here
-    root.walkRules(rule => {
-      rule.selector
-        .split(" ")
-        .map(sel => sel.split(","))
-        .reduce((arr, v) => (arr.push(...v), arr), [])
+    root.walkRules(/^\./, rule => {
+      rule.selectors
         .forEach(selector => processSelector(selector, opts));
     });
 


### PR DESCRIPTION
Whilst debugging some of the problems I found with https://github.com/sparksp/postcss-elm-tailwind/pull/1 I discovered that Postcss can do all the hard work to gather the selectors for you!

There's two small changes here:

1. The addition of a regex filter `/^\./` to grab only class selectors,
    * I've left the guard in `processSelector` but confirmed by debugging that it now doesn't trigger.
2. Use `rule.selectors` to replace the manual work of splitting, mapping and reducing `rule.selector`
    * Bonus: `rule.selectors` correctly handles newlines and other whitespace in the selector list - that said, tailwind is strictly a 1 selector per rule framework anyway.
    * Verified by running this on my project that the generated modules do not change.

