### PR TITLE
Improve removal of pseudo classes and elements

### DIFF
--- a/demo/tailwind.config.js
+++ b/demo/tailwind.config.js
@@ -3,12 +3,18 @@ module.exports = {
   variants: {
     backgroundColor: [
       "responsive",
-      "first",
-      "last",
-      "hover",
-      "focus",
+      "active",
+      "disabled",
       "even",
-      "odd"
+      "first",
+      "focus-within",
+      "focus",
+      "group-focus",
+      "group-hover",
+      "hover",
+      "last",
+      "odd",
+      "visited"
     ]
   },
   plugins: [require("@tailwindcss/custom-forms"), require("@tailwindcss/ui")],

--- a/helpers.js
+++ b/helpers.js
@@ -92,27 +92,21 @@ function fixClass(cls) {
   cls = cls.replace(/^(\.)/, "");
   // make other dots safe
   cls = cls.replace(/\\\./g, ".");
-  // remove extras at end
+  // remove > anything
+  cls = cls.replace(/\s?>\s?.*/, "");
+  // remove pseudo-elements (::)
+  cls = cls.replace(/::.*$/, "");
+  // remove pseudo-classes (:)
   cls = cls.replace(
-    /:(focus-within|first-child|last-child|odd|even|hover|focus|active|visited|disabled)$/,
+    /(:(active|after|before|checked|disabled|focus|focus-within|hover|visited|nth-child\((even|odd)\)|(first|last)-child))+$/,
     ""
   );
-  // remove extras at end
-  cls = cls.replace(/::(placeholder)$/, "");
-  cls = cls.replace(/:(first|last)-child/, "");
-  cls = cls.replace(/:before/, "");
-  cls = cls.replace(/:nth-child\((even|odd)\)/, "");
-  cls = cls.replace(/\s?>\s?.*/, "");
-  //
+  // make / safe for elm
   cls = cls.replace(/\\\//g, "/");
   // make \/ safe for elm
   cls = cls.replace(/\\([/])/g, "\\\\$1");
   // make \: safe for elm
   cls = cls.replace(/\\([:])/g, "$1");
-  cls = cls.replace(
-    /^(responsive|group-hover|focus-within|first|last|odd|even|hover|focus|active|visited|disabled)\\\\:/,
-    "$1:"
-  );
   return cls;
 }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -33,18 +33,81 @@ describe("cleanOpts", () => {
 
 describe("fixClass", () => {
   it("should let container pass through", () => {
-    assert.equal(h.fixClass("container"), "container");
+    assert.equal(h.fixClass(".container"), "container");
   });
   it("should let mx-auto pass through", () => {
-    assert.equal(h.fixClass("mx-auto"), "mx-auto");
+    assert.equal(h.fixClass(".mx-auto"), "mx-auto");
   });
   it("responsive", () => {
-    assert.equal(h.fixClass("sm:mx-auto"), "sm:mx-auto");
+    assert.equal(h.fixClass(".sm:mx-auto"), "sm:mx-auto");
   });
-  it("responsive and focus", () => {
+  describe("pseudo-classes", () => {
+    it("removes :after", () => {
+      assert.equal(
+        h.fixClass(".tw-clearfix:after"),
+        "tw-clearfix"
+      );  
+    });
+    it("removes :before", () => {
+      assert.equal(
+        h.fixClass(".fa-accessible-icon:before"),
+        "fa-accessible-icon"
+      );  
+    });
+    it("removes :disabled", () => {
+      assert.equal(
+        h.fixClass(".disabled:tw-bg-transparent:disabled"),
+        "disabled:tw-bg-transparent"
+      );
+    });
+    it("removes :focus-within", () => {
+      assert.equal(
+        h.fixClass(".sm:focus-within:tw-text-transparent:focus-within"),
+        "sm:focus-within:tw-text-transparent"
+      );
+    });
+    it("removes :visited", () => {
+      assert.equal(
+        h.fixClass(".visited:tw-bg-teal-100:visited"),
+        "visited:tw-bg-teal-100"
+      );
+    });
+  });
+  it("removes pseudo-elements (::)", () => {
+    assert.equal(h.fixClass(".tw-form-select::-ms-expand"), "tw-form-select");
+  });
+  it("removes pseudo-classes and psuedo-elements", () => {
+    assert.equal(
+      h.fixClass(".focus:placeholder-gray-400:focus::placeholder"),
+      "focus:placeholder-gray-400"
+    );
+    assert.equal(
+      h.fixClass(".focus:tw-placeholder-transparent:focus::-webkit-input-placeholder"),
+      "focus:tw-placeholder-transparent"
+    );
+  });
+  it("removes chained pseudo-classes", () => {
+    assert.equal(
+      h.fixClass(".tw-form-checkbox:checked:focus"),
+      "tw-form-checkbox"
+    );
+    assert.equal(
+      h.fixClass(".tw-form-checkbox:focus:checked"),
+      "tw-form-checkbox"
+    );
+  });
+  it("handles responsive with pseudo-classes", () => {
+    assert.equal(
+      h.fixClass(".lg:active:tw-text-transparent:active"),
+      "lg:active:tw-text-transparent"
+    );
     assert.equal(
       h.fixClass(".xl:focus:no-underline:focus"),
       "xl:focus:no-underline"
+    );
+    assert.equal(
+      h.fixClass(".lg:hover:tw-text-opacity-50:hover"),
+      "lg:hover:tw-text-opacity-50"
     );
   });
   it("with prefix", () => {
@@ -65,6 +128,10 @@ describe("fixClass", () => {
     assert.equal(
       h.fixClass(".lg:even:bg-pink-700:nth-child(even)"),
       "lg:even:bg-pink-700"
+    );
+    assert.equal(
+      h.fixClass(".first:tw-bg-red-400:first-child"),
+      "first:tw-bg-red-400"
     );
     assert.equal(
       h.fixClass(".last:tw-bg-transparent:last-child"),


### PR DESCRIPTION
We now remove all pseudo-elements (`::` things) and any chain of known pseudo-classes (`:` things) at the end of the class name.  I've enabled all known variants for backgroundColor so that we can test them all, and added extra tests to cover any missing cases with examples taken from the generated CSS.


Fixes #26