### PR TITLE
Split each breakpoint into a separate Elm module

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,28 +51,17 @@ npm i -D postcss-elm-tailwind
 
 ## Usage
 
-### No config
-
-```js
-module.exports = {
-  plugins: [
-    require("tailwindcss"),
-    require("postcss-elm-tailwind")()
-]
-};
-```
-
-### With config
-
 ```js
 module.exports = {
   plugins: [
     require("tailwindcss"),
     require("postcss-elm-tailwind")({
-      prefix: "tw-", // you must tell us if you have set a prefix in your tailwind.config.js
+      tailwindConfig: "./tailwind.config.js", // tell us where your tailwind.config.js lives
+      // only the tailwindConfig key is required, the rest are optional:
       elmFile: "src/Tailwind.elm", // change where the generated Elm module is saved
       elmModuleName: "Tailwind", // this must match the file name or Elm will complain
-      nameStyle: "snake" // "snake" for snake case, "camel" for camel case
+      nameStyle: "snake", // "snake" for snake case, "camel" for camel case
+      splitByScreens: true // generate an Elm module for each screen
     })
   ]
 };
@@ -91,6 +80,7 @@ module.exports = {
   plugins: [
     require("tailwindcss"),
     require("postcss-elm-tailwind")({
+      tailwindConfig: "./tailwind.config.js",
       elmFile: "src/Tailwind.elm",
       elmModuleName: "Tailwind",
       formats: {
@@ -113,6 +103,7 @@ module.exports = {
   plugins: [
     require("tailwindcss"),
     require("postcss-elm-tailwind")({
+      tailwindConfig: "./tailwind.config.js",
       elmFile: "src/Tailwind.elm",
       elmModuleName: "Tailwind",
       formats: {
@@ -131,4 +122,4 @@ module.exports = {
 In order to get a small build, you'll need to build Tailwind twice - once
 without purgecss to build `TW.elm` with all the classes and once with purgecss
 so that all the unused classes are removed from your production CSS.
-See how this is implemented in the [demo](https://github.com/monty5811/postcss-elm-tailwind/blob/master/demo/package.json#L19).
+See how this is implemented in the [demo](https://github.com/monty5811/postcss-elm-tailwind/blob/master/demo/package.json#L22).

--- a/demo/package.json
+++ b/demo/package.json
@@ -20,7 +20,7 @@
     "build-tw": "postcss -o dist/main.css main.css",
     "build": "yarn build-tw && yarn build-elm && yarn copy-index",
     "build-prod": "yarn build-tw && yarn build-elm && NODE_ENV=production yarn build-tw && yarn copy-index",
-    "check-format": "elm-format src/TLWND.elm src/TLWND/String.elm src/TLWND/Svg.elm --validate"
+    "check-format": "elm-format src/**/*.elm --validate"
   },
   "devDependencies": {}
 }

--- a/demo/postcss.config.js
+++ b/demo/postcss.config.js
@@ -1,8 +1,8 @@
 const process = require("process");
 const postcssElmTailwind = require("../index.js")({
+  tailwindConfig: "./tailwind.config.js",
   elmFile: "src/TLWND.elm",
   elmModuleName: "TLWND",
-  prefix: "tw-",
   formats: {
     svg: {
       elmFile: "src/TLWND/Svg.elm",

--- a/demo/src/Main.elm
+++ b/demo/src/Main.elm
@@ -5,6 +5,7 @@ import Html exposing (Html)
 import Html.Attributes as A
 import Html.Events as E
 import TLWND as TW
+import TLWND.LG as TW_lg
 -- here to make sure we compile the other formats:
 import TLWND.Svg
 import TLWND.String
@@ -213,8 +214,8 @@ buttonCls =
     , TW.tw_text_lg
     , TW.tw_bg_blue_500
     , TW.hover__tw_bg_blue_700
-    , TW.lg__tw_bg_green_500
-    , TW.lg__hover__tw_bg_green_700
+    , TW_lg.tw_bg_green_500
+    , TW_lg.hover__tw_bg_green_700
     , TW.hover__tw_font_bold
     , TW.tw_mx_auto
     , TW.tw_block

--- a/index.js
+++ b/index.js
@@ -5,41 +5,77 @@ const { promisify } = require("util");
 
 const mkdir = promisify(fs.mkdir);
 
-let h = require("./helpers.js");
+const { fixClass, toElmName, toScreen } = require("./code-gen.js");
+const { formats, cleanOpts } = require("./options.js");
 
 let classes = new Map();
 
-module.exports = postcss.plugin("postcss-elm-tailwind", opts => {
-  opts = h.cleanOpts(opts);
+module.exports = postcss.plugin("postcss-elm-tailwind", (opts) => {
+  opts = cleanOpts(opts);
 
   return (root, result) => {
     // Transform CSS AST here
-    root.walkRules(rule => {
+    root.walkRules((rule) => {
       rule.selector
         .split(" ")
-        .map(sel => sel.split(","))
+        .map((sel) => sel.split(","))
         .reduce((arr, v) => (arr.push(...v), arr), [])
-        .forEach(selector => processSelector(selector, opts));
+        .forEach((selector) => processSelector(selector, opts));
     });
 
-    const formats = h
-      .formats(opts)
-      .map(({ elmFile, elmModuleName, elmBodyFn }) =>
-        writeFile(elmFile, elmBodyFn(elmModuleName, classes)));
-    return tap(Promise.all(formats), p =>
-      p.then(files => console.log("Saved", files)));
+    const formats_ = formats(opts)
+      .map(data => splitByScreens(opts, classes, data))
+      .flat()
+      .map(data => {
+        const fileContent = data.elmBodyFn(data.elmModuleName, data.classesSet); 
+        return writeFile(data.elmFile, fileContent);
+      }
+      );
+    return tap(Promise.all(formats_), (p) =>
+      p.then((files) => console.log("Saved", files))
+    );
   };
 });
+
+function splitByScreens(opts, classesSet, {elmFile, elmModuleName, elmBodyFn} ) {
+  if (!opts.splitByScreens) {
+    return [{elmFile, elmModuleName, elmBodyFn, classesSet}]
+  }
+  const screens = [...opts.screens];
+  screens.push(null)
+
+  return screens.map(
+    screen => extractScreen(screen, elmFile, elmModuleName, elmBodyFn, classesSet)
+  )
+}
+
+function extractScreen(screen, elmFile, elmModuleName, elmBodyFn, classesSet) {
+  let newFile = elmFile;
+  let newModule = elmModuleName;
+  if (screen !== null) {
+    const screenUpper = screen.toUpperCase();
+    newFile = newFile.replace(".elm", `/${screenUpper}.elm`);
+    newModule = `${newModule}.${screenUpper}`;
+  }
+  const newClasses = new Map();
+  for (let [cls, val] of classesSet) {
+    if (screen === val.screen) {
+      newClasses.set(cls, val);
+    }
+  }
+  return {elmFile: newFile, elmModuleName: newModule, elmBodyFn: elmBodyFn, classesSet: newClasses}
+}
 
 async function writeFile(fname, content) {
   folder = path.dirname(fname);
   await mkdir(folder, { recursive: true });
 
   return new Promise((resolve, reject) =>
-    fs.writeFile(fname, content, err => {
+    fs.writeFile(fname, content, (err) => {
       if (err) return reject(err);
       resolve(fname);
-    }));
+    })
+  );
 }
 
 function processSelector(selector, opts) {
@@ -48,12 +84,13 @@ function processSelector(selector, opts) {
     return;
   }
 
-  let cls, elm;
+  let cls, elm, screen;
 
-  cls = h.fixClass(selector);
-  elm = h.toElmName(cls, opts);
+  cls = fixClass(selector);
+  elm = toElmName(cls, opts);
+  screen = toScreen(cls, opts);
 
-  classes.set(cls, elm);
+  classes.set(cls, {elm, screen});
 }
 
 const tap = (v, fn) => {

--- a/options.js
+++ b/options.js
@@ -1,0 +1,54 @@
+const path = require("path");
+const resolveConfig = require("tailwindcss/resolveConfig");
+const { elmBodyHtml, elmBodyString, elmBodySvg}  = require("./code-gen.js")
+
+const defaultOpts = {
+  tailwindConfig: null,
+  splitByScreens: true,
+  elmFile: "src/TW.elm",
+  elmModuleName: "TW",
+  prefix: "",
+  nameStyle: "snake",
+  formats: {
+    /*
+      string: {
+        elmFile: "src/TW/String.elm",
+      },
+      svg: {
+        elmFile: "src/TW/Svg.elm",
+      }
+    */
+  },
+};
+
+function cleanOpts(opts) {
+  opts = { ...defaultOpts, ...opts };
+  opts.formats = { ...opts.formats };
+  // grab resolved tailwind config:
+  if (opts.tailwindConfig === null) {
+    throw new Error("Failed to specify Tailwind config file. Add a `tailwindConfig` key to your config.");
+  }
+  const twConfig = resolveConfig(require(path.resolve(opts.tailwindConfig)));
+  opts.prefix = twConfig.prefix;
+  opts.screens = Object.keys(twConfig.theme.screens);
+  
+  return opts;
+}
+
+function formats(opts) {
+  return [
+    cleanFormat(opts, elmBodyHtml),
+    cleanFormat({ ...opts.formats.string }, elmBodyString),
+    cleanFormat({ ...opts.formats.svg }, elmBodySvg),
+  ].filter((f) => f);
+}
+
+function cleanFormat({ elmFile, elmModuleName }, elmBodyFn) {
+  if (!elmFile) return false;
+  if (!elmModuleName) return false;
+  return { elmFile, elmModuleName, elmBodyFn };
+}
+
+exports.cleanOpts = cleanOpts;
+exports.defaultOpts = defaultOpts;
+exports.formats = formats;

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,269 +1,271 @@
-const h = require("../helpers");
+const { fixClass, toElmName, elmFunction } = require("../code-gen.js");
+const { cleanOpts, defaultOpts } = require("../options.js");
+
 var assert = require("assert");
 
+function toElmName_(cls) {
+  return toElmName(fixClass(cls), {...defaultOpts, screens: ["sm"]})
+}
+
 describe("cleanOpts", () => {
-  it("should return default config if none supplied", () => {
-    assert.deepEqual(h.cleanOpts(undefined), {
-      elmFile: "src/TW.elm",
-      elmModuleName: "TW",
-      prefix: "",
-      nameStyle: "snake",
-      formats: {}
-    });
+  it("should throw if no tailwind config supplied", () => {
+    assert.throws(() => cleanOpts(undefined));
   });
   it("should not override elmFile", () => {
-    assert.deepEqual(h.cleanOpts({ elmFile: "src/NotTW.elm" }), {
+    assert.deepStrictEqual(cleanOpts({ elmFile: "src/NotTW.elm", tailwindConfig: "./demo/tailwind.config.js" }), {
       elmFile: "src/NotTW.elm",
       elmModuleName: "TW",
-      prefix: "",
+      prefix: "tw-",
       nameStyle: "snake",
-      formats: {}
-    });
-  });
-  it("should not override prefix", () => {
-    assert.deepEqual(h.cleanOpts({ prefix: "tw--" }), {
-      elmFile: "src/TW.elm",
-      elmModuleName: "TW",
-      prefix: "tw--",
-      nameStyle: "snake",
-      formats: {}
+      formats: {},
+      splitByScreens: true,
+      tailwindConfig: "./demo/tailwind.config.js",
+      screens: ["sm", "md", "lg", "xl"]
     });
   });
 });
 
 describe("fixClass", () => {
   it("should let container pass through", () => {
-    assert.equal(h.fixClass(".container"), "container");
+    assert.strictEqual(fixClass(".container"), "container");
   });
   it("should let mx-auto pass through", () => {
-    assert.equal(h.fixClass(".mx-auto"), "mx-auto");
+    assert.strictEqual(fixClass(".mx-auto"), "mx-auto");
   });
   it("responsive", () => {
-    assert.equal(h.fixClass(".sm:mx-auto"), "sm:mx-auto");
+    assert.strictEqual(fixClass(".sm:mx-auto"), "sm:mx-auto");
   });
   describe("pseudo-classes", () => {
     it("removes :after", () => {
-      assert.equal(
-        h.fixClass(".tw-clearfix:after"),
+      assert.strictEqual(
+        fixClass(".tw-clearfix:after"),
         "tw-clearfix"
       );
     });
     it("removes :before", () => {
-      assert.equal(
-        h.fixClass(".fa-accessible-icon:before"),
+      assert.strictEqual(
+        fixClass(".fa-accessible-icon:before"),
         "fa-accessible-icon"
       );
     });
     it("removes :disabled", () => {
-      assert.equal(
-        h.fixClass(".disabled:tw-bg-transparent:disabled"),
+      assert.strictEqual(
+        fixClass(".disabled:tw-bg-transparent:disabled"),
         "disabled:tw-bg-transparent"
       );
     });
     it("removes :focus-within", () => {
-      assert.equal(
-        h.fixClass(".sm:focus-within:tw-text-transparent:focus-within"),
+      assert.strictEqual(
+        fixClass(".sm:focus-within:tw-text-transparent:focus-within"),
         "sm:focus-within:tw-text-transparent"
       );
     });
     it("removes :not", () => {
-      assert.equal(
-        h.fixClass(".sm:not(:active)"),
+      assert.strictEqual(
+        fixClass(".sm:not(:active)"),
         "sm"
       );
     });
     it("removes :visited", () => {
-      assert.equal(
-        h.fixClass(".visited:tw-bg-teal-100:visited"),
+      assert.strictEqual(
+        fixClass(".visited:tw-bg-teal-100:visited"),
         "visited:tw-bg-teal-100"
       );
     });
     it("removes chained pseudo classes", () => {
-      assert.equal(
-        h.fixClass(".visited:tw-bg-teal-100:nth-child(odd):active"),
+      assert.strictEqual(
+        fixClass(".visited:tw-bg-teal-100:nth-child(odd):active"),
         "visited:tw-bg-teal-100"
       );
     });
   });
   it("removes pseudo-elements (::)", () => {
-    assert.equal(h.fixClass(".tw-form-select::-ms-expand"), "tw-form-select");
+    assert.strictEqual(fixClass(".tw-form-select::-ms-expand"), "tw-form-select");
   });
   it("removes pseudo-classes and psuedo-elements", () => {
-    assert.equal(
-      h.fixClass(".focus:placeholder-gray-400:focus::placeholder"),
+    assert.strictEqual(
+      fixClass(".focus:placeholder-gray-400:focus::placeholder"),
       "focus:placeholder-gray-400"
     );
-    assert.equal(
-      h.fixClass(".focus:tw-placeholder-transparent:focus::-webkit-input-placeholder"),
+    assert.strictEqual(
+      fixClass(".focus:tw-placeholder-transparent:focus::-webkit-input-placeholder"),
       "focus:tw-placeholder-transparent"
     );
   });
   it("removes chained pseudo-classes", () => {
-    assert.equal(
-      h.fixClass(".tw-form-checkbox:checked:focus"),
+    assert.strictEqual(
+      fixClass(".tw-form-checkbox:checked:focus"),
       "tw-form-checkbox"
     );
-    assert.equal(
-      h.fixClass(".tw-form-checkbox:focus:checked"),
+    assert.strictEqual(
+      fixClass(".tw-form-checkbox:focus:checked"),
       "tw-form-checkbox"
     );
   });
   it("handles responsive with pseudo-classes", () => {
-    assert.equal(
-      h.fixClass(".lg:active:tw-text-transparent:active"),
+    assert.strictEqual(
+      fixClass(".lg:active:tw-text-transparent:active"),
       "lg:active:tw-text-transparent"
     );
-    assert.equal(
-      h.fixClass(".xl:focus:no-underline:focus"),
+    assert.strictEqual(
+      fixClass(".xl:focus:no-underline:focus"),
       "xl:focus:no-underline"
     );
-    assert.equal(
-      h.fixClass(".lg:hover:tw-text-opacity-50:hover"),
+    assert.strictEqual(
+      fixClass(".lg:hover:tw-text-opacity-50:hover"),
       "lg:hover:tw-text-opacity-50"
     );
   });
   it("with prefix", () => {
-    assert.equal(
-      h.fixClass(".hover:tw-bg-blue-500:hover"),
+    assert.strictEqual(
+      fixClass(".hover:tw-bg-blue-500:hover"),
       "hover:tw-bg-blue-500"
     );
   });
   it("ratio", () => {
-    assert.equal(h.fixClass(".w-1\\/2"), "w-1/2");
+    assert.strictEqual(fixClass(".w-1\\/2"), "w-1/2");
   });
   // regression tests for github issue #7:
   it("handle variants", () => {
-    assert.equal(
-      h.fixClass(".xl:odd:tw-bg-pink-700:nth-child(odd)"),
+    assert.strictEqual(
+      fixClass(".xl:odd:tw-bg-pink-700:nth-child(odd)"),
       "xl:odd:tw-bg-pink-700"
     );
-    assert.equal(
-      h.fixClass(".lg:even:bg-pink-700:nth-child(even)"),
+    assert.strictEqual(
+      fixClass(".lg:even:bg-pink-700:nth-child(even)"),
       "lg:even:bg-pink-700"
     );
-    assert.equal(
-      h.fixClass(".first:tw-bg-red-400:first-child"),
+    assert.strictEqual(
+      fixClass(".first:tw-bg-red-400:first-child"),
       "first:tw-bg-red-400"
     );
-    assert.equal(
-      h.fixClass(".last:tw-bg-transparent:last-child"),
+    assert.strictEqual(
+      fixClass(".last:tw-bg-transparent:last-child"),
       "last:tw-bg-transparent"
     );
   });
   // regession tests for github issue #13
   it("handle '.' in class names", () => {
-    assert.equal(h.fixClass(".col-gap-1\\.5"), "col-gap-1.5");
+    assert.strictEqual(fixClass(".col-gap-1\\.5"), "col-gap-1.5");
   });
   // regression test for font awesome (and a lot of other stuff)
   it("handle '>' in class names", () => {
-    assert.equal(h.fixClass("fa > li"), "fa");
-    assert.equal(h.fixClass("fa >li"), "fa");
-    assert.equal(h.fixClass("fa> li"), "fa");
+    assert.strictEqual(fixClass("fa > li"), "fa");
+    assert.strictEqual(fixClass("fa >li"), "fa");
+    assert.strictEqual(fixClass("fa> li"), "fa");
   });
 });
 
 describe("fixClass -> toElmName", () => {
-  const camelCaseOpts = { ...h.defaultOpts, nameStyle: "camel" };
+  const camelCaseOpts = { ...defaultOpts, nameStyle: "camel", screens: ["sm"] };
   it("should let container pass through", () => {
-    assert.equal(h.toElmName(h.fixClass("container")), "container");
+    assert.strictEqual(toElmName_("container"), "container");
   });
   it("should let mx-auto pass through", () => {
-    assert.equal(h.toElmName(h.fixClass("mx-auto")), "mx_auto");
+    assert.strictEqual(toElmName_("mx-auto"), "mx_auto");
   });
   it("should let mx-auto pass through camel case", () => {
-    assert.equal(h.toElmName(h.fixClass("mx-auto"), camelCaseOpts), "mxAuto");
+    assert.strictEqual(toElmName(fixClass("mx-auto"), camelCaseOpts), "mxAuto");
   });
   it("responsive", () => {
-    assert.equal(h.toElmName(h.fixClass("sm:mx-auto")), "sm__mx_auto");
+    assert.strictEqual(toElmName_("sm:mx-auto"), "mx_auto");
   });
   it("responsive and focus", () => {
-    assert.equal(
-      h.toElmName(h.fixClass(".xl:focus:no-underline:focus")),
+    assert.strictEqual(
+      toElmName_(".xl:focus:no-underline:focus"),
       "xl__focus__no_underline"
     );
   });
   it("over", () => {
-    assert.equal(h.toElmName(h.fixClass(".w-1\\/2")), "w_1over2");
+    assert.strictEqual(toElmName_(".w-1\\/2"), "w_1over2");
   });
   it("negative", () => {
-    assert.equal(h.toElmName(h.fixClass(".-m-1")), "neg_m_1");
+    assert.strictEqual(toElmName_(".-m-1"), "neg_m_1");
   });
   it("negative with variant .sm:-m-24", () => {
-    assert.equal(h.toElmName(h.fixClass(".sm:-m-24")), "sm__neg_m_24");
+    assert.strictEqual(toElmName_(".sm:-m-24"), "neg_m_24");
   });
   it("negative with variant .sm:-translate-x-1", () => {
-    assert.equal(
-      h.toElmName(h.fixClass(".sm:-translate-x-1")),
+    assert.strictEqual(
+      toElmName_(".sm:-translate-x-1"),
+      "neg_translate_x_1"
+    );
+    assert.strictEqual(
+      toElmName(fixClass(".sm:-translate-x-1"), {...defaultOpts, splitByScreens: false}),
       "sm__neg_translate_x_1"
     );
   });
   it("with prefix", () => {
-    assert.equal(
-      h.toElmName(h.fixClass(".hover:tw-bg-blue-500:hover"), "tw-"),
+    assert.strictEqual(
+      toElmName(fixClass(".hover:tw-bg-blue-500:hover"), {
+        ...defaultOpts,
+        prefix: "tw-",
+        screens: ["sm"]
+      }),
       "hover__tw_bg_blue_500"
     );
   });
   it("negative with prefix and variant .xl:tw--my-64", () => {
-    assert.equal(
-      h.toElmName(h.fixClass(".xl:tw--my-64"), {
-        ...h.defaultOpts,
-        prefix: "tw-"
+    assert.strictEqual(
+      toElmName(fixClass(".xl:tw--my-64"), {
+        ...defaultOpts,
+        prefix: "tw-",
+        screens: ["sm"]
       }),
       "xl__tw_neg_my_64"
     );
   });
   it("negative with prefix and variant .xl:tw--my-64 camel", () => {
-    assert.equal(
-      h.toElmName(h.fixClass(".xl:tw--my-64"), {
+    assert.strictEqual(
+      toElmName(fixClass(".xl:tw--my-64"), {
         ...camelCaseOpts,
-        prefix: "tw-"
+        prefix: "tw-",
+        
       }),
       "xlTwNegMy64"
     );
   });
   it("not-negative with prefix .xl:tw-my-64", () => {
-    assert.equal(
-      h.toElmName(h.fixClass(".xl:tw-my-64"), {
-        ...h.defaultOpts,
-        prefix: "-tw"
+    assert.strictEqual(
+      toElmName(fixClass(".xl:tw-my-64"), {
+        ...defaultOpts,
+        prefix: "-tw",
+        screens: ["sm"]
       }),
       "xl__tw_my_64"
     );
   });
   it("cursor-pointer", () => {
-    assert.equal(h.toElmName(h.fixClass(".cursor-pointer")), "cursor_pointer");
+    assert.strictEqual(toElmName_(".cursor-pointer"), "cursor_pointer");
   });
   it("font-medium", () => {
-    assert.equal(h.toElmName(h.fixClass(".font-medium")), "font_medium");
+    assert.strictEqual(toElmName_(".font-medium"), "font_medium");
   });
   // regression tests for github issue #7:
   it("handle variants", () => {
-    assert.equal(
-      h.toElmName(h.fixClass(".xl\:odd\:tw-bg-pink-700:nth-child(odd)")),
+    assert.strictEqual(
+      toElmName_(".xl\:odd\:tw-bg-pink-700:nth-child(odd)"),
       "xl__odd__tw_bg_pink_700"
     );
-    assert.equal(
-      h.toElmName(h.fixClass(".lg\:even\:tw-bg-pink-700:nth-child(even)")),
+    assert.strictEqual(
+      toElmName_(".lg\:even\:tw-bg-pink-700:nth-child(even)"),
       "lg__even__tw_bg_pink_700"
     );
-    assert.equal(
-      h.toElmName(h.fixClass(".last\:tw-bg-transparent:last-child")),
-      "last__tw_bg_transparent"
-    );
+    assert.strictEqual(toElmName_(".last\:tw-bg-transparent:last-child"), "last__tw_bg_transparent");
   });
   // regession tests for github issue #13
   it("handle '.' in class names", () => {
-    assert.equal(h.toElmName(h.fixClass(".col-gap-1\\.5")), "col_gap_1_dot_5");
+    assert.strictEqual(toElmName_(".col-gap-1\\.5"), "col_gap_1_dot_5");
   });
   // regression test for font awesome (and a lot of other stuff)
   it("handle '>' in class names", () => {
-    assert.equal(h.toElmName(h.fixClass("fa > li")), "fa");
-    assert.equal(h.toElmName(h.fixClass("fa> li")), "fa");
-    assert.equal(h.toElmName(h.fixClass("fa >li")), "fa");
+    assert.strictEqual(toElmName_("fa > li"), "fa");
+    assert.strictEqual(toElmName_("fa> li"), "fa");
+    assert.strictEqual(toElmName_("fa >li"), "fa");
   });
   // regression test for .bottom-0.5
   it("handle '.bottom-0.5'", () => {
-    assert.equal(h.toElmName(h.fixClass(".bottom-0\.5")), "bottom_0_dot_5");
+    assert.strictEqual(toElmName_(".bottom-0\.5"), "bottom_0_dot_5");
   });
 });
 
@@ -271,7 +273,7 @@ describe("elmFunction", () => {
   it("generates Html attributes", () => {
     assert.ok(
       /Html\.Attribute/.test(
-        h.elmFunction(
+        elmFunction(
           { type: "Html.Attribute msg", fn: "A.class " },
           "bg-pink-700",
           "bg_pink_700"
@@ -282,7 +284,7 @@ describe("elmFunction", () => {
   it("generates Svg attributes", () => {
     assert.ok(
       /Svg\.Attribute/.test(
-        h.elmFunction(
+        elmFunction(
           { type: "Svg.Attribute msg", fn: "A.class " },
           "bg-pink-700",
           "bg_pink_700"
@@ -293,7 +295,7 @@ describe("elmFunction", () => {
   it("generates strings", () => {
     assert.ok(
       /String/.test(
-        h.elmFunction({ type: "String", fn: "" }, "bg-pink-700", "bg_pink_700")
+        elmFunction({ type: "String", fn: "" }, "bg-pink-700", "bg_pink_700")
       )
     );
   });


### PR DESCRIPTION
## What

We output several Elm modules now - partitioned by the Tailwind breakpoint the class applies to.

## Why

This should make Elm compile times a bit quicker - the file sizes should be about `1/(n+1)`ish what they were before (where `n` is the number of breakpoints. This should also make third-party Elm tooling a bit happier too (elm-format, elm-ls).

## How

 - User needs to tell us where their `tailwind.config.js` is
 - We read in the config and use `resolveConfig` from [Tailwind](https://tailwindcss.com/docs/configuration#referencing-in-java-script) to figure out what the breakpoints are
 - While we are here, we can grab the `prefix` too, so we don't have to ask the user to configure that anymore
 - During the css rule parsing, we figure out which class the breakpoint applies to
 - During codegen, we generate a base module and a module for each breakpoint too
 - All this is optional, but turned on by default, one can turn this off and get a single module output if they want (not sure if I tested that bit very well...)

```bash
# the demo src folder looks like this after code-gen:

src/
├── Main.elm
├── TLWND
│   ├── LG.elm
│   ├── MD.elm
│   ├── SM.elm
│   ├── String
│   │   ├── LG.elm
│   │   ├── MD.elm
│   │   ├── SM.elm
│   │   └── XL.elm
│   ├── String.elm
│   ├── Svg
│   │   ├── LG.elm
│   │   ├── MD.elm
│   │   ├── SM.elm
│   │   └── XL.elm
│   ├── Svg.elm
│   └── XL.elm
└── TLWND.elm
```