### PR TITLE
Remove :not pseudo-classes

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -99,7 +99,10 @@ function fixClass(cls) {
   // remove not pseudo-classes (:not())
   cls = cls.replace(/:not\([^\)]*\)/g, "");
   // remove pseudo-classes (:)
-  cls = removePseudoClass(cls);
+  cls = cls.replace(
+    /(:(active|after|before|checked|disabled|focus|focus-within|hover|visited|nth-child\((even|odd)\)|(first|last)-child))+$/,
+    ""
+  );
   // make / safe for elm
   cls = cls.replace(/\\\//g, "/");
   // make \/ safe for elm
@@ -107,17 +110,6 @@ function fixClass(cls) {
   // make \: safe for elm
   cls = cls.replace(/\\([:])/g, "$1");
   return cls;
-}
-
-function removePseudoClass(cls) {
-  const result = cls.replace(
-    /(:(active|after|before|checked|disabled|focus|focus-within|hover|visited|nth-child\((even|odd)\)|(first|last)-child))+$/,
-    ""
-  );
-
-  // Remove multiple by doing recursion when the result differs
-  if (result !== cls) return removePseudoClass(result);
-  return result;
 }
 
 function toElmName(cls, opts) {

--- a/helpers.js
+++ b/helpers.js
@@ -115,6 +115,7 @@ function removePseudoClass(cls) {
     ""
   );
 
+  // Remove multiple by doing recursion when the result differs
   if (result !== cls) return removePseudoClass(result);
   return result;
 }

--- a/helpers.js
+++ b/helpers.js
@@ -96,11 +96,10 @@ function fixClass(cls) {
   cls = cls.replace(/\s?>\s?.*/, "");
   // remove pseudo-elements (::)
   cls = cls.replace(/::.*$/, "");
+  // remove not pseudo-classes (:not())
+  cls = cls.replace(/:not\([^\)]*\)/g, "");
   // remove pseudo-classes (:)
-  cls = cls.replace(
-    /(:(active|after|before|checked|disabled|focus|focus-within|hover|visited|nth-child\((even|odd)\)|(first|last)-child))+$/,
-    ""
-  );
+  cls = removePseudoClass(cls);
   // make / safe for elm
   cls = cls.replace(/\\\//g, "/");
   // make \/ safe for elm
@@ -108,6 +107,16 @@ function fixClass(cls) {
   // make \: safe for elm
   cls = cls.replace(/\\([:])/g, "$1");
   return cls;
+}
+
+function removePseudoClass(cls) {
+  const result = cls.replace(
+    /(:(active|after|before|checked|disabled|focus|focus-within|hover|visited|nth-child\((even|odd)\)|(first|last)-child))+$/,
+    ""
+  );
+
+  if (result !== cls) return removePseudoClass(result);
+  return result;
 }
 
 function toElmName(cls, opts) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postcss-elm-tailwind",
   "main": "./index.js",
-  "version": "0.10.1",
+  "version": "0.10.0",
   "description": "PostCSS plugin Tailwind classes for Elm",
   "keywords": [
     "postcss",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postcss-elm-tailwind",
   "main": "./index.js",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "PostCSS plugin Tailwind classes for Elm",
   "keywords": [
     "postcss",

--- a/test/tests.js
+++ b/test/tests.js
@@ -46,13 +46,13 @@ describe("fixClass", () => {
       assert.equal(
         h.fixClass(".tw-clearfix:after"),
         "tw-clearfix"
-      );  
+      );
     });
     it("removes :before", () => {
       assert.equal(
         h.fixClass(".fa-accessible-icon:before"),
         "fa-accessible-icon"
-      );  
+      );
     });
     it("removes :disabled", () => {
       assert.equal(
@@ -66,9 +66,21 @@ describe("fixClass", () => {
         "sm:focus-within:tw-text-transparent"
       );
     });
+    it("removes :not", () => {
+      assert.equal(
+        h.fixClass(".sm:not(:active)"),
+        "sm"
+      );
+    });
     it("removes :visited", () => {
       assert.equal(
         h.fixClass(".visited:tw-bg-teal-100:visited"),
+        "visited:tw-bg-teal-100"
+      );
+    });
+    it("removes chained pseudo classes", () => {
+      assert.equal(
+        h.fixClass(".visited:tw-bg-teal-100:nth-child(odd):active"),
         "visited:tw-bg-teal-100"
       );
     });


### PR DESCRIPTION
Hey 👋 

Made a quick adjustment that removes the `:not()` pseudo-classes as well.
~~Also changes the other pseudo-classes-removal part to remove multiple instances.~~